### PR TITLE
Table tree overlap

### DIFF
--- a/sucpp/api.cpp
+++ b/sucpp/api.cpp
@@ -24,14 +24,19 @@
                                               return err;                                                      \
                                           }
 
-#define PARSE_SYNC_TREE_TABLE(tree_filename, table_filename) std::ifstream ifs(tree_filename);                                      \
-                                                             std::string content = std::string(std::istreambuf_iterator<char>(ifs), \
-                                                                                               std::istreambuf_iterator<char>());   \
-                                                             su::BPTree tree = su::BPTree(content);                                 \
-                                                             su::biom table = su::biom(biom_filename);                              \
-                                                             std::unordered_set<std::string> to_keep(table.obs_ids.begin(),         \
-                                                                                                     table.obs_ids.end());          \
+#define PARSE_SYNC_TREE_TABLE(tree_filename, table_filename) std::ifstream ifs(tree_filename);                                        \
+                                                             std::string content = std::string(std::istreambuf_iterator<char>(ifs),   \
+                                                                                               std::istreambuf_iterator<char>());     \
+                                                             su::BPTree tree = su::BPTree(content);                                   \
+                                                             su::biom table = su::biom(biom_filename);                                \
+                                                             std::string bad_id = su::test_table_ids_are_subset_of_tree(table, tree); \
+                                                             if(bad_id != "") {                                                       \
+                                                                 return table_and_tree_do_not_overlap;                                \
+                                                             }                                                                        \
+                                                             std::unordered_set<std::string> to_keep(table.obs_ids.begin(),           \
+                                                                                                     table.obs_ids.end());            \
                                                              su::BPTree tree_sheared = tree.shear(to_keep).collapse();
+
 
 using namespace su;
 using namespace std;

--- a/sucpp/api.hpp
+++ b/sucpp/api.hpp
@@ -12,9 +12,9 @@
 
 #define PARTIAL_MAGIC "SSU-PARTIAL-01"
 
-typedef enum compute_status {okay, tree_missing, table_missing, unknown_method} ComputeStatus;
-typedef enum io_status {read_okay, write_okay, open_error, read_error, magic_incompatible, bad_header, unexpected_end} IOStatus;
-typedef enum merge_status {merge_okay, incomplete_stripe_set, sample_id_consistency, square_mismatch, partials_mismatch, stripes_overlap} MergeStatus; 
+typedef enum compute_status {okay=0, tree_missing, table_missing, unknown_method, table_and_tree_do_not_overlap} ComputeStatus;
+typedef enum io_status {read_okay=0, write_okay, open_error, read_error, magic_incompatible, bad_header, unexpected_end} IOStatus;
+typedef enum merge_status {merge_okay=0, incomplete_stripe_set, sample_id_consistency, square_mismatch, partials_mismatch, stripes_overlap} MergeStatus; 
 
 /* a result matrix
  *

--- a/sucpp/su.cpp
+++ b/sucpp/su.cpp
@@ -59,7 +59,7 @@ const char* compute_status_messages[5] = {"No error.",
                                           "The tree file cannot be found.", 
                                           "The table file cannot be found.", 
                                           "An unknown method was requested.", 
-                                          "Table observation IDs are not a subset of the tree tips."};
+                                          "Table observation IDs are not a subset of the tree tips. This error can also be triggered if a node name contains a single quote (this is unlikely)."};
 
 
 // https://stackoverflow.com/questions/8401777/simple-glob-in-c-on-unix-system

--- a/sucpp/su.cpp
+++ b/sucpp/su.cpp
@@ -55,6 +55,12 @@ void usage() {
     std::cout << std::endl;
 }
 
+const char* compute_status_messages[5] = {"No error.", 
+                                          "The tree file cannot be found.", 
+                                          "The table file cannot be found.", 
+                                          "An unknown method was requested.", 
+                                          "Table observation IDs are not a subset of the tree tips."};
+
 
 // https://stackoverflow.com/questions/8401777/simple-glob-in-c-on-unix-system
 inline std::vector<std::string> glob(const std::string& pat){
@@ -213,7 +219,7 @@ int mode_partial(std::string table_filename, std::string tree_filename,
     status = partial(table_filename.c_str(), tree_filename.c_str(), method_string.c_str(), 
                      vaw, g_unifrac_alpha, bypass_tips, nthreads, start_stripe, stop_stripe, &result);
     if(status != okay || result == NULL) {
-        fprintf(stderr, "Compute failed in one_off with error code: %d\n", status);
+        fprintf(stderr, "Compute failed in partial: %s\n", compute_status_messages[status]);
         exit(EXIT_FAILURE);
     }
    
@@ -257,7 +263,7 @@ int mode_one_off(std::string table_filename, std::string tree_filename,
     status = one_off(table_filename.c_str(), tree_filename.c_str(), method_string.c_str(), 
                      vaw, g_unifrac_alpha, bypass_tips, nthreads, &result);
     if(status != okay || result == NULL) {
-        fprintf(stderr, "Compute failed in one_off with error code: %d\n", status);
+        fprintf(stderr, "Compute failed in one_off: %s\n", compute_status_messages[status]);
         exit(EXIT_FAILURE);
     }
    

--- a/sucpp/test_su.cpp
+++ b/sucpp/test_su.cpp
@@ -991,6 +991,15 @@ void test_bptree_shear_deep() {
     SUITE_END();
 }
 
+void test_bptree_get_tip_names() {
+    SUITE_START("test bptree get_tip_names");
+    su::BPTree tree = su::BPTree("((a:2,b:3,(c:5)d:4)e:1,f:6,((g:9,h:10)i:8)j:7)r");
+    
+    std::unordered_set<std::string> expected = {"a", "b", "c", "f", "g", "h"};
+    std::unordered_set<std::string> observed = tree.get_tip_names();
+    ASSERT(observed == expected);
+    SUITE_END();
+}    
 
 void test_bptree_collapse_simple() {
     SUITE_START("test bptree collapse simple");
@@ -1162,6 +1171,7 @@ int main(int argc, char** argv) {
     test_bptree_leftchild();
     test_bptree_rightchild();
     test_bptree_rightsibling();
+    test_bptree_get_tip_names();
     test_bptree_mask();
     test_bptree_shear_simple();
     test_bptree_shear_deep();

--- a/sucpp/test_su.cpp
+++ b/sucpp/test_su.cpp
@@ -355,6 +355,29 @@ void test_bptree_constructor_edgecases() {
     SUITE_END();
 }
 
+void test_bptree_constructor_quoted_comma() {
+    SUITE_START("quoted comma bug");
+    su::BPTree tree = su::BPTree("((3,'foo,bar')x,c)r;");
+    std::vector<std::string> exp_names = {"r", "x", "3", "", "foo,bar", "", "", "c", "", ""};
+    ASSERT(exp_names.size() == tree.names.size());
+    
+    for(unsigned int i = 0; i < tree.names.size(); i++) {
+        ASSERT(exp_names[i] == tree.names[i]);
+    }
+    SUITE_END();
+}
+
+void test_bptree_constructor_quoted_parens() {
+    SUITE_START("quoted parens");
+    su::BPTree tree = su::BPTree("((3,'foo(b)ar')x,c)r;");
+    std::vector<std::string> exp_names = {"r", "x", "3", "", "foo(b)ar", "", "", "c", "", ""};
+    ASSERT(exp_names.size() == tree.names.size());
+    
+    for(unsigned int i = 0; i < tree.names.size(); i++) {
+        ASSERT(exp_names[i] == tree.names[i]);
+    }
+    SUITE_END();
+}
 void test_bptree_postorder() {
     SUITE_START("postorderselect");
     
@@ -1183,6 +1206,8 @@ int main(int argc, char** argv) {
     test_bptree_constructor_complex();
     test_bptree_constructor_semicolon();
     test_bptree_constructor_edgecases();
+    test_bptree_constructor_quoted_comma();
+    test_bptree_constructor_quoted_parens();
     test_bptree_postorder();
     test_bptree_preorder();
     test_bptree_parent();

--- a/sucpp/test_su.cpp
+++ b/sucpp/test_su.cpp
@@ -991,6 +991,24 @@ void test_bptree_shear_deep() {
     SUITE_END();
 }
 
+void test_test_table_ids_are_subset_of_tree() {
+    SUITE_START("test test_table_ids_are_subset_of_tree");
+
+    su::BPTree tree = su::BPTree("(a:1,b:2)r;");
+    su::biom table = su::biom("test.biom");
+    std::string expected = "GG_OTU_1";
+    std::string observed = su::test_table_ids_are_subset_of_tree(table, tree);
+    ASSERT(observed == expected);
+   
+    su::BPTree tree2 = su::BPTree("(GG_OTU_1,GG_OTU_5,GG_OTU_6,GG_OTU_2,GG_OTU_3,GG_OTU_4);");
+    su::biom table2 = su::biom("test.biom");
+    expected = "";
+    observed = su::test_table_ids_are_subset_of_tree(table2, tree2);
+    ASSERT(observed == expected);
+    SUITE_END();
+}
+
+
 void test_bptree_get_tip_names() {
     SUITE_START("test bptree get_tip_names");
     su::BPTree tree = su::BPTree("((a:2,b:3,(c:5)d:4)e:1,f:6,((g:9,h:10)i:8)j:7)r");
@@ -1197,6 +1215,7 @@ int main(int argc, char** argv) {
     test_vaw_unifrac_weighted_normalized();
     test_unifrac_sample_counts();
     test_set_tasks();
+    test_test_table_ids_are_subset_of_tree();
 
     printf("\n");
     printf(" %i / %i suites failed\n", suites_failed, suites_run);

--- a/sucpp/tree.cpp
+++ b/sucpp/tree.cpp
@@ -82,6 +82,18 @@ BPTree BPTree::mask(std::vector<bool> topology_mask, std::vector<double> in_leng
     return BPTree(new_structure, new_lengths, new_names);
 }
 
+std::unordered_set<std::string> BPTree::get_tip_names() {
+    std::unordered_set<std::string> observed;
+	
+    for(unsigned int i = 0; i < this->nparens; i++) {
+        if(this->isleaf(i)) {
+            observed.insert(this->names[i]);
+        }
+    }
+
+    return observed;
+}
+
 BPTree BPTree::shear(std::unordered_set<std::string> to_keep) {
     std::vector<bool> shearmask = std::vector<bool>(this->nparens);
     int32_t p;

--- a/sucpp/tree.cpp
+++ b/sucpp/tree.cpp
@@ -268,7 +268,14 @@ void BPTree::newick_to_bp(std::string newick) {
     char last_structure;
     bool potential_single_descendent = false;
     int count = 0;
+    bool in_quote = false;
     for(auto c = newick.begin(); c != newick.end(); c++) {
+        if(*c == '\'') 
+            in_quote = !in_quote;
+
+        if(in_quote)
+            continue;
+
         switch(*c) {
             case '(':
                 // opening of a node
@@ -421,7 +428,7 @@ std::string BPTree::tokenize(std::string::iterator &start, const std::string::it
             continue;
         }
 
-        isquote = (c == '"' || c == '\'');
+        isquote = c == '\'';
         
         if(inquote && isquote) {
             inquote = false;

--- a/sucpp/tree.hpp
+++ b/sucpp/tree.hpp
@@ -77,6 +77,9 @@ namespace su {
              */
             int32_t parent(uint32_t i);
 
+            /* get the names at the tips of the tree */
+            std::unordered_set<std::string> get_tip_names();
+
             /* public getters */
             std::vector<bool> get_structure();
             std::vector<uint32_t> get_openclose();

--- a/sucpp/unifrac.cpp
+++ b/sucpp/unifrac.cpp
@@ -11,6 +11,22 @@
 
 static pthread_mutex_t printf_mutex;
 
+std::string su::test_table_ids_are_subset_of_tree(su::biom &table, su::BPTree &tree) {
+    std::unordered_set<std::string> tip_names = tree.get_tip_names();
+    std::unordered_set<std::string>::const_iterator hit;
+    std::string a_missing_name = "";
+
+    for(auto i : table.obs_ids) {
+        hit = tip_names.find(i);
+        if(hit == tip_names.end()) {
+            a_missing_name = i;
+            break;
+        }
+    }
+
+    return a_missing_name;
+}
+
 int sync_printf(const char *format, ...) {
     // https://stackoverflow.com/a/23587285/19741
     va_list args;

--- a/sucpp/unifrac.hpp
+++ b/sucpp/unifrac.hpp
@@ -21,6 +21,7 @@
                 double* get(uint32_t i);
         };
 
+        std::string test_table_ids_are_subset_of_tree(biom &table, BPTree &tree);
         void unifrac(biom &table, 
                      BPTree &tree, 
                      Method unifrac_method,

--- a/unifrac/_api.pxd
+++ b/unifrac/_api.pxd
@@ -12,7 +12,8 @@ cdef extern from "../sucpp/api.hpp":
         okay, 
         tree_missing,
         table_missing,
-        unknown_method
+        unknown_method,
+        table_and_tree_do_not_overlap
 
     compute_status one_off(const char* biom_filename, const char* tree_filename, 
                                const char* unifrac_method, bool variance_adjust, double alpha,


### PR DESCRIPTION
@ElDeveloper This is the PR. It spans three items:

- explicitly test to make sure the observation IDs in the table are a subset of the tip names in the tree
- provide human readable messages when an error occurs (e.g., missing a filename)
- fixes a bug where quoted structural characters were not appropriately being captured