### PR TITLE
Short circuit

### DIFF
--- a/sucpp/Makefile
+++ b/sucpp/Makefile
@@ -36,6 +36,7 @@ test: tree.o test_su.cpp biom.o unifrac.o unifrac_task.o api.o
 
 main: tree.o biom.o unifrac.o cmd.o unifrac_task.o api.o
 	$(CXX) $(CPPFLAGS) su.cpp -o ssu tree.o biom.o unifrac.o cmd.o unifrac_task.o api.o -lhdf5_cpp 
+	cp ssu ${CONDA_PREFIX}/bin/
 
 api: tree.o biom.o unifrac.o cmd.o unifrac_task.o
 	$(CXX) $(CPPFLAGS) api.cpp -c -o api.o -fPIC

--- a/sucpp/api.hpp
+++ b/sucpp/api.hpp
@@ -54,6 +54,7 @@ typedef struct partial_mat {
  * unifrac_method <const char*> the requested unifrac method.
  * variance_adjust <bool> whether to apply variance adjustment.
  * alpha <double> GUniFrac alpha, only relevant if method == generalized.
+ * bypass_tips <bool> disregard tips, reduces compute by about 50%
  * threads <uint> the number of threads to use.
  * result <mat*> the resulting distance matrix in condensed form
  *
@@ -66,7 +67,7 @@ typedef struct partial_mat {
  */
 EXTERN ComputeStatus one_off(const char* biom_filename, const char* tree_filename, 
                              const char* unifrac_method, bool variance_adjust, double alpha,
-                             unsigned int threads, mat_t** result);
+                             bool bypass_tips, unsigned int threads, mat_t** result);
 
 void destroy_mat(mat_t** result);
 
@@ -78,6 +79,7 @@ void destroy_mat(mat_t** result);
  * unifrac_method <const char*> the requested unifrac method.
  * variance_adjust <bool> whether to apply variance adjustment.
  * alpha <double> GUniFrac alpha, only relevant if method == generalized.
+ * bypass_tips <bool> disregard tips, reduces compute by about 50%
  * threads <uint> the number of threads to use.
  * stripe_start <uint> the starting stripe to compute
  * stripe_stop <uint> the last stripe to compute
@@ -97,7 +99,7 @@ void destroy_mat(mat_t** result);
 // TODO: this should use an out parameter of type partial_mat_t instead of the dm_stripes
 // once done, this does not need to be wrapped in a __cplusplus tag
 compute_status partial(const char* biom_filename, const char* tree_filename, 
-                       const char* unifrac_method, bool variance_adjust, double alpha,
+                       const char* unifrac_method, bool variance_adjust, double alpha, bool bypass_tips,
                        unsigned int threads, unsigned int stripe_start, unsigned int stripe_stop,
                        std::vector<double*> &dm_stripes,
                        std::vector<double*> &dm_stripes_total);
@@ -107,6 +109,7 @@ void set_tasks(std::vector<su::task_parameters> &tasks,
                double alpha,
                unsigned int n_samples,
                unsigned int stripe_start, 
-               unsigned int stripe_stop, 
+               unsigned int stripe_stop,
+               bool bypass_tips,
                unsigned int nthreads);
 #endif

--- a/sucpp/su.cpp
+++ b/sucpp/su.cpp
@@ -31,6 +31,14 @@ void usage() {
     std::cout << "    For Variance Adjusted UniFrac, please see: " << std::endl;
     std::cout << "        Chang et al. BMC Bioinformatics 2011; DOI: 10.1186/1471-2105-12-118" << std::endl;
     std::cout << std::endl;
+    std::cout << "Runtime progress can be obtained by issuing a SIGUSR1 signal. If running with " << std::endl;
+    std::cout << "multiple threads, this signal will only be honored if issued to the master PID. " << std::endl;
+    std::cout << "The report will yield the following information: " << std::endl;
+    std::cout << std::endl;
+    std::cout << "tid:<thread ID> k:<postorder node index> total:<number of nodes>" << std::endl;
+    std::cout << std::endl;
+    std::cout << "The proportion of the tree that has been evaluated can be determined from (k / total)." << std::endl;
+    std::cout << std::endl;
 }
 
 void err(std::string msg) {

--- a/sucpp/su.cpp
+++ b/sucpp/su.cpp
@@ -17,6 +17,7 @@ void usage() {
     std::cout << "    -o\t\tThe output distance matrix." << std::endl;
     std::cout << "    -n\t\t[OPTIONAL] The number of threads, default is 1." << std::endl;
     std::cout << "    -a\t\t[OPTIONAL] Generalized UniFrac alpha, default is 1." << std::endl;
+    std::cout << "    -f\t\t[OPTIONAL] Bypass tips, reduces compute by about 50%." << std::endl;
     std::cout << "    --vaw\t[OPTIONAL] Variance adjusted, default is to not adjust for variance." << std::endl;
     std::cout << std::endl;
     std::cout << "Citations: " << std::endl;
@@ -96,7 +97,9 @@ int main(int argc, char **argv){
     }
     
     bool vaw = input.cmdOptionExists("--vaw"); 
+    bool bypass_tips = input.cmdOptionExists("-f");
     double g_unifrac_alpha;
+
     if(gunifrac_arg.empty()) {
         g_unifrac_alpha = 1.0;
     } else {
@@ -106,7 +109,7 @@ int main(int argc, char **argv){
     mat_t *result = NULL;
     compute_status status;
     status = one_off(table_filename.c_str(), tree_filename.c_str(), method_string.c_str(), 
-                     vaw, g_unifrac_alpha, nthreads, &result);
+                     vaw, g_unifrac_alpha, bypass_tips, nthreads, &result);
     if(status != okay || result == NULL) {
         fprintf(stderr, "Compute failed in one_off with error code: %d\n", status);
         exit(EXIT_FAILURE);

--- a/sucpp/task_parameters.hpp
+++ b/sucpp/task_parameters.hpp
@@ -11,6 +11,7 @@
          * start <uint> the first stride to process
          * stop <uint> the last stride to process
          * tid <uint> the thread identifier
+         * bypass_tips <bool> ignore tips on compute, reduces compute by ~50%
          * g_unifrac_alpha <double> an alpha value for generalized unifrac
          */
         struct task_parameters {
@@ -18,6 +19,7 @@
            unsigned int start;          // starting stripe
            unsigned int stop;           // stopping stripe
            unsigned int tid;            // thread ID
+           bool bypass_tips = false;    // avoid compute at tips
            
            // task specific arguments below
            double g_unifrac_alpha;      // generalized unifrac alpha

--- a/sucpp/test_su.cpp
+++ b/sucpp/test_su.cpp
@@ -1014,7 +1014,7 @@ void test_set_tasks() {
     exp[0].stop = 100;
     exp[0].tid = 0;
 
-    set_tasks(obs, 1.0, 100, 0, 100, 1);
+    set_tasks(obs, 1.0, 100, 0, 100, false, 1);
     ASSERT(obs[0].g_unifrac_alpha == exp[0].g_unifrac_alpha);
     ASSERT(obs[0].n_samples == exp[0].n_samples);
     ASSERT(obs[0].start == exp[0].start);
@@ -1035,7 +1035,7 @@ void test_set_tasks() {
     exp2[1].stop = 100;
     exp2[1].tid = 1;
     
-    set_tasks(obs2, 1.0, 100, 0, 100, 2);
+    set_tasks(obs2, 1.0, 100, 0, 100, false, 2);
     for(unsigned int i=0; i < 2; i++) {
         ASSERT(obs2[i].g_unifrac_alpha == exp2[i].g_unifrac_alpha);
         ASSERT(obs2[i].n_samples == exp2[i].n_samples);
@@ -1063,7 +1063,7 @@ void test_set_tasks() {
     exp3[2].stop = 100;
     exp3[2].tid = 2;
     
-    set_tasks(obs3, 1.0, 100, 25, 100, 3);
+    set_tasks(obs3, 1.0, 100, 25, 100, false, 3);
     for(unsigned int i=0; i < 3; i++) {
         ASSERT(obs3[i].g_unifrac_alpha == exp3[i].g_unifrac_alpha);
         ASSERT(obs3[i].n_samples == exp3[i].n_samples);
@@ -1091,7 +1091,7 @@ void test_set_tasks() {
     exp4[2].stop = 100;
     exp4[2].tid = 2;
     
-    set_tasks(obs4, 1.0, 100, 26, 100, 3);
+    set_tasks(obs4, 1.0, 100, 26, 100, false, 3);
     for(unsigned int i=0; i < 3; i++) {
         ASSERT(obs4[i].g_unifrac_alpha == exp4[i].g_unifrac_alpha);
         ASSERT(obs4[i].n_samples == exp4[i].n_samples);

--- a/sucpp/unifrac.cpp
+++ b/sucpp/unifrac.cpp
@@ -6,6 +6,38 @@
 #include <cstdlib>
 #include <thread>
 #include <algorithm>
+#include <signal.h>
+#include <stdarg.h>
+
+static pthread_mutex_t printf_mutex;
+
+int sync_printf(const char *format, ...) {
+	// https://stackoverflow.com/a/23587285/19741
+    va_list args;
+    va_start(args, format);
+
+    pthread_mutex_lock(&printf_mutex);
+    vprintf(format, args);
+    pthread_mutex_unlock(&printf_mutex);
+
+    va_end(args);
+}
+
+
+static bool* report_status;
+
+void sig_handler(int signo) {
+    // http://www.thegeekstuff.com/2012/03/catch-signals-sample-c-code
+    if (signo == SIGUSR1) {
+        if(report_status == NULL)
+            fprintf(stderr, "Cannot report status.\n"); 
+        else {
+            for(int i = 0; i < CPU_SETSIZE; i++) {
+                report_status[i] = true;
+            }
+        }
+    }
+}
 
 
 using namespace su;
@@ -217,6 +249,13 @@ void su::unifrac(biom &table,
         exit(EXIT_FAILURE);
     }
 
+    // register a signal handler so we can ask the master thread for its
+    // progress
+	if(task_p->tid == 0) {
+        if (signal(SIGUSR1, sig_handler) == SIG_ERR)
+            fprintf(stderr, "Can't catch SIGUSR1\n");
+    }
+
     void (*func)(std::vector<double*>&,  // dm_stripes
                  std::vector<double*>&,  // dm_stripes_total
                  double*,                // embedded_proportions
@@ -314,6 +353,11 @@ void su::unifrac(biom &table,
          * (see C) but that is small over large N.  
          */
         func(dm_stripes, dm_stripes_total, embedded_proportions, length, task_p);
+
+		if(__builtin_expect(report_status[task_p->tid], false)) {
+            sync_printf("tid:%d\tk:%d\ttotal:%d\n", task_p->tid, k, (tree.nparens / 2) - 1);
+            report_status[task_p->tid] = false;
+        }
     }
     
     if(unifrac_method == weighted_normalized || unifrac_method == unweighted || unifrac_method == generalized) {
@@ -343,6 +387,13 @@ void su::unifrac_vaw(biom &table,
     if(table.n_samples != task_p->n_samples) {
         fprintf(stderr, "Task and table n_samples not equal\n");
         exit(EXIT_FAILURE);
+    }
+
+    // register a signal handler so we can ask the master thread for its
+    // progress
+	if(task_p->tid == 0) {
+        if (signal(SIGUSR1, sig_handler) == SIG_ERR)
+            fprintf(stderr, "Can't catch SIGUSR1\n");
     }
 
     void (*func)(std::vector<double*>&,  // dm_stripes
@@ -408,6 +459,11 @@ void su::unifrac_vaw(biom &table,
         embed_proportions(embedded_counts, node_counts, task_p->n_samples);
 
         func(dm_stripes, dm_stripes_total, embedded_proportions, embedded_counts, sample_total_counts, length, task_p);
+		
+        if(__builtin_expect(report_status[task_p->tid], false)) {
+            sync_printf("tid:%d\tk:%d\ttotal:%d\n", task_p->tid, k, (tree.nparens / 2) - 1);
+            report_status[task_p->tid] = false;
+        }
     }
     
     if(unifrac_method == weighted_normalized || unifrac_method == unweighted || unifrac_method == generalized) {
@@ -485,6 +541,13 @@ void su::process_stripes(biom &table,
                          std::vector<double*> &dm_stripes_total,
                          std::vector<std::thread> &threads,
                          std::vector<su::task_parameters> &tasks) {
+
+    // for thread status reporting, and safe multithreaded output to console
+    if(report_status != NULL)
+        free(report_status);
+    report_status = (bool*)calloc(sizeof(bool), CPU_SETSIZE);
+    pthread_mutex_init(&printf_mutex, NULL);
+
     for(unsigned int tid = 0; tid < threads.size(); tid++) {
         if(variance_adjust)
             threads[tid] = std::thread(su::unifrac_vaw, 
@@ -507,4 +570,5 @@ void su::process_stripes(biom &table,
     for(unsigned int tid = 0; tid < threads.size(); tid++) {
         threads[tid].join();
     }
+    free(report_status);
 }

--- a/sucpp/unifrac.cpp
+++ b/sucpp/unifrac.cpp
@@ -263,6 +263,10 @@ void su::unifrac(biom &table,
 
         node_proportions = propstack.pop(node);
         set_proportions(node_proportions, tree, node, table, propstack);
+
+        if(task_p->bypass_tips && tree.isleaf(node))
+            continue;
+
         embed_proportions(embedded_proportions, node_proportions, task_p->n_samples);
 
         /*
@@ -396,6 +400,9 @@ void su::unifrac_vaw(biom &table,
 
         set_proportions(node_proportions, tree, node, table, propstack);
         set_proportions(node_counts, tree, node, table, countstack, false);
+
+        if(task_p->bypass_tips && tree.isleaf(node))
+            continue;
 
         embed_proportions(embedded_proportions, node_proportions, task_p->n_samples);
         embed_proportions(embedded_counts, node_counts, task_p->n_samples);

--- a/sucpp/unifrac.cpp
+++ b/sucpp/unifrac.cpp
@@ -12,7 +12,7 @@
 static pthread_mutex_t printf_mutex;
 
 int sync_printf(const char *format, ...) {
-	// https://stackoverflow.com/a/23587285/19741
+    // https://stackoverflow.com/a/23587285/19741
     va_list args;
     va_start(args, format);
 
@@ -251,7 +251,7 @@ void su::unifrac(biom &table,
 
     // register a signal handler so we can ask the master thread for its
     // progress
-	if(task_p->tid == 0) {
+    if(task_p->tid == 0) {
         if (signal(SIGUSR1, sig_handler) == SIG_ERR)
             fprintf(stderr, "Can't catch SIGUSR1\n");
         
@@ -357,7 +357,7 @@ void su::unifrac(biom &table,
          */
         func(dm_stripes, dm_stripes_total, embedded_proportions, length, task_p);
 
-		if(__builtin_expect(report_status[task_p->tid], false)) {
+        if(__builtin_expect(report_status[task_p->tid], false)) {
             sync_printf("tid:%d\tk:%d\ttotal:%d\n", task_p->tid, k, (tree.nparens / 2) - 1);
             report_status[task_p->tid] = false;
         }
@@ -395,7 +395,7 @@ void su::unifrac_vaw(biom &table,
 
     // register a signal handler so we can ask the master thread for its
     // progress
-	if(task_p->tid == 0) {
+    if(task_p->tid == 0) {
         if (signal(SIGUSR1, sig_handler) == SIG_ERR)
             fprintf(stderr, "Can't catch SIGUSR1\n");
         
@@ -466,7 +466,7 @@ void su::unifrac_vaw(biom &table,
         embed_proportions(embedded_counts, node_counts, task_p->n_samples);
 
         func(dm_stripes, dm_stripes_total, embedded_proportions, embedded_counts, sample_total_counts, length, task_p);
-		
+        
         if(__builtin_expect(report_status[task_p->tid], false)) {
             sync_printf("tid:%d\tk:%d\ttotal:%d\n", task_p->tid, k, (tree.nparens / 2) - 1);
             report_status[task_p->tid] = false;

--- a/sucpp/unifrac.cpp
+++ b/sucpp/unifrac.cpp
@@ -254,6 +254,9 @@ void su::unifrac(biom &table,
 	if(task_p->tid == 0) {
         if (signal(SIGUSR1, sig_handler) == SIG_ERR)
             fprintf(stderr, "Can't catch SIGUSR1\n");
+        
+        report_status = (bool*)calloc(sizeof(bool), CPU_SETSIZE);
+        pthread_mutex_init(&printf_mutex, NULL);
     }
 
     void (*func)(std::vector<double*>&,  // dm_stripes
@@ -369,6 +372,7 @@ void su::unifrac(biom &table,
     }
     
     free(embedded_proportions);
+    free(report_status);
 }
 
 void su::unifrac_vaw(biom &table,
@@ -394,6 +398,9 @@ void su::unifrac_vaw(biom &table,
 	if(task_p->tid == 0) {
         if (signal(SIGUSR1, sig_handler) == SIG_ERR)
             fprintf(stderr, "Can't catch SIGUSR1\n");
+        
+        report_status = (bool*)calloc(sizeof(bool), CPU_SETSIZE);
+        pthread_mutex_init(&printf_mutex, NULL);
     }
 
     void (*func)(std::vector<double*>&,  // dm_stripes
@@ -477,7 +484,9 @@ void su::unifrac_vaw(biom &table,
     free(embedded_proportions);
     free(embedded_counts);
     free(sample_total_counts);
+    free(report_status);
 }
+
 void su::set_proportions(double* props, 
                          BPTree &tree, 
                          uint32_t node, 
@@ -542,12 +551,6 @@ void su::process_stripes(biom &table,
                          std::vector<std::thread> &threads,
                          std::vector<su::task_parameters> &tasks) {
 
-    // for thread status reporting, and safe multithreaded output to console
-    if(report_status != NULL)
-        free(report_status);
-    report_status = (bool*)calloc(sizeof(bool), CPU_SETSIZE);
-    pthread_mutex_init(&printf_mutex, NULL);
-
     for(unsigned int tid = 0; tid < threads.size(); tid++) {
         if(variance_adjust)
             threads[tid] = std::thread(su::unifrac_vaw, 
@@ -570,5 +573,4 @@ void su::process_stripes(biom &table,
     for(unsigned int tid = 0; tid < threads.size(); tid++) {
         threads[tid].join();
     }
-    free(report_status);
 }

--- a/unifrac/_api.pxd
+++ b/unifrac/_api.pxd
@@ -16,5 +16,5 @@ cdef extern from "../sucpp/api.hpp":
 
     compute_status one_off(const char* biom_filename, const char* tree_filename, 
                                const char* unifrac_method, bool variance_adjust, double alpha,
-                               unsigned int threads, mat** result)
+                               bool bypass_tips, unsigned int threads, mat** result)
     void destroy_mat(mat** result)

--- a/unifrac/_api.pyx
+++ b/unifrac/_api.pyx
@@ -4,7 +4,7 @@ cimport numpy as np
 
 def ssu(str biom_filename, str tree_filename, 
         str unifrac_method, bool variance_adjust, double alpha,
-        unsigned int threads):
+        bool bypass_tips, unsigned int threads):
     """Execute a call to Strided State UniFrac via the direct API
 
     Parameters
@@ -20,7 +20,10 @@ def ssu(str biom_filename, str tree_filename,
         Whether to perform Variance Adjusted UniFrac
     alpha : float
         The value of alpha for Generalized UniFrac; only applies to
-        Generalized UniFrac
+        Generalized UniFraca
+    bypass_tips : bool
+        Bypass the tips of the tree in the computation. This reduces compute
+        by about 50%, but is an approximation.
     threads : int
         The number of threads to use.
 
@@ -62,7 +65,8 @@ def ssu(str biom_filename, str tree_filename,
                      tree_c_string, 
                      met_c_string, 
                      variance_adjust, 
-                     alpha, 
+                     alpha,
+                     bypass_tips,
                      threads, 
                      &result)
 

--- a/unifrac/_methods.py
+++ b/unifrac/_methods.py
@@ -64,6 +64,9 @@ def unweighted(table: str,
         The number of threads to use. Default of 1.
     variance_adjusted : bool, optional
         Adjust for varianace or not. Default is False.
+    bypass_tips : bool
+        Bypass the tips of the tree in the computation. This reduces compute
+        by about 50%, but is an approximation.
 
     Returns
     -------
@@ -97,7 +100,7 @@ def unweighted(table: str,
     """
     _validate(table, phylogeny)
     return qsu.ssu(table, phylogeny, 'unweighted',
-                   variance_adjusted, 1.0, threads)
+                   variance_adjusted, 1.0, bypass_tips, threads)
 
 
 def weighted_normalized(table: str,
@@ -117,6 +120,9 @@ def weighted_normalized(table: str,
         The number of threads to use. Default of 1.
     variance_adjusted : bool, optional
         Adjust for varianace or not. Default is False.
+    bypass_tips : bool
+        Bypass the tips of the tree in the computation. This reduces compute
+        by about 50%, but is an approximation.
 
     Returns
     -------
@@ -148,7 +154,7 @@ def weighted_normalized(table: str,
        phylogeny. BMC Bioinformatics 12:118 (2011).
     """
     return qsu.ssu(str(table), str(phylogeny), 'weighted_normalized',
-                   variance_adjusted, 1.0, threads)
+                   variance_adjusted, 1.0, bypass_tips, threads)
 
 
 def weighted_unnormalized(table: str,
@@ -168,6 +174,9 @@ def weighted_unnormalized(table: str,
         The number of threads to use. Default is 1.
     variance_adjusted : bool, optional
         Adjust for varianace or not. Default is False.
+    bypass_tips : bool
+        Bypass the tips of the tree in the computation. This reduces compute
+        by about 50%, but is an approximation.
 
     Returns
     -------
@@ -199,7 +208,7 @@ def weighted_unnormalized(table: str,
        phylogeny. BMC Bioinformatics 12:118 (2011).
     """
     return qsu.ssu(str(table), str(phylogeny), 'weighted_unnormalized',
-                   variance_adjusted, 1.0, threads)
+                   variance_adjusted, 1.0, bypass_tips, threads)
 
 
 def generalized(table: str,
@@ -225,6 +234,9 @@ def generalized(table: str,
         range [0, 1]. Default is 1.0.
     variance_adjusted : bool, optional
         Adjust for varianace or not. Default is False.
+    bypass_tips : bool
+        Bypass the tips of the tree in the computation. This reduces compute
+        by about 50%, but is an approximation.
 
     Returns
     -------
@@ -270,7 +282,7 @@ def generalized(table: str,
                                    variance_adjusted)
     else:
         return qsu.ssu(str(table), str(phylogeny), 'generalized',
-                       variance_adjusted, alpha, threads)
+                       variance_adjusted, alpha, bypass_tips, threads)
 
 
 METHODS = {'unweighted': unweighted,
@@ -307,6 +319,9 @@ def meta(tables: tuple, phylogenies: tuple, weights: tuple=None,
         'generalized'.
     threads : int, optional
         The number of threads to use. Default is 1
+    bypass_tips : bool
+        Bypass the tips of the tree in the computation. This reduces compute
+        by about 50%, but is an approximation.
     alpha : float, optional
         The level of contribution of high abundance branches. Higher alpha
         increases the contribution of from high abundance branches while lower

--- a/unifrac/_methods.py
+++ b/unifrac/_methods.py
@@ -50,7 +50,8 @@ def _validate(table, phylogeny):
 def unweighted(table: str,
                phylogeny: str,
                threads: int=1,
-               variance_adjusted: bool=False)-> skbio.DistanceMatrix:
+               variance_adjusted: bool=False,
+               bypass_tips: bool=False)-> skbio.DistanceMatrix:
     """Compute Unweighted UniFrac
 
     Parameters
@@ -102,7 +103,8 @@ def unweighted(table: str,
 def weighted_normalized(table: str,
                         phylogeny: str,
                         threads: int=1,
-                        variance_adjusted: bool=False)-> skbio.DistanceMatrix:
+                        variance_adjusted: bool=False,
+                        bypass_tips: bool=False)-> skbio.DistanceMatrix:
     """Compute weighted normalized UniFrac
 
     Parameters
@@ -152,7 +154,8 @@ def weighted_normalized(table: str,
 def weighted_unnormalized(table: str,
                           phylogeny: str,
                           threads: int=1,
-                          variance_adjusted: bool=False) -> skbio.DistanceMatrix:  # noqa
+                          variance_adjusted: bool=False,
+                          bypass_tips: bool=False) -> skbio.DistanceMatrix:  # noqa
     """Compute weighted unnormalized UniFrac
 
     Parameters
@@ -203,7 +206,8 @@ def generalized(table: str,
                 phylogeny: str,
                 threads: int=1,
                 alpha: float=1.0,
-                variance_adjusted: bool=False)-> skbio.DistanceMatrix:
+                variance_adjusted: bool=False,
+                bypass_tips: bool=False)-> skbio.DistanceMatrix:
     """Compute Generalized UniFrac
 
     Parameters
@@ -278,7 +282,7 @@ METHODS = {'unweighted': unweighted,
 def meta(tables: tuple, phylogenies: tuple, weights: tuple=None,
          consolidation: str=None, method: str=None,
          threads: int=1, variance_adjusted: bool=False,
-         alpha: float=None) -> skbio.DistanceMatrix:
+         alpha: float=None, bypass_tips: bool=False) -> skbio.DistanceMatrix:
     """Compute meta UniFrac
 
     Parameters
@@ -385,7 +389,9 @@ def meta(tables: tuple, phylogenies: tuple, weights: tuple=None,
                          "is set as 'generalized', the selected method is "
                          "'%s'." % method)
 
-    kwargs = {'threads': threads, 'variance_adjusted': variance_adjusted}
+    kwargs = {'threads': threads,
+              'bypass_tips': bypass_tips,
+              'variance_adjusted': variance_adjusted}
     if alpha is not None:
         kwargs['alpha'] = alpha
 

--- a/unifrac/tests/test_api.py
+++ b/unifrac/tests/test_api.py
@@ -32,7 +32,7 @@ class UnifracAPITests(unittest.TestCase):
         t1 = self.get_data_path('t1.newick')
         e1 = self.get_data_path('e1.biom')
 
-        result = ssu(e1, t1, 'unweighted', False, 1.0, 1)
+        result = ssu(e1, t1, 'unweighted', False, 1.0, False, 1)
 
         u1_distances = np.array([[0, 10/16., 8/13.],
                                  [10/16., 0, 8/17.],
@@ -44,19 +44,19 @@ class UnifracAPITests(unittest.TestCase):
     def test_ssu_bad_tree(self):
         e1 = self.get_data_path('e1.biom')
         with self.assertRaisesRegex(IOError, "Tree file not found."):
-            ssu(e1, 'bad-file', 'unweighted', False, 1.0, 1)
+            ssu(e1, 'bad-file', 'unweighted', False, 1.0, False, 1)
 
     def test_ssu_bad_table(self):
         t1 = self.get_data_path('t1.newick')
         with self.assertRaisesRegex(IOError, "Table file not found."):
-            ssu('bad-file', t1, 'unweighted', False, 1.0, 1)
+            ssu('bad-file', t1, 'unweighted', False, 1.0, False, 1)
 
     def test_ssu_bad_method(self):
         t1 = self.get_data_path('t1.newick')
         e1 = self.get_data_path('e1.biom')
 
         with self.assertRaisesRegex(ValueError, "Unknown method."):
-            ssu(e1, t1, 'unweightedfoo', False, 1.0, 1)
+            ssu(e1, t1, 'unweightedfoo', False, 1.0, False, 1)
 
 
 class EdgeCasesTests(unittest.TestCase):
@@ -87,7 +87,7 @@ class EdgeCasesTests(unittest.TestCase):
         tree.write(tr)
 
         # return value is a distance matrix, get the distance from u->v
-        return ssu(ta, tr, method, False, 1.0, 1)['u', 'v']
+        return ssu(ta, tr, method, False, 1.0, False, 1)['u', 'v']
 
     def weighted_unifrac(self, u_counts, v_counts, otu_ids, tree,
                          normalized=False):


### PR DESCRIPTION
Should be quick, although I'd understand if an integration test is requested. By disregarding tips, approximately 50% of the tree does not get evaluated for UniFrac, which in turn removes about 50% of the compute. This works though because we're, in effect, collapsing the phylogeny slightly which is similar to using a coarser OTU picking level (e.g., 99% vs 97%).

Thanks, @dkoslicki, for the idea! This was the easiest thing to do first -- collapsing at a deeper level required a bit more changes.