### PR TITLE
Faith pd

### DIFF
--- a/sucpp/api.cpp
+++ b/sucpp/api.cpp
@@ -29,6 +29,9 @@
                                                                                                std::istreambuf_iterator<char>());     \
                                                              su::BPTree tree = su::BPTree(content);                                   \
                                                              su::biom table = su::biom(biom_filename);                                \
+                                                             if(table.n_samples <= 0 | table.n_obs <= 0) {                            \
+                                                                 return table_empty;                                                  \
+                                                             }                                                                        \
                                                              std::string bad_id = su::test_table_ids_are_subset_of_tree(table, tree); \
                                                              if(bad_id != "") {                                                       \
                                                                  return table_and_tree_do_not_overlap;                                \
@@ -89,6 +92,7 @@ void initialize_mat(mat_t* &result, biom &table, bool is_upper_triangle) {
 }
 
 void initialize_results_vec(r_vec* &result, biom& table){
+    // Stores results for Faith PD
     result = (r_vec*)malloc(sizeof(results_vec));
     result->n_samples = table.n_samples;
     result->values = (double*)malloc(sizeof(double) * result->n_samples);
@@ -143,14 +147,15 @@ void initialize_partial_mat(partial_mat_t* &result, biom &table, std::vector<dou
 }
 
 void destroy_results_vec(r_vec** result) {
+    // for Faith PD
     for(unsigned int i = 0; i < (*result)->n_samples; i++) {
         free((*result)->sample_ids[i]);
     };
     free((*result)->sample_ids);
     free((*result)->values);
     free(*result);
-
 }
+
 void destroy_mat(mat_t** result) {
     for(unsigned int i = 0; i < (*result)->n_samples; i++) {
         free((*result)->sample_ids[i]);
@@ -273,9 +278,7 @@ compute_status faith_pd_one_off(const char* biom_filename, const char* tree_file
     su::faith_pd(table, tree_sheared, std::ref((*result)->values));
 
     return okay;
-
 }
-
 
 compute_status one_off(const char* biom_filename, const char* tree_filename,
                        const char* unifrac_method, bool variance_adjust, double alpha,

--- a/sucpp/api.cpp
+++ b/sucpp/api.cpp
@@ -267,10 +267,9 @@ compute_status faith_pd_one_off(const char* biom_filename, const char* tree_file
     initialize_results_vec(*result, table);
 
     // compute faithpd
+    su::faith_pd(table, tree, std::ref((*result)->values));
+
     return okay;
-
-
-
 
 }
 

--- a/sucpp/api.cpp
+++ b/sucpp/api.cpp
@@ -268,7 +268,7 @@ compute_status faith_pd_one_off(const char* biom_filename, const char* tree_file
     initialize_results_vec(*result, table);
 
     // compute faithpd
-    su::faith_pd(table, tree, std::ref((*result)->values));
+    su::faith_pd(table, tree_sheared, std::ref((*result)->values));
 
     return okay;
 

--- a/sucpp/api.cpp
+++ b/sucpp/api.cpp
@@ -48,7 +48,8 @@ bool is_file_exists(const char *fileName) {
 }
 
 
-void destroy_stripes(vector<double*> &dm_stripes, vector<double*> &dm_stripes_total, unsigned int n_samples, unsigned int stripe_start, unsigned int stripe_stop) {
+void destroy_stripes(vector<double*> &dm_stripes, vector<double*> &dm_stripes_total, unsigned int n_samples,
+                     unsigned int stripe_start, unsigned int stripe_stop) {
     unsigned int n_rotations = (n_samples + 1) / 2;
 
     if(stripe_stop == 0) {
@@ -117,7 +118,8 @@ void initialize_mat_no_biom(mat_t* &result, char** sample_ids, unsigned int n_sa
     }
 }
 
-void initialize_partial_mat(partial_mat_t* &result, biom &table, std::vector<double*> &dm_stripes, unsigned int stripe_start, unsigned int stripe_stop, bool is_upper_triangle) {
+void initialize_partial_mat(partial_mat_t* &result, biom &table, std::vector<double*> &dm_stripes,
+                            unsigned int stripe_start, unsigned int stripe_stop, bool is_upper_triangle) {
     result = (partial_mat_t*)malloc(sizeof(partial_mat));
     result->n_samples = table.n_samples;
 

--- a/sucpp/api.cpp
+++ b/sucpp/api.cpp
@@ -54,7 +54,7 @@ void destroy_stripes(vector<double*> &dm_stripes, vector<double*> &dm_stripes_to
     if(stripe_stop == 0) {
         for(unsigned int i = 0; i < n_rotations; i++) {
             free(dm_stripes[i]);
-            if(dm_stripes_total[i] != NULL) 
+            if(dm_stripes_total[i] != NULL)
                 free(dm_stripes_total[i]);
         }
     } else {
@@ -63,7 +63,7 @@ void destroy_stripes(vector<double*> &dm_stripes, vector<double*> &dm_stripes_to
         // and subsequently freed in destroy_partial_mat. but, we do need to free dm_stripes_total
         // if appropriate
         for(unsigned int i = stripe_start; i < stripe_stop; i++) {
-            if(dm_stripes_total[i] != NULL) 
+            if(dm_stripes_total[i] != NULL)
                 free(dm_stripes_total[i]);
         }
     }
@@ -73,8 +73,8 @@ void destroy_stripes(vector<double*> &dm_stripes, vector<double*> &dm_stripes_to
 void initialize_mat(mat_t* &result, biom &table, bool is_upper_triangle) {
     result = (mat_t*)malloc(sizeof(mat));
     result->n_samples = table.n_samples;
-    
-    result->cf_size = su::comb_2(table.n_samples); 
+
+    result->cf_size = su::comb_2(table.n_samples);
     result->is_upper_triangle = is_upper_triangle;
     result->sample_ids = (char**)malloc(sizeof(char*) * result->n_samples);
     result->condensed_form = (double*)malloc(sizeof(double) * su::comb_2(table.n_samples));
@@ -98,6 +98,7 @@ void initialize_results_vec(r_vec* &result, biom& table){
         result->sample_ids[i] = (char*)malloc(sizeof(char) * len + 1);
         table.sample_ids[i].copy(result->sample_ids[i], len);
         result->sample_ids[i][len] = '\0';
+        result->values[i] = 0;
     }
 
 }
@@ -105,21 +106,21 @@ void initialize_results_vec(r_vec* &result, biom& table){
 void initialize_mat_no_biom(mat_t* &result, char** sample_ids, unsigned int n_samples, bool is_upper_triangle) {
     result = (mat_t*)malloc(sizeof(mat));
     result->n_samples = n_samples;
-    
-    result->cf_size = su::comb_2(n_samples); 
+
+    result->cf_size = su::comb_2(n_samples);
     result->is_upper_triangle = is_upper_triangle;
     result->sample_ids = (char**)malloc(sizeof(char*) * result->n_samples);
     result->condensed_form = (double*)malloc(sizeof(double) * su::comb_2(n_samples));
-    
+
     for(unsigned int i = 0; i < n_samples; i++) {
-        result->sample_ids[i] = strdup(sample_ids[i]); 
+        result->sample_ids[i] = strdup(sample_ids[i]);
     }
 }
 
 void initialize_partial_mat(partial_mat_t* &result, biom &table, std::vector<double*> &dm_stripes, unsigned int stripe_start, unsigned int stripe_stop, bool is_upper_triangle) {
     result = (partial_mat_t*)malloc(sizeof(partial_mat));
     result->n_samples = table.n_samples;
-    
+
     result->sample_ids = (char**)malloc(sizeof(char*) * result->n_samples);
     for(unsigned int i = 0; i < result->n_samples; i++) {
         size_t len = table.sample_ids[i].length();
@@ -178,8 +179,8 @@ void destroy_partial_mat(partial_mat_t** result) {
 void set_tasks(std::vector<su::task_parameters> &tasks,
                double alpha,
                unsigned int n_samples,
-               unsigned int stripe_start, 
-               unsigned int stripe_stop, 
+               unsigned int stripe_start,
+               unsigned int stripe_stop,
                bool bypass_tips,
                unsigned int nthreads) {
 
@@ -200,17 +201,17 @@ void set_tasks(std::vector<su::task_parameters> &tasks,
         n_fullbins = nthreads;
 
     unsigned int start = stripe_start;
-    
+
     for(unsigned int tid = 0; tid < nthreads; tid++) {
         tasks[tid].tid = tid;
         tasks[tid].start = start; // stripe start
         tasks[tid].bypass_tips = bypass_tips;
 
         if(tid < n_fullbins) {
-            tasks[tid].stop = start + fullchunk;  // stripe end 
+            tasks[tid].stop = start + fullchunk;  // stripe end
             start = start + fullchunk;
         } else {
-            tasks[tid].stop = start + smallchunk;  // stripe end 
+            tasks[tid].stop = start + smallchunk;  // stripe end
             start = start + smallchunk;
         }
 
@@ -219,7 +220,7 @@ void set_tasks(std::vector<su::task_parameters> &tasks,
     }
 }
 
-compute_status partial(const char* biom_filename, const char* tree_filename, 
+compute_status partial(const char* biom_filename, const char* tree_filename,
                        const char* unifrac_method, bool variance_adjust, double alpha, bool bypass_tips,
                        unsigned int nthreads, unsigned int stripe_start, unsigned int stripe_stop,
                        partial_mat_t** result) {
@@ -232,8 +233,8 @@ compute_status partial(const char* biom_filename, const char* tree_filename,
     // we resize to the largest number of possible stripes even if only computing
     // partial, however we do not allocate arrays for non-computed stripes so
     // there is a little memory waste here but should be on the order of
-    // 8 bytes * N samples per vector. 
-    std::vector<double*> dm_stripes((table.n_samples + 1) / 2); 
+    // 8 bytes * N samples per vector.
+    std::vector<double*> dm_stripes((table.n_samples + 1) / 2);
     std::vector<double*> dm_stripes_total((table.n_samples + 1) / 2);
 
     if(nthreads > dm_stripes.size()) {
@@ -254,7 +255,7 @@ compute_status partial(const char* biom_filename, const char* tree_filename,
 
     initialize_partial_mat(*result, table, dm_stripes, stripe_start, stripe_stop, true);  // true -> is_upper_triangle
     destroy_stripes(dm_stripes, dm_stripes_total, table.n_samples, stripe_start, stripe_stop);
-    
+
     return okay;
 }
 
@@ -274,7 +275,7 @@ compute_status faith_pd_one_off(const char* biom_filename, const char* tree_file
 }
 
 
-compute_status one_off(const char* biom_filename, const char* tree_filename, 
+compute_status one_off(const char* biom_filename, const char* tree_filename,
                        const char* unifrac_method, bool variance_adjust, double alpha,
                        bool bypass_tips, unsigned int nthreads, mat_t** result) {
 
@@ -286,8 +287,8 @@ compute_status one_off(const char* biom_filename, const char* tree_filename,
     // we resize to the largest number of possible stripes even if only computing
     // partial, however we do not allocate arrays for non-computed stripes so
     // there is a little memory waste here but should be on the order of
-    // 8 bytes * N samples per vector. 
-    std::vector<double*> dm_stripes((table.n_samples + 1) / 2); 
+    // 8 bytes * N samples per vector.
+    std::vector<double*> dm_stripes((table.n_samples + 1) / 2);
     std::vector<double*> dm_stripes_total((table.n_samples + 1) / 2);
 
     if(nthreads > dm_stripes.size()) {
@@ -303,13 +304,13 @@ compute_status one_off(const char* biom_filename, const char* tree_filename,
 
     initialize_mat(*result, table, true);  // true -> is_upper_triangle
     for(unsigned int tid = 0; tid < threads.size(); tid++) {
-        threads[tid] = std::thread(su::stripes_to_condensed_form, 
-                                   std::ref(dm_stripes), 
+        threads[tid] = std::thread(su::stripes_to_condensed_form,
+                                   std::ref(dm_stripes),
                                    table.n_samples,
                                    std::ref((*result)->condensed_form),
                                    tasks[tid].start,
                                    tasks[tid].stop);
-    } 
+    }
     for(unsigned int tid = 0; tid < threads.size(); tid++) {
         threads[tid].join();
     }
@@ -322,11 +323,11 @@ compute_status one_off(const char* biom_filename, const char* tree_filename,
 IOStatus write_mat(const char* output_filename, mat_t* result) {
     std::ofstream output;
     output.open(output_filename);
-  
+
     uint64_t comb_N = su::comb_2(result->n_samples);
     uint64_t comb_N_minus = 0;
     double v;
-   
+
     for(unsigned int i = 0; i < result->n_samples; i++)
         output << "\t" << result->sample_ids[i];
     output << std::endl;
@@ -354,9 +355,9 @@ IOStatus write_mat(const char* output_filename, mat_t* result) {
 IOStatus write_partial(const char* output_filename, partial_mat_t* result) {
     std::ofstream output;
     output.open(output_filename, std::ios::binary);
-    if(!output.is_open()) 
+    if(!output.is_open())
         return open_error;
-    
+
     uint32_t n_stripes = result->stripe_stop - result->stripe_start;
     std::string magic(PARTIAL_MAGIC);
     uint32_t magic_len = magic.length();
@@ -369,7 +370,7 @@ IOStatus write_partial(const char* output_filename, partial_mat_t* result) {
     output.write(reinterpret_cast<const char*>(&result->stripe_start),      sizeof(uint32_t));
     output.write(reinterpret_cast<const char*>(&result->stripe_total),      sizeof(uint32_t));
     output.write(reinterpret_cast<const char*>(&result->is_upper_triangle), sizeof(uint8_t));
-    
+
     /* sample IDs */
     for(unsigned int i = 0; i < result->n_samples; i++) {
         uint16_t length = strlen(result->sample_ids[i]);
@@ -384,7 +385,7 @@ IOStatus write_partial(const char* output_filename, partial_mat_t* result) {
         for(unsigned int j = 0; j < result->n_samples; j++)
             output.write(reinterpret_cast<const char*>(&result->stripes[i][j]), sizeof(double));
     }
-    
+
     /* footer */
     output << magic;
     output.close();
@@ -395,14 +396,14 @@ IOStatus write_partial(const char* output_filename, partial_mat_t* result) {
 IOStatus _is_partial_file(const char* input_filename) {
     std::ifstream input;
     input.open(input_filename, std::ios::in | std::ios::binary);
-    if(!input.is_open()) 
+    if(!input.is_open())
         return open_error;
 
     char magic[32];
     uint16_t magic_len;
 
     input.read((char*)&magic_len, 2);
-    
+
     // if the length of the magic is unexpected then bail
     if(magic_len <= 0 || magic_len > 32) {
         return magic_incompatible;
@@ -412,8 +413,8 @@ IOStatus _is_partial_file(const char* input_filename) {
     if(strncmp(magic, PARTIAL_MAGIC, magic_len) != 0) {
         return magic_incompatible;
     }
-    
-    input.close(); 
+
+    input.close();
     return read_okay;
 }
 
@@ -429,26 +430,26 @@ IOStatus read_partial(const char* input_filename, partial_mat_t** result_out) {
     /* load header */
     uint16_t magic_len;
     input.read((char*)&magic_len, 2);  // magic length
-    
+
     char header_magic[32];
     input.read(header_magic, magic_len);  // magic
     header_magic[magic_len] = '\0';
-    
+
     uint32_t n_samples;
     input.read((char*)&n_samples, 4);  // number of samples
-   
-    uint32_t n_stripes; 
+
+    uint32_t n_stripes;
     input.read((char*)&n_stripes, 4);  // number of stripes
-   
-    uint32_t stripe_start; 
+
+    uint32_t stripe_start;
     input.read((char*)&stripe_start, 4);  // stripe start
-    
+
     uint32_t stripe_total;
     input.read((char*)&stripe_total, 4);  // stripe total
-   
-    bool is_upper_triangle; 
+
+    bool is_upper_triangle;
     input.read((char*)&is_upper_triangle, 1);  // is_upper_triangle
-    
+
     /* sanity check header */
     if(n_samples <= 0 || n_stripes <= 0 || stripe_start < 0 || stripe_total <= 0 || is_upper_triangle < 0)
         return bad_header;
@@ -464,7 +465,7 @@ IOStatus read_partial(const char* input_filename, partial_mat_t** result_out) {
     result->stripe_stop = stripe_start + n_stripes;
     result->is_upper_triangle = is_upper_triangle;
     result->stripe_total = stripe_total;
-    
+
     /* load samples */
     for(int i = 0; i < n_samples; i++) {
         uint16_t sample_length;
@@ -486,7 +487,7 @@ IOStatus read_partial(const char* input_filename, partial_mat_t** result_out) {
         result->stripes[i] = (double*)ptr;
         input.read(reinterpret_cast<char*>(result->stripes[i]), sizeof(double) * n_samples);
     }
-    
+
     /* sanity check the footer */
     char footer_magic[32];
     input.read(footer_magic, magic_len);
@@ -496,8 +497,8 @@ IOStatus read_partial(const char* input_filename, partial_mat_t** result_out) {
         return magic_incompatible;
     }
 
-    (*result_out) = result; 
-    return read_okay; 
+    (*result_out) = result;
+    return read_okay;
 }
 
 MergeStatus merge_partial(partial_mat_t** partial_mats, int n_partials, unsigned int nthreads, mat_t** result) {
@@ -552,7 +553,7 @@ MergeStatus merge_partial(partial_mat_t** partial_mats, int n_partials, unsigned
         int n_stripes = partial_mats[i]->stripe_stop - partial_mats[i]->stripe_start;
         for(int j = 0; j < n_stripes; j++) {
             // as this is potentially a large amount of memory, don't copy, just adopt
-            *&(stripes[j + partial_mats[i]->stripe_start]) = partial_mats[i]->stripes[j]; 
+            *&(stripes[j + partial_mats[i]->stripe_start]) = partial_mats[i]->stripes[j];
         }
     }
 
@@ -571,4 +572,3 @@ MergeStatus merge_partial(partial_mat_t** partial_mats, int n_partials, unsigned
 
     return merge_okay;
 }
-

--- a/sucpp/api.cpp
+++ b/sucpp/api.cpp
@@ -87,6 +87,21 @@ void initialize_mat(mat_t* &result, biom &table, bool is_upper_triangle) {
     }
 }
 
+void initialize_results_vec(r_vec* &result, biom& table){
+    result = (r_vec*)malloc(sizeof(results_vec));
+    result->n_samples = table.n_samples;
+    result->values = (double*)malloc(sizeof(double) * result->n_samples);
+    result->sample_ids = (char**)malloc(sizeof(char*) * result->n_samples);
+
+    for(unsigned int i = 0; i < result->n_samples; i++) {
+        size_t len = table.sample_ids[i].length();
+        result->sample_ids[i] = (char*)malloc(sizeof(char) * len + 1);
+        table.sample_ids[i].copy(result->sample_ids[i], len);
+        result->sample_ids[i][len] = '\0';
+    }
+
+}
+
 void initialize_mat_no_biom(mat_t* &result, char** sample_ids, unsigned int n_samples, bool is_upper_triangle) {
     result = (mat_t*)malloc(sizeof(mat));
     result->n_samples = n_samples;
@@ -124,7 +139,15 @@ void initialize_partial_mat(partial_mat_t* &result, biom &table, std::vector<dou
     }
 }
 
+void destroy_results_vec(r_vec** result) {
+    for(unsigned int i = 0; i < (*result)->n_samples; i++) {
+        free((*result)->sample_ids[i]);
+    };
+    free((*result)->sample_ids);
+    free((*result)->values);
+    free(*result);
 
+}
 void destroy_mat(mat_t** result) {
     for(unsigned int i = 0; i < (*result)->n_samples; i++) {
         free((*result)->sample_ids[i]);
@@ -233,6 +256,22 @@ compute_status partial(const char* biom_filename, const char* tree_filename,
     destroy_stripes(dm_stripes, dm_stripes_total, table.n_samples, stripe_start, stripe_stop);
     
     return okay;
+}
+
+compute_status faith_pd_one_off(const char* biom_filename, const char* tree_filename,
+                                r_vec** result){
+    CHECK_FILE(biom_filename, table_missing)
+    CHECK_FILE(tree_filename, tree_missing)
+    PARSE_SYNC_TREE_TABLE(tree_filename, table_filename)
+
+    initialize_results_vec(*result, table);
+
+    // compute faithpd
+    return okay;
+
+
+
+
 }
 
 

--- a/sucpp/api.hpp
+++ b/sucpp/api.hpp
@@ -7,30 +7,30 @@
 
 #else
 #include <stdbool.h>
-#define EXTERN 
+#define EXTERN
 #endif
 
 #define PARTIAL_MAGIC "SSU-PARTIAL-01"
 
 typedef enum compute_status {okay=0, tree_missing, table_missing, unknown_method, table_and_tree_do_not_overlap} ComputeStatus;
 typedef enum io_status {read_okay=0, write_okay, open_error, read_error, magic_incompatible, bad_header, unexpected_end} IOStatus;
-typedef enum merge_status {merge_okay=0, incomplete_stripe_set, sample_id_consistency, square_mismatch, partials_mismatch, stripes_overlap} MergeStatus; 
+typedef enum merge_status {merge_okay=0, incomplete_stripe_set, sample_id_consistency, square_mismatch, partials_mismatch, stripes_overlap} MergeStatus;
 
 /* a result matrix
  *
  * n_samples <uint> the number of samples.
  * cf_size <uint> the size of the condensed form.
  * is_upper_triangle <bool> if true, indicates condensed_form represents a square
- *      matrix, and only the upper triangle is contained. if false, 
+ *      matrix, and only the upper triangle is contained. if false,
  *      condensed_form represents the lower triangle of a matrix.
  * condensed_form <double*> the matrix values of length cf_size.
  * sample_ids <char**> the sample IDs of length n_samples.
  */
 typedef struct mat {
-    unsigned int n_samples;  
-    unsigned int cf_size;   
-    bool is_upper_triangle;          
-    double* condensed_form;    
+    unsigned int n_samples;
+    unsigned int cf_size;
+    bool is_upper_triangle;
+    double* condensed_form;
     char** sample_ids;
 } mat_t;
 
@@ -45,14 +45,14 @@ typedef struct results_vec{
  * n_samples <uint> the number of samples.
  * sample_ids <char**> the sample IDs of length n_samples.
  * stripes <double**> the stripe data of dimension (stripe_stop - stripe_start, n_samples)
- * stripe_start <uint> the logical starting stripe in the final matrix. 
+ * stripe_start <uint> the logical starting stripe in the final matrix.
  * stripe_stop <uint> the logical stopping stripe in the final matrix.
  * stripe_total <uint> the total number of stripes present in the final matrix.
- * is_upper_triangle <bool> whether the stripes correspond to the upper triangle of the resulting matrix. 
- *      This is useful for asymmetric unifrac metrics. 
+ * is_upper_triangle <bool> whether the stripes correspond to the upper triangle of the resulting matrix.
+ *      This is useful for asymmetric unifrac metrics.
  */
 typedef struct partial_mat {
-    uint32_t n_samples;  
+    uint32_t n_samples;
     char** sample_ids;
     double** stripes;
     uint32_t stripe_start;
@@ -83,7 +83,7 @@ void destroy_results_vec(r_vec** result);
  * tree_missing   : the filename for the tree does not exist
  * unknown_method : the requested method is unknown.
  */
-EXTERN ComputeStatus one_off(const char* biom_filename, const char* tree_filename, 
+EXTERN ComputeStatus one_off(const char* biom_filename, const char* tree_filename,
                              const char* unifrac_method, bool variance_adjust, double alpha,
                              bool bypass_tips, unsigned int threads, mat_t** result);
 
@@ -145,9 +145,9 @@ EXTERN IOStatus write_mat(const char* filename, mat_t* result);
  * unknown_method : the requested method is unknown.
  */
 
-EXTERN ComputeStatus partial(const char* biom_filename, const char* tree_filename, 
+EXTERN ComputeStatus partial(const char* biom_filename, const char* tree_filename,
                              const char* unifrac_method, bool variance_adjust, double alpha,
-                             bool bypass_tips, unsigned int threads, unsigned int stripe_start, 
+                             bool bypass_tips, unsigned int threads, unsigned int stripe_start,
                              unsigned int stripe_stop, partial_mat_t** result);
 
 /* Write a partial matrix object
@@ -161,7 +161,7 @@ EXTERN ComputeStatus partial(const char* biom_filename, const char* tree_filenam
  * open_error : could not open the file
  *
  * The structure of the binary output file is as follows. Newlines added for clarity, but are not stored.
- * The file has logical blocks, but are not explicitly denoted in the format. These logical blocks are 
+ * The file has logical blocks, but are not explicitly denoted in the format. These logical blocks are
  * just used to improve readability here, and are denoted by ### marks.
  *
  * ### HEADER ###
@@ -215,7 +215,7 @@ EXTERN IOStatus read_partial(const char* filename, partial_mat_t** result);
  * merged <mat_t**> the full matrix, output parameters, this is initialized in the method so using **
  *
  * The following error codes are returned:
- * 
+ *
  * merge_okay            : no problems
  * incomplete_stripe_set : not all stripes needed to create a full matrix were foun
  * sample_id_consistency : samples described by stripes are inconsistent
@@ -228,7 +228,7 @@ EXTERN MergeStatus merge_partial(partial_mat_t** partial_mats, int n_partials, u
 void set_tasks(std::vector<su::task_parameters> &tasks,
                double alpha,
                unsigned int n_samples,
-               unsigned int stripe_start, 
+               unsigned int stripe_start,
                unsigned int stripe_stop,
                bool bypass_tips,
                unsigned int nthreads);

--- a/sucpp/api.hpp
+++ b/sucpp/api.hpp
@@ -12,7 +12,7 @@
 
 #define PARTIAL_MAGIC "SSU-PARTIAL-01"
 
-typedef enum compute_status {okay=0, tree_missing, table_missing, unknown_method, table_and_tree_do_not_overlap} ComputeStatus;
+typedef enum compute_status {okay=0, tree_missing, table_missing, table_empty, unknown_method, table_and_tree_do_not_overlap} ComputeStatus;
 typedef enum io_status {read_okay=0, write_okay, open_error, read_error, magic_incompatible, bad_header, unexpected_end} IOStatus;
 typedef enum merge_status {merge_okay=0, incomplete_stripe_set, sample_id_consistency, square_mismatch, partials_mismatch, stripes_overlap} MergeStatus;
 
@@ -34,6 +34,12 @@ typedef struct mat {
     char** sample_ids;
 } mat_t;
 
+/* a result vector
+ *
+ * n_samples <uint> the number of samples.
+ * values <double*> the score values of length n_samples.
+ * sample_ids <char**> the sample IDs of length n_samples.
+ */
 typedef struct results_vec{
     unsigned int n_samples;
     double* values;
@@ -82,6 +88,7 @@ void destroy_results_vec(r_vec** result);
  * table_missing  : the filename for the table does not exist
  * tree_missing   : the filename for the tree does not exist
  * unknown_method : the requested method is unknown.
+ * table_empty    : the table does not have any entries
  */
 EXTERN ComputeStatus one_off(const char* biom_filename, const char* tree_filename,
                              const char* unifrac_method, bool variance_adjust, double alpha,
@@ -89,7 +96,16 @@ EXTERN ComputeStatus one_off(const char* biom_filename, const char* tree_filenam
 
 
 /* compute Faith PD
- * TODO: DOCUMENT
+ * biom_filename <const char*> the filename to the biom table.
+ * tree_filename <const char*> the filename to the correspodning tree.
+ * result <r_vec**> the resulting vector of computed Faith PD values
+ *
+ * faith_pd_one_off returns the following error codes:
+ *
+ * okay           : no problems encountered
+ * table_missing  : the filename for the table does not exist
+ * tree_missing   : the filename for the tree does not exist
+ * table_empty    : the table does not have any entries
  */
 EXTERN ComputeStatus faith_pd_one_off(const char* biom_filename, const char* tree_filename,
                                       r_vec** result);

--- a/sucpp/api.hpp
+++ b/sucpp/api.hpp
@@ -34,6 +34,12 @@ typedef struct mat {
     char** sample_ids;
 } mat_t;
 
+typedef struct results_vec{
+    unsigned int n_samples;
+    double* values;
+    char** sample_ids;
+} r_vec;
+
 /* a partial result containing stripe data
  *
  * n_samples <uint> the number of samples.
@@ -57,6 +63,7 @@ typedef struct partial_mat {
 
 void destroy_mat(mat_t** result);
 void destroy_partial_mat(partial_mat_t** result);
+void destroy_results_vec(r_vec** result);
 
 /* Compute UniFrac
  *
@@ -79,6 +86,13 @@ void destroy_partial_mat(partial_mat_t** result);
 EXTERN ComputeStatus one_off(const char* biom_filename, const char* tree_filename, 
                              const char* unifrac_method, bool variance_adjust, double alpha,
                              bool bypass_tips, unsigned int threads, mat_t** result);
+
+
+/* compute Faith PD
+ * TODO: DOCUMENT
+ */
+EXTERN ComputeStatus faith_pd_one_off(const char* biom_filename, const char* tree_filename,
+                                      r_vec** result);
 
 /* Write a matrix object
  *

--- a/sucpp/su_R.cpp
+++ b/sucpp/su_R.cpp
@@ -26,4 +26,19 @@ Rcpp::List unifrac(const char* table, const char* tree, int nthreads){
 
 }
 
+// [[Rcpp::export]]
+Rcpp::List faithpd(const char* table, const char tree){
+    r_vec* result = NULL;
+    ComputeStatus status;
+    status = faith_pd_one_off(table, tree, r_vec);
+    vector<double> values;
+    for(int i = 0; i < result->n_samples; i++){
+        values.push_back(result->values[i]);
+    }
+
+    return Rcpp::List::create(Rcpp::Named("n_samples") = result->n_samples,
+                              Rcpp::Named("pd") = values);
+
+}
+
 

--- a/sucpp/test_su.cpp
+++ b/sucpp/test_su.cpp
@@ -883,11 +883,9 @@ void test_make_strides() {
 void test_faith_pd() {
     SUITE_START("test faith PD");
 
-    // std::vector<std::thread> threads(1);
     // Note this tree is binary (opposed to example below)
     su::BPTree tree = su::BPTree("((GG_OTU_1:1,(GG_OTU_2:1,GG_OTU_3:1):1):2,(GG_OTU_5:1,GG_OTU_4:1):1);");
     su::biom table = su::biom("test.biom");
-
 
     // make vector of expectations from faith PD
     double exp[6] = {6., 7., 8., 5., 4., 7.};
@@ -897,23 +895,18 @@ void test_faith_pd() {
 
     su::faith_pd(table, tree, obs);
 
-
     // ASSERT that results = expectation
     for (unsigned int i = 0; i < 6; i++){
         ASSERT(fabs(exp[i]-obs[i]) < 0.000001)
     }
-
     SUITE_END();
-
 }
 
 void test_faith_pd_shear(){
     SUITE_START("test faith PD extra OTUs in tree");
 
-    // std::vector<std::thread> threads(1);
     su::BPTree tree = su::BPTree("((GG_OTU_1:1,(GG_OTU_2:1,GG_OTU_3:1,GG_OTU_ex:9):1):2,(GG_OTU_5:1,GG_OTU_4:1,GG_OTU_ex2:12):1);");
     su::biom table = su::biom("test.biom");
-
 
     // make vector of expectations from faith PD
     double exp[6] = {6., 7., 8., 5., 4., 7.};
@@ -926,14 +919,11 @@ void test_faith_pd_shear(){
     su::BPTree tree_sheared = tree.shear(to_keep).collapse();
     su::faith_pd(table, tree_sheared, obs);
 
-
     // ASSERT that results = expectation
     for (unsigned int i = 0; i < 6; i++){
         ASSERT(fabs(exp[i]-obs[i]) < 0.000001)
     }
-
     SUITE_END();
-
 }
 
 void test_unweighted_unifrac() {

--- a/sucpp/test_su.cpp
+++ b/sucpp/test_su.cpp
@@ -880,6 +880,33 @@ void test_make_strides() {
     }
 }
 
+void test_faith_pd() {
+    SUITE_START("test faith PD");
+
+    // std::vector<std::thread> threads(1);
+    // Note this tree is binary (opposed to example below)
+    su::BPTree tree = su::BPTree("((GG_OTU_1:1,(GG_OTU_2:1,GG_OTU_3:1):1):2,(GG_OTU_5:1,GG_OTU_4:1):1);");
+    su::biom table = su::biom("test.biom");
+
+
+    // make vector of expectations from faith PD
+    double exp[6] = {6., 7., 8., 5., 4., 7.};
+
+    // run faith PD to get obs
+    double obs[6]; // = {0, 0, 0, 0, 0, 0};
+
+    su::faith_pd(table, tree, obs);
+
+
+    // ASSERT that results = expectation
+    for (unsigned int i = 0; i < 6; i++){
+        ASSERT(fabs(exp[i]-obs[i]) < 0.000001)
+    }
+
+    SUITE_END();
+
+}
+
 void test_unweighted_unifrac() {
     SUITE_START("test unweighted unifrac");
     double **obs;
@@ -1241,6 +1268,8 @@ int main(int argc, char** argv) {
     test_unifrac_sample_counts();
     test_set_tasks();
     test_test_table_ids_are_subset_of_tree();
+
+    test_faith_pd();
 
     printf("\n");
     printf(" %i / %i suites failed\n", suites_failed, suites_run);

--- a/sucpp/test_su.cpp
+++ b/sucpp/test_su.cpp
@@ -8,7 +8,7 @@
 #include <string.h>
 
 /*
- * test harness adapted from 
+ * test harness adapted from
  * https://github.com/noporpoise/BitArray/blob/master/dev/bit_array_test.c
  */
 const char *suite_name;
@@ -259,10 +259,10 @@ void test_bptree_constructor_single_descendent() {
     SUITE_START("bptree constructor single descendent");
 
     su::BPTree tree = su::BPTree("(((a)b)c,((d)e)f,g)r;");
-    
+
     unsigned int exp_nparens = 16;
 
-    bool structure_arr[] = {1, 1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 0, 0, 1, 0, 0}; 
+    bool structure_arr[] = {1, 1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 0, 0, 1, 0, 0};
     std::vector<bool> exp_structure = _bool_array_to_vector(structure_arr, exp_nparens);
 
     double length_arr[] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
@@ -275,14 +275,14 @@ void test_bptree_constructor_single_descendent() {
     ASSERT(tree.get_structure() == exp_structure);
     ASSERT(vec_almost_equal(tree.lengths, exp_lengths));
     ASSERT(tree.names == exp_names);
-    
+
     SUITE_END();
 }
 
 void test_bptree_constructor_complex() {
     SUITE_START("bp tree constructor complex");
     su::BPTree tree = su::BPTree("(((a:1,b:2.5)c:6,d:8,(e),(f,g,(h:1,i:2)j:1)k:1.2)l,m:2)r;");
-    
+
     unsigned int exp_nparens = 30;
 
     bool structure_arr[] = {1, 1, 1, 1, 0, 1, 0, 0, 1, 0, 1, 1, 0, 0, 1, 1, 0, 1, 0, 1, 1, 0, 1, 0, 0, 0, 0, 1, 0, 0};
@@ -304,7 +304,7 @@ void test_bptree_constructor_complex() {
 void test_bptree_constructor_semicolon() {
     SUITE_START("bp tree constructor semicolon");
     su::BPTree tree = su::BPTree("((a,(b,c):5)'d','e; foo':10,((f))g)r;");
-    
+
     unsigned int exp_nparens = 20;
 
     bool structure_arr[] = {1, 1, 1, 0, 1, 1, 0, 1, 0, 0, 0, 1, 0, 1, 1, 1, 0, 0, 0, 0};
@@ -360,7 +360,7 @@ void test_bptree_constructor_quoted_comma() {
     su::BPTree tree = su::BPTree("((3,'foo,bar')x,c)r;");
     std::vector<std::string> exp_names = {"r", "x", "3", "", "foo,bar", "", "", "c", "", ""};
     ASSERT(exp_names.size() == tree.names.size());
-    
+
     for(unsigned int i = 0; i < tree.names.size(); i++) {
         ASSERT(exp_names[i] == tree.names[i]);
     }
@@ -372,7 +372,7 @@ void test_bptree_constructor_quoted_parens() {
     su::BPTree tree = su::BPTree("((3,'foo(b)ar')x,c)r;");
     std::vector<std::string> exp_names = {"r", "x", "3", "", "foo(b)ar", "", "", "c", "", ""};
     ASSERT(exp_names.size() == tree.names.size());
-    
+
     for(unsigned int i = 0; i < tree.names.size(); i++) {
         ASSERT(exp_names[i] == tree.names[i]);
     }
@@ -380,56 +380,56 @@ void test_bptree_constructor_quoted_parens() {
 }
 void test_bptree_postorder() {
     SUITE_START("postorderselect");
-    
+
     // fig1 from https://www.dcc.uchile.cl/~gnavarro/ps/tcs16.2.pdf
     su::BPTree tree = su::BPTree("((3,4,(6)5)2,7,((10,100)9)8)1;");
     uint32_t exp[] = {2, 4, 7, 6, 1, 11, 15, 17, 14, 13, 0};
     uint32_t obs[tree.nparens / 2];
-    
+
     for(int i = 0; i < (tree.nparens / 2); i++)
         obs[i] = tree.postorderselect(i);
 
     std::vector<uint32_t> exp_v = _uint32_array_to_vector(exp, tree.nparens / 2);
     std::vector<uint32_t> obs_v = _uint32_array_to_vector(obs, tree.nparens / 2);
-    
+
     ASSERT(obs_v == exp_v);
     SUITE_END();
 }
 
 void test_bptree_preorder() {
     SUITE_START("preorderselect");
-    
+
     // fig1 from https://www.dcc.uchile.cl/~gnavarro/ps/tcs16.2.pdf
     su::BPTree tree = su::BPTree("((3,4,(6)5)2,7,((10,100)9)8)1;");
     uint32_t exp[] = {0, 1, 2, 4, 6, 7, 11, 13, 14, 15, 17};
     uint32_t obs[tree.nparens / 2];
-    
+
     for(int i = 0; i < (tree.nparens / 2); i++)
         obs[i] = tree.preorderselect(i);
 
     std::vector<uint32_t> exp_v = _uint32_array_to_vector(exp, tree.nparens / 2);
     std::vector<uint32_t> obs_v = _uint32_array_to_vector(obs, tree.nparens / 2);
-    
+
     ASSERT(obs_v == exp_v);
     SUITE_END();
 }
 
 void test_bptree_parent() {
     SUITE_START("parent");
-    
+
     // fig1 from https://www.dcc.uchile.cl/~gnavarro/ps/tcs16.2.pdf
     su::BPTree tree = su::BPTree("((3,4,(6)5)2,7,((10,100)9)8)1;");
     uint32_t exp[] = {0, 1, 1, 1, 1, 1, 6, 6, 1, 0, 0, 0, 0, 13, 14, 14, 14, 14, 13, 0};
-    
+
     // all the -2 and +1 garbage is to avoid testing the root.
     uint32_t obs[tree.nparens - 2];
-    
+
     for(int i = 0; i < (tree.nparens) - 2; i++)
         obs[i] = tree.parent(i+1);
 
     std::vector<uint32_t> exp_v = _uint32_array_to_vector(exp, tree.nparens - 2);
     std::vector<uint32_t> obs_v = _uint32_array_to_vector(obs, tree.nparens - 2);
-   
+
     ASSERT(obs_v == exp_v);
     SUITE_END();
 }
@@ -443,16 +443,16 @@ void test_biom_constructor() {
 
     std::string sids[] = {"Sample1", "Sample2", "Sample3", "Sample4", "Sample5", "Sample6"};
     std::vector<std::string> exp_sids = _string_array_to_vector(sids, exp_n_samples);
-    
+
     std::string oids[] = {"GG_OTU_1", "GG_OTU_2","GG_OTU_3", "GG_OTU_4", "GG_OTU_5"};
     std::vector<std::string> exp_oids = _string_array_to_vector(oids, exp_n_obs);
 
     uint32_t s_indptr[] = {0, 2, 5, 9, 11, 12, 15};
     std::vector<uint32_t> exp_s_indptr = _uint32_array_to_vector(s_indptr, exp_n_samples + 1);
-    
+
     uint32_t o_indptr[] = {0, 1, 6, 9, 13, 15};
     std::vector<uint32_t> exp_o_indptr = _uint32_array_to_vector(o_indptr, exp_n_obs + 1);
-  
+
     uint32_t exp_nnz = 15;
 
     ASSERT(table.n_samples == exp_n_samples);
@@ -480,7 +480,7 @@ void test_biom_get_obs_data() {
     std::vector<double> exp3_vec = _double_array_to_vector(exp3, 6);
     double exp4[] = {0.0, 1.0, 1.0, 0.0, 0.0, 0.0};
     std::vector<double> exp4_vec = _double_array_to_vector(exp4, 6);
-    
+
     double *out = (double*)malloc(sizeof(double) * 6);
     std::vector<double> obs_vec;
 
@@ -544,7 +544,7 @@ void test_bptree_rightsibling() {
 
     uint32_t exp[] = {0, 11, 4, 6, 0, 0, 13, 0, 0, 17, 0};
     std::vector<bool> structure = tree.get_structure();
-    
+
     uint32_t exp_pos = 0;
     for(int i = 0; i < tree.nparens; i++) {
         if(structure[i])
@@ -571,10 +571,10 @@ void test_propstack_push_and_pop() {
     double *vec2_obs;
     double *vec3_obs;
 
-    ps.push(1); 
-    ps.push(2); 
+    ps.push(1);
+    ps.push(2);
     ps.push(3);
-    
+
     vec3_obs = ps.pop(4);
     vec2_obs = ps.pop(5);
     vec1_obs = ps.pop(6);
@@ -592,7 +592,7 @@ void test_propstack_get() {
     double *vec1 = ps.pop(1);
     double *vec2 = ps.pop(2);
     double *vec3 = ps.pop(3);
-    
+
     double *vec1_obs = ps.get(1);
     double *vec2_obs = ps.get(2);
     double *vec3_obs = ps.get(3);
@@ -610,8 +610,8 @@ void test_unifrac_set_proportions() {
     su::BPTree tree = su::BPTree("(GG_OTU_1,(GG_OTU_2,GG_OTU_3),(GG_OTU_5,GG_OTU_4));");
     su::biom table = su::biom("test.biom");
     su::PropStack ps = su::PropStack(table.n_samples);
-   
-    double sample_counts[] = {7, 3, 4, 6, 3, 4}; 
+
+    double sample_counts[] = {7, 3, 4, 6, 3, 4};
     double *obs = ps.pop(4); // GG_OTU_2
     double exp4[] = {0.714285714286, 0.333333333333, 0.0, 0.333333333333, 1.0, 0.25};
     set_proportions(obs, tree, 4, table, ps);
@@ -627,7 +627,7 @@ void test_unifrac_set_proportions() {
     obs = ps.pop(3); // node containing GG_OTU_2 and GG_OTU_3
     double exp3[] = {0.71428571, 0.33333333, 0.25, 1.0, 1.0, 0.75};
     set_proportions(obs, tree, 3, table, ps);
-    for(unsigned int i = 0; i < table.n_samples; i++) 
+    for(unsigned int i = 0; i < table.n_samples; i++)
         ASSERT(fabs(obs[i] - exp3[i]) < 0.000001);
     SUITE_END();
 }
@@ -669,7 +669,7 @@ void test_unifrac_stripes_to_condensed_form_even() {
     // {x, x, 0, 9, 10, 11},
     // {x, x, x, 0, 12, 13},
     // {x, x, x, x, 0, 14},
-    // {x, x, x, x, x, 0} 
+    // {x, x, x, x, x, 0}
     stripes.push_back(s1);
     stripes.push_back(s2);
     stripes.push_back(s3);
@@ -690,7 +690,7 @@ void test_unifrac_stripes_to_condensed_form_odd() {
     double s1[] = {1, 2, 3, 4, 5, 6, 0};
     double s2[] = {12, 11, 10, 9, 8, 7, 1};
     double s3[] = {13, 14, 15, 16, 17, 18, 2};
-                         
+
     // {0, 1, 12, 13, 17,  7,  0},
     // {x, 0,  2, 11, 14, 18,  1},
     // {x, x,  0,  3, 10, 15,  2},
@@ -701,7 +701,7 @@ void test_unifrac_stripes_to_condensed_form_odd() {
     stripes.push_back(s1);
     stripes.push_back(s2);
     stripes.push_back(s3);
-    
+
     double exp[21] = {1, 12, 13, 17, 7, 0, 2, 11, 14, 18, 1, 3, 10, 15, 2, 4, 9, 16, 5, 8, 6};
     double *obs = (double*)malloc(sizeof(double) * 21);
     su::stripes_to_condensed_form(stripes, 7, obs, 0, 3);
@@ -714,11 +714,11 @@ void test_unifrac_stripes_to_condensed_form_odd() {
 
 void test_unnormalized_weighted_unifrac() {
     SUITE_START("test unnormalized weighted unifrac");
-    
+
     std::vector<std::thread> threads(1);
     su::BPTree tree = su::BPTree("(GG_OTU_1:1,(GG_OTU_2:1,GG_OTU_3:1):1,(GG_OTU_5:1,GG_OTU_4:1):1);");
     su::biom table = su::biom("test.biom");
-    
+
     std::vector<double*> exp;
     double stride1[] = {1.52380952, 1.25, 2.75, 1.33333333, 2., 1.07142857};
     double stride2[] = {2.17857143, 2.66666667, 3.25, 1.0, 1.14285714, 1.83333333};
@@ -728,9 +728,9 @@ void test_unnormalized_weighted_unifrac() {
     exp.push_back(stride3);
     std::vector<double*> strides = su::make_strides(6);
     std::vector<double*> strides_total = su::make_strides(6);
-    
+
     su::task_parameters task_p;
-    task_p.start = 0; task_p.stop = 3; task_p.tid = 0; task_p.n_samples = 6; 
+    task_p.start = 0; task_p.stop = 3; task_p.tid = 0; task_p.n_samples = 6;
 
     su::unifrac(table, tree, su::weighted_unnormalized, strides, strides_total, &task_p);
     for(unsigned int i = 0; i < 3; i++) {
@@ -744,11 +744,11 @@ void test_unnormalized_weighted_unifrac() {
 
 void test_generalized_unifrac() {
     SUITE_START("test generalized unifrac");
-    
+
     std::vector<std::thread> threads(1);
     su::BPTree tree = su::BPTree("(GG_OTU_1:1,(GG_OTU_2:1,GG_OTU_3:1):1,(GG_OTU_5:1,GG_OTU_4:1):1);");
     su::biom table = su::biom("test.biom");
-    
+
     // weighted normalized unifrac as computed above
     std::vector<double*> w_exp;
     double w_stride1[] = {0.38095238, 0.33333333, 0.73333333, 0.33333333, 0.5, 0.26785714};
@@ -760,10 +760,10 @@ void test_generalized_unifrac() {
     std::vector<double*> w_strides = su::make_strides(6);
     std::vector<double*> w_strides_total = su::make_strides(6);
     su::task_parameters w_task_p;
-    w_task_p.start = 0; w_task_p.stop = 3; w_task_p.tid = 0; w_task_p.n_samples = 6; 
+    w_task_p.start = 0; w_task_p.stop = 3; w_task_p.tid = 0; w_task_p.n_samples = 6;
     w_task_p.g_unifrac_alpha = 1.0;
     su::unifrac(table, tree, su::generalized, w_strides, w_strides_total, &w_task_p);
-    
+
     // as computed by GUniFrac v1.0
     //          Sample1   Sample2   Sample3   Sample4   Sample5   Sample6
     //Sample1 0.0000000 0.4408392 0.6886965 0.7060606 0.5833333 0.3278410
@@ -782,7 +782,7 @@ void test_generalized_unifrac() {
     std::vector<double*> d0_strides = su::make_strides(6);
     std::vector<double*> d0_strides_total = su::make_strides(6);
     su::task_parameters d0_task_p;
-    d0_task_p.start = 0; d0_task_p.stop = 3; d0_task_p.tid = 0; d0_task_p.n_samples = 6; 
+    d0_task_p.start = 0; d0_task_p.stop = 3; d0_task_p.tid = 0; d0_task_p.n_samples = 6;
     d0_task_p.g_unifrac_alpha = 0.0;
     su::unifrac(table, tree, su::generalized, d0_strides, d0_strides_total, &d0_task_p);
 
@@ -804,10 +804,10 @@ void test_generalized_unifrac() {
     std::vector<double*> d05_strides = su::make_strides(6);
     std::vector<double*> d05_strides_total = su::make_strides(6);
     su::task_parameters d05_task_p;
-    d05_task_p.start = 0; d05_task_p.stop = 3; d05_task_p.tid = 0; d05_task_p.n_samples = 6; 
+    d05_task_p.start = 0; d05_task_p.stop = 3; d05_task_p.tid = 0; d05_task_p.n_samples = 6;
     d05_task_p.g_unifrac_alpha = 0.5;
     su::unifrac(table, tree, su::generalized, d05_strides, d05_strides_total, &d05_task_p);
-    
+
     for(unsigned int i = 0; i < 3; i++) {
         for(unsigned int j = 0; j < 6; j++) {
             ASSERT(fabs(w_strides[i][j] - w_exp[i][j]) < 0.000001);
@@ -823,11 +823,11 @@ void test_generalized_unifrac() {
 
 void test_vaw_unifrac_weighted_normalized() {
     SUITE_START("test vaw weighted normalized unifrac");
-    
+
     std::vector<std::thread> threads(1);
     su::BPTree tree = su::BPTree("(GG_OTU_1:1,(GG_OTU_2:1,GG_OTU_3:1):1,(GG_OTU_5:1,GG_OTU_4:1):1);");
     su::biom table = su::biom("test.biom");
-    
+
     // as computed by GUniFrac, the original implementation of VAW-UniFrac
     // could not be found.
     //          Sample1   Sample2   Sample3   Sample4   Sample5   Sample6
@@ -838,7 +838,7 @@ void test_vaw_unifrac_weighted_normalized() {
     //Sample5 0.2857143 0.6807616 0.8812897 0.6666667 0.0000000 0.4735991
     //Sample6 0.2766318 0.4735781 0.5047114 0.2709298 0.4735991 0.0000000
     // weighted normalized unifrac as computed above
-    
+
     std::vector<double*> w_exp;
     double w_stride1[] = {0.4086040, 0.3798594, 0.7713254, 0.6666667, 0.4735991, 0.2766318};
     double w_stride2[] = {0.6240185, 0.6884992, 0.8812897, 0.2709298, 0.2857143, 0.4735781};
@@ -849,10 +849,10 @@ void test_vaw_unifrac_weighted_normalized() {
     std::vector<double*> w_strides = su::make_strides(6);
     std::vector<double*> w_strides_total = su::make_strides(6);
     su::task_parameters w_task_p;
-    w_task_p.start = 0; w_task_p.stop = 3; w_task_p.tid = 0; w_task_p.n_samples = 6; 
+    w_task_p.start = 0; w_task_p.stop = 3; w_task_p.tid = 0; w_task_p.n_samples = 6;
     w_task_p.g_unifrac_alpha = 1.0;
     su::unifrac_vaw(table, tree, su::weighted_normalized, w_strides, w_strides_total, &w_task_p);
-    
+
     for(unsigned int i = 0; i < 3; i++) {
         for(unsigned int j = 0; j < 6; j++) {
             ASSERT(fabs(w_strides[i][j] - w_exp[i][j]) < 0.000001);
@@ -893,9 +893,38 @@ void test_faith_pd() {
     double exp[6] = {6., 7., 8., 5., 4., 7.};
 
     // run faith PD to get obs
-    double obs[6]; // = {0, 0, 0, 0, 0, 0};
+    double obs[6] = {0, 0, 0, 0, 0, 0};
 
     su::faith_pd(table, tree, obs);
+
+
+    // ASSERT that results = expectation
+    for (unsigned int i = 0; i < 6; i++){
+        ASSERT(fabs(exp[i]-obs[i]) < 0.000001)
+    }
+
+    SUITE_END();
+
+}
+
+void test_faith_pd_shear(){
+    SUITE_START("test faith PD extra OTUs in tree");
+
+    // std::vector<std::thread> threads(1);
+    su::BPTree tree = su::BPTree("((GG_OTU_1:1,(GG_OTU_2:1,GG_OTU_3:1,GG_OTU_ex:9):1):2,(GG_OTU_5:1,GG_OTU_4:1,GG_OTU_ex2:12):1);");
+    su::biom table = su::biom("test.biom");
+
+
+    // make vector of expectations from faith PD
+    double exp[6] = {6., 7., 8., 5., 4., 7.};
+
+    // run faith PD to get obs
+    double obs[6] = {0, 0, 0, 0, 0, 0};
+
+    std::unordered_set<std::string> to_keep(table.obs_ids.begin(),           \
+                                            table.obs_ids.end());            \
+    su::BPTree tree_sheared = tree.shear(to_keep).collapse();
+    su::faith_pd(table, tree_sheared, obs);
 
 
     // ASSERT that results = expectation
@@ -913,7 +942,7 @@ void test_unweighted_unifrac() {
     std::vector<std::thread> threads(1);
     su::BPTree tree = su::BPTree("(GG_OTU_1:1,(GG_OTU_2:1,GG_OTU_3:1):1,(GG_OTU_5:1,GG_OTU_4:1):1);");
     su::biom table = su::biom("test.biom");
-   
+
     std::vector<double*> exp;
     double stride1[] = {0.2, 0.42857143, 0.71428571, 0.33333333, 0.6, 0.2};
     double stride2[] = {0.57142857, 0.66666667, 0.85714286, 0.4, 0.5, 0.33333333};
@@ -925,10 +954,10 @@ void test_unweighted_unifrac() {
     std::vector<double*> strides_total = su::make_strides(6);
 
     su::task_parameters task_p;
-    task_p.start = 0; task_p.stop = 3; task_p.tid = 0; task_p.n_samples = 6; 
+    task_p.start = 0; task_p.stop = 3; task_p.tid = 0; task_p.n_samples = 6;
 
     su::unifrac(table, tree, su::unweighted, strides, strides_total, &task_p);
- 
+
     for(unsigned int i = 0; i < 3; i++) {
         for(unsigned int j = 0; j < 6; j++) {
             ASSERT(fabs(strides[i][j] - exp[i][j]) < 0.000001);
@@ -944,7 +973,7 @@ void test_unweighted_unifrac_fast() {
     std::vector<std::thread> threads(1);
     su::BPTree tree = su::BPTree("(GG_OTU_1:1,(GG_OTU_2:1,GG_OTU_3:1):1,(GG_OTU_5:1,GG_OTU_4:1):1);");
     su::biom table = su::biom("test.biom");
-   
+
     std::vector<double*> exp;
     double stride1[] = {0., 0., 0.5, 0., 0.5, 0.};
     double stride2[] = {0., 0.5, 0.5, 0.5, 0.5, 0.};
@@ -956,10 +985,10 @@ void test_unweighted_unifrac_fast() {
     std::vector<double*> strides_total = su::make_strides(6);
 
     su::task_parameters task_p;
-    task_p.start = 0; task_p.stop = 3; task_p.tid = 0; task_p.n_samples = 6; task_p.bypass_tips = true; 
+    task_p.start = 0; task_p.stop = 3; task_p.tid = 0; task_p.n_samples = 6; task_p.bypass_tips = true;
 
     su::unifrac(table, tree, su::unweighted, strides, strides_total, &task_p);
- 
+
     for(unsigned int i = 0; i < 3; i++) {
         for(unsigned int j = 0; j < 6; j++) {
             ASSERT(fabs(strides[i][j] - exp[i][j]) < 0.000001);
@@ -975,7 +1004,7 @@ void test_normalized_weighted_unifrac() {
     std::vector<std::thread> threads(1);
     su::BPTree tree = su::BPTree("(GG_OTU_1:1,(GG_OTU_2:1,GG_OTU_3:1):1,(GG_OTU_5:1,GG_OTU_4:1):1);");
     su::biom table = su::biom("test.biom");
-    
+
     std::vector<double*> exp;
     double stride1[] = {0.38095238, 0.33333333, 0.73333333, 0.33333333, 0.5, 0.26785714};
     double stride2[] = {0.58095238, 0.66666667, 0.86666667, 0.25, 0.28571429, 0.45833333};
@@ -985,9 +1014,9 @@ void test_normalized_weighted_unifrac() {
     exp.push_back(stride3);
     std::vector<double*> strides = su::make_strides(6);
     std::vector<double*> strides_total = su::make_strides(6);
-   
+
     su::task_parameters task_p;
-    task_p.start = 0; task_p.stop = 3; task_p.tid = 0; task_p.n_samples = 6; 
+    task_p.start = 0; task_p.stop = 3; task_p.tid = 0; task_p.n_samples = 6;
 
     su::unifrac(table, tree, su::weighted_normalized, strides, strides_total, &task_p);
     for(unsigned int i = 0; i < 3; i++) {
@@ -1002,14 +1031,14 @@ void test_normalized_weighted_unifrac() {
 void test_bptree_shear_simple() {
     SUITE_START("test bptree shear simple");
     su::BPTree tree = su::BPTree("((3:2,4:3,(6:5)5:4)2:1,7:6,((10:9,11:10)9:8)8:7)r");
- 
+
     // simple
-    std::unordered_set<std::string> to_keep = {"4", "6", "7", "10", "11"};    
-    
+    std::unordered_set<std::string> to_keep = {"4", "6", "7", "10", "11"};
+
     uint32_t exp_nparens = 20;
-    std::vector<bool> exp_structure = {true, true, true, false, true, true, false, false, false, true, 
+    std::vector<bool> exp_structure = {true, true, true, false, true, true, false, false, false, true,
                                        false, true, true, true, false, true, false, false, false, false};
-    std::vector<std::string> exp_names = {"r", "2", "4", "", "5", "6", "", "", "", "7", "", "8", "9", "10", "", 
+    std::vector<std::string> exp_names = {"r", "2", "4", "", "5", "6", "", "", "", "7", "", "8", "9", "10", "",
                                           "11", "", "", "", ""};
     std::vector<double> exp_lengths = {0, 1, 3, 0, 4, 5, 0, 0, 0, 6, 0, 7, 8, 9, 0, 10, 0, 0, 0, 0};
 
@@ -1024,10 +1053,10 @@ void test_bptree_shear_simple() {
 void test_bptree_shear_deep() {
     SUITE_START("test bptree shear deep");
     su::BPTree tree = su::BPTree("((3:2,4:3,(6:5)5:4)2:1,7:6,((10:9,11:10)9:8)8:7)r");
- 
+
     // deep
-    std::unordered_set<std::string> to_keep = {"10", "11"};    
-    
+    std::unordered_set<std::string> to_keep = {"10", "11"};
+
     uint32_t exp_nparens = 10;
     std::vector<bool> exp_structure = {true, true, true, true, false, true, false, false, false, false};
     std::vector<std::string> exp_names = {"r", "8", "9", "10", "", "11", "", "", "", ""};
@@ -1049,7 +1078,7 @@ void test_test_table_ids_are_subset_of_tree() {
     std::string expected = "GG_OTU_1";
     std::string observed = su::test_table_ids_are_subset_of_tree(table, tree);
     ASSERT(observed == expected);
-   
+
     su::BPTree tree2 = su::BPTree("(GG_OTU_1,GG_OTU_5,GG_OTU_6,GG_OTU_2,GG_OTU_3,GG_OTU_4);");
     su::biom table2 = su::biom("test.biom");
     expected = "";
@@ -1062,19 +1091,19 @@ void test_test_table_ids_are_subset_of_tree() {
 void test_bptree_get_tip_names() {
     SUITE_START("test bptree get_tip_names");
     su::BPTree tree = su::BPTree("((a:2,b:3,(c:5)d:4)e:1,f:6,((g:9,h:10)i:8)j:7)r");
-    
+
     std::unordered_set<std::string> expected = {"a", "b", "c", "f", "g", "h"};
     std::unordered_set<std::string> observed = tree.get_tip_names();
     ASSERT(observed == expected);
     SUITE_END();
-}    
+}
 
 void test_bptree_collapse_simple() {
     SUITE_START("test bptree collapse simple");
     su::BPTree tree = su::BPTree("((3:2,4:3,(6:5)5:4)2:1,7:6,((10:9,11:10)9:8)8:7)r");
-    
+
     uint32_t exp_nparens = 18;
-    std::vector<bool> exp_structure = {true, true, true, false, true, false, true, false, false, 
+    std::vector<bool> exp_structure = {true, true, true, false, true, false, true, false, false,
                                        true, false, true, true, false, true, false, false, false};
     std::vector<std::string> exp_names = {"r", "2", "3", "", "4", "", "6", "", "", "7", "", "9", "10", "", "11", "", "", ""};
     std::vector<double> exp_lengths = {0, 1, 2, 0, 3, 0, 9, 0, 0, 6, 0, 15, 9, 0, 10, 0, 0, 0};
@@ -1142,7 +1171,7 @@ void test_set_tasks() {
     exp2[1].start = 50;
     exp2[1].stop = 100;
     exp2[1].tid = 1;
-    
+
     set_tasks(obs2, 1.0, 100, 0, 100, false, 2);
     for(unsigned int i=0; i < 2; i++) {
         ASSERT(obs2[i].g_unifrac_alpha == exp2[i].g_unifrac_alpha);
@@ -1151,7 +1180,7 @@ void test_set_tasks() {
         ASSERT(obs2[i].stop == exp2[i].stop);
         ASSERT(obs2[i].tid == exp2[i].tid);
     }
-    
+
     std::vector<su::task_parameters> obs3(3);
     std::vector<su::task_parameters> exp3(3);
 
@@ -1170,7 +1199,7 @@ void test_set_tasks() {
     exp3[2].start = 75;
     exp3[2].stop = 100;
     exp3[2].tid = 2;
-    
+
     set_tasks(obs3, 1.0, 100, 25, 100, false, 3);
     for(unsigned int i=0; i < 3; i++) {
         ASSERT(obs3[i].g_unifrac_alpha == exp3[i].g_unifrac_alpha);
@@ -1179,7 +1208,7 @@ void test_set_tasks() {
         ASSERT(obs3[i].stop == exp3[i].stop);
         ASSERT(obs3[i].tid == exp3[i].tid);
     }
-    
+
     std::vector<su::task_parameters> obs4(3);
     std::vector<su::task_parameters> exp4(3);
 
@@ -1198,7 +1227,7 @@ void test_set_tasks() {
     exp4[2].start = 76;
     exp4[2].stop = 100;
     exp4[2].tid = 2;
-    
+
     set_tasks(obs4, 1.0, 100, 26, 100, false, 3);
     for(unsigned int i=0; i < 3; i++) {
         ASSERT(obs4[i].g_unifrac_alpha == exp4[i].g_unifrac_alpha);
@@ -1207,7 +1236,7 @@ void test_set_tasks() {
         ASSERT(obs4[i].stop == exp4[i].stop);
         ASSERT(obs4[i].tid == exp4[i].tid);
     }
-    
+
     // set_tasks boundary bug
     std::vector<su::task_parameters> obs16(16);
     std::vector<su::task_parameters> exp16(16);
@@ -1270,13 +1299,14 @@ int main(int argc, char** argv) {
     test_test_table_ids_are_subset_of_tree();
 
     test_faith_pd();
+    test_faith_pd_shear();
 
     printf("\n");
     printf(" %i / %i suites failed\n", suites_failed, suites_run);
     printf(" %i / %i suites empty\n", suites_empty, suites_run);
     printf(" %i / %i tests failed\n", tests_failed, tests_run);
-  
+
     printf("\n THE END.\n");
-    
+
     return tests_failed ? EXIT_FAILURE : EXIT_SUCCESS;
 }

--- a/sucpp/unifrac.cpp
+++ b/sucpp/unifrac.cpp
@@ -244,9 +244,13 @@ void initialize_stripes(std::vector<double*> &dm_stripes,
     }
 }
 
+// Computes Faith's PD for the samples in  `table` over the phylogenetic
+// tree given by `tree`.
 void su::faith_pd(biom &table,
                   BPTree &tree,
                   double* result) {
+
+    // Assure that tree does not contain ids that are not in table
 
     PropStack propstack(table.n_samples);
 
@@ -262,11 +266,12 @@ void su::faith_pd(biom &table,
 
         // get node proportions
         node_proportions = propstack.pop(node);
+
         set_proportions(node_proportions, tree, node, table, propstack);
 
-        // TODO: make kernel for calculating faith
+        // TODO: make kernel for calculating faith <- probably faster if not
         for (unsigned int sample = 0; sample < table.n_samples; sample++){
-           // calculate contribution of node to score
+            // calculate contribution of node to score
             result[sample] += (node_proportions[sample] > 0) * length;
         }
     }

--- a/sucpp/unifrac.cpp
+++ b/sucpp/unifrac.cpp
@@ -254,13 +254,6 @@ void su::faith_pd(biom &table,
     double *node_proportions;
     double length;
 
-    std::cout << "Before iterations\n";
-    //for (unsigned int sample = 0; sample < table.n_samples; sample++){
-    //    // result[sample] += (node_proportions[sample] > 0) * length
-    //    //result[sample] = 0;
-    //    std::cout << sample << ": " << result[sample] << "\n";
-    //}
-
     // for node in postorderselect
     for(unsigned int k = 0; k < (tree.nparens / 2) - 1; k++) {
         node = tree.postorderselect(k);
@@ -272,28 +265,11 @@ void su::faith_pd(biom &table,
         set_proportions(node_proportions, tree, node, table, propstack);
 
         // TODO: make kernel for calculating faith
-        // allocate score
-        // for sample in node_proportions:
-        //std::cout << "iteration: " << k << "\n";
         for (unsigned int sample = 0; sample < table.n_samples; sample++){
-            // result[sample] += (node_proportions[sample] > 0) * length
+           // calculate contribution of node to score
             result[sample] += (node_proportions[sample] > 0) * length;
-            //std::cout << sample << ": " << result[sample] << "\n";
         }
     }
-       // calculate contribution of node to score
-            // I(count > 0) * branch length
-
-       // set node_scores to contribution + sum(children_scores)
-
-    // return total_score (in result)
-
-    // this is just to see if I set up the test correctly
-    // double obs[6] = {6, 7, 8, 5, 4, 7};
-
-    // for(unsigned int i = 0; i < 6; i++){
-    //     *(result + i) = *(obs + i);
-    // }
 }
 
 

--- a/sucpp/unifrac.cpp
+++ b/sucpp/unifrac.cpp
@@ -246,12 +246,10 @@ void initialize_stripes(std::vector<double*> &dm_stripes,
 
 // Computes Faith's PD for the samples in  `table` over the phylogenetic
 // tree given by `tree`.
+// Assure that tree does not contain ids that are not in table
 void su::faith_pd(biom &table,
                   BPTree &tree,
                   double* result) {
-
-    // Assure that tree does not contain ids that are not in table
-
     PropStack propstack(table.n_samples);
 
     uint32_t node;
@@ -264,19 +262,16 @@ void su::faith_pd(biom &table,
         // get branch length
         length = tree.lengths[node];
 
-        // get node proportions
+        // get node proportions and set intermediate scores
         node_proportions = propstack.pop(node);
-
         set_proportions(node_proportions, tree, node, table, propstack);
 
-        // TODO: make kernel for calculating faith <- probably faster if not
         for (unsigned int sample = 0; sample < table.n_samples; sample++){
             // calculate contribution of node to score
             result[sample] += (node_proportions[sample] > 0) * length;
         }
     }
 }
-
 
 void su::unifrac(biom &table,
                  BPTree &tree,

--- a/sucpp/unifrac.cpp
+++ b/sucpp/unifrac.cpp
@@ -244,6 +244,49 @@ void initialize_stripes(std::vector<double*> &dm_stripes,
     }
 }
 
+void su::faith_pd(biom &table,
+                  BPTree &tree,
+                  double* result) {
+
+    PropStack propstack(table.n_samples);
+
+    uint32_t node;
+    double *node_proportions;
+    double length;
+
+    // for node in postorderselect
+    for(unsigned int k = 0; k < (tree.nparens / 2) - 1; k++) {
+        node = tree.postorderselect(k);
+        // get branch length
+        length = tree.lengths[node];
+
+        // get node proportions
+        node_proportions = propstack.pop(node);
+        set_proportions(node_proportions, tree, node, table, propstack);
+
+        // TODO: make kernel for calculating faith
+        // allocate score
+        // for sample in node_proportions:
+        for (unsigned int sample = 0; sample < table.n_samples; sample++){
+            // result[sample] += (node_proportions[sample] > 0) * length
+            result[sample] += (node_proportions[sample] > 0) * length;
+        }
+    }
+       // calculate contribution of node to score
+            // I(count > 0) * branch length
+
+       // set node_scores to contribution + sum(children_scores)
+
+    // return total_score (in result)
+
+    // this is just to see if I set up the test correctly
+    // double obs[6] = {6, 7, 8, 5, 4, 7};
+
+    // for(unsigned int i = 0; i < 6; i++){
+    //     *(result + i) = *(obs + i);
+    // }
+}
+
 
 void su::unifrac(biom &table,
                  BPTree &tree, 

--- a/sucpp/unifrac.cpp
+++ b/sucpp/unifrac.cpp
@@ -45,7 +45,7 @@ void sig_handler(int signo) {
     // http://www.thegeekstuff.com/2012/03/catch-signals-sample-c-code
     if (signo == SIGUSR1) {
         if(report_status == NULL)
-            fprintf(stderr, "Cannot report status.\n"); 
+            fprintf(stderr, "Cannot report status.\n");
         else {
             for(int i = 0; i < CPU_SETSIZE; i++) {
                 report_status[i] = true;
@@ -73,7 +73,7 @@ PropStack::~PropStack() {
         prop_stack.pop();
         free(vec);
     }
-    
+
     // drain the map
     for(auto it = prop_map.begin(); it != prop_map.end(); it++) {
         vec = it->second;
@@ -102,7 +102,7 @@ double* PropStack::pop(uint32_t node) {
     if(prop_stack.empty()) {
         err = posix_memalign((void **)&vec, 32, sizeof(double) * defaultsize);
         if(vec == NULL || err != 0) {
-            fprintf(stderr, "Failed to allocate %zd bytes, err %d; [%s]:%d\n", 
+            fprintf(stderr, "Failed to allocate %zd bytes, err %d; [%s]:%d\n",
                     sizeof(double) * defaultsize, err, __FILE__, __LINE__);
             exit(EXIT_FAILURE);
         }
@@ -121,14 +121,14 @@ double** su::deconvolute_stripes(std::vector<double*> &stripes, uint32_t n) {
     double **dm;
     dm = (double**)malloc(sizeof(double*) * n);
     if(dm == NULL) {
-        fprintf(stderr, "Failed to allocate %zd bytes; [%s]:%d\n", 
+        fprintf(stderr, "Failed to allocate %zd bytes; [%s]:%d\n",
                 sizeof(double*) * n, __FILE__, __LINE__);
         exit(EXIT_FAILURE);
     }
     for(unsigned int i = 0; i < n; i++) {
         dm[i] = (double*)malloc(sizeof(double) * n);
         if(dm[i] == NULL) {
-            fprintf(stderr, "Failed to allocate %zd bytes; [%s]:%d\n", 
+            fprintf(stderr, "Failed to allocate %zd bytes; [%s]:%d\n",
                     sizeof(double) * n, __FILE__, __LINE__);
             exit(EXIT_FAILURE);
         }
@@ -155,7 +155,7 @@ double** su::deconvolute_stripes(std::vector<double*> &stripes, uint32_t n) {
 
 void su::stripes_to_condensed_form(std::vector<double*> &stripes, uint32_t n, double* &cf, unsigned int start, unsigned int stop) {
     // n must be >= 2, but that should be enforced upstream as that would imply
-    // computing unifrac on a single sample. 
+    // computing unifrac on a single sample.
 
     uint64_t comb_N = comb_2(n);
     for(unsigned int stripe = start; stripe < stop; stripe++) {
@@ -196,7 +196,7 @@ void initialize_embedded(double*& prop, const su::task_parameters* task_p) {
     int err = 0;
     err = posix_memalign((void **)&prop, 32, sizeof(double) * task_p->n_samples * 2);
     if(prop == NULL || err != 0) {
-        fprintf(stderr, "Failed to allocate %zd bytes, err %d; [%s]:%d\n", 
+        fprintf(stderr, "Failed to allocate %zd bytes, err %d; [%s]:%d\n",
                 sizeof(double) * task_p->n_samples * 2, err, __FILE__, __LINE__);
         exit(EXIT_FAILURE);
     }
@@ -206,7 +206,7 @@ void initialize_sample_counts(double*& counts, const su::task_parameters* task_p
     int err = 0;
     err = posix_memalign((void **)&counts, 32, sizeof(double) * task_p->n_samples * 2);
     if(counts == NULL || err != 0) {
-        fprintf(stderr, "Failed to allocate %zd bytes, err %d; [%s]:%d\n", 
+        fprintf(stderr, "Failed to allocate %zd bytes, err %d; [%s]:%d\n",
                 sizeof(double) * task_p->n_samples, err, __FILE__, __LINE__);
         exit(EXIT_FAILURE);
     }
@@ -216,15 +216,15 @@ void initialize_sample_counts(double*& counts, const su::task_parameters* task_p
     }
 }
 
-void initialize_stripes(std::vector<double*> &dm_stripes, 
-                        std::vector<double*> &dm_stripes_total, 
-                        Method unifrac_method, 
+void initialize_stripes(std::vector<double*> &dm_stripes,
+                        std::vector<double*> &dm_stripes_total,
+                        Method unifrac_method,
                         const su::task_parameters* task_p) {
     int err = 0;
     for(unsigned int i = task_p->start; i < task_p->stop; i++){
         err = posix_memalign((void **)&dm_stripes[i], 32, sizeof(double) * task_p->n_samples);
         if(dm_stripes[i] == NULL || err != 0) {
-            fprintf(stderr, "Failed to allocate %zd bytes, err %d; [%s]:%d\n", 
+            fprintf(stderr, "Failed to allocate %zd bytes, err %d; [%s]:%d\n",
                     sizeof(double) * task_p->n_samples, err, __FILE__, __LINE__);
             exit(EXIT_FAILURE);
         }
@@ -234,7 +234,7 @@ void initialize_stripes(std::vector<double*> &dm_stripes,
         if(unifrac_method == unweighted || unifrac_method == weighted_normalized || unifrac_method == generalized) {
             err = posix_memalign((void **)&dm_stripes_total[i], 32, sizeof(double) * task_p->n_samples);
             if(dm_stripes_total[i] == NULL || err != 0) {
-                fprintf(stderr, "Failed to allocate %zd bytes err %d; [%s]:%d\n", 
+                fprintf(stderr, "Failed to allocate %zd bytes err %d; [%s]:%d\n",
                         sizeof(double) * task_p->n_samples, err, __FILE__, __LINE__);
                 exit(EXIT_FAILURE);
             }
@@ -254,6 +254,13 @@ void su::faith_pd(biom &table,
     double *node_proportions;
     double length;
 
+    std::cout << "Before iterations\n";
+    //for (unsigned int sample = 0; sample < table.n_samples; sample++){
+    //    // result[sample] += (node_proportions[sample] > 0) * length
+    //    //result[sample] = 0;
+    //    std::cout << sample << ": " << result[sample] << "\n";
+    //}
+
     // for node in postorderselect
     for(unsigned int k = 0; k < (tree.nparens / 2) - 1; k++) {
         node = tree.postorderselect(k);
@@ -267,9 +274,11 @@ void su::faith_pd(biom &table,
         // TODO: make kernel for calculating faith
         // allocate score
         // for sample in node_proportions:
+        //std::cout << "iteration: " << k << "\n";
         for (unsigned int sample = 0; sample < table.n_samples; sample++){
             // result[sample] += (node_proportions[sample] > 0) * length
             result[sample] += (node_proportions[sample] > 0) * length;
+            //std::cout << sample << ": " << result[sample] << "\n";
         }
     }
        // calculate contribution of node to score
@@ -289,7 +298,7 @@ void su::faith_pd(biom &table,
 
 
 void su::unifrac(biom &table,
-                 BPTree &tree, 
+                 BPTree &tree,
                  Method unifrac_method,
                  std::vector<double*> &dm_stripes,
                  std::vector<double*> &dm_stripes_total,
@@ -336,7 +345,7 @@ void su::unifrac(biom &table,
     if(task_p->tid == 0) {
         if (signal(SIGUSR1, sig_handler) == SIG_ERR)
             fprintf(stderr, "Can't catch SIGUSR1\n");
-        
+
         report_status = (bool*)calloc(sizeof(bool), CPU_SETSIZE);
         pthread_mutex_init(&printf_mutex, NULL);
     }
@@ -350,7 +359,7 @@ void su::unifrac(biom &table,
 
     uint32_t node;
     double *node_proportions;
-    double *embedded_proportions; 
+    double *embedded_proportions;
     double length;
 
     initialize_embedded(embedded_proportions, task_p);
@@ -368,8 +377,8 @@ void su::unifrac(biom &table,
 
         embed_proportions(embedded_proportions, node_proportions, task_p->n_samples);
         /*
-         * The values in the example vectors correspond to index positions of an 
-         * element in the resulting distance matrix. So, in the example below, 
+         * The values in the example vectors correspond to index positions of an
+         * element in the resulting distance matrix. So, in the example below,
          * the following can be interpreted:
          *
          * [0 1 2]
@@ -380,7 +389,7 @@ void su::unifrac(biom &table,
          * against the sample for col 3.
          *
          * In other words, we're computing stripes of a distance matrix. In the
-         * following example, we're computing over 6 samples requiring 3 
+         * following example, we're computing over 6 samples requiring 3
          * stripes.
          *
          * A; stripe == 0
@@ -408,17 +417,17 @@ void su::unifrac(biom &table,
          * However, we store those stripes as vectors, ie
          * [ A A A A A A ]
          *
-         * We end up performing N / 2 redundant calculations on the last stripe 
-         * (see C) but that is small over large N.  
+         * We end up performing N / 2 redundant calculations on the last stripe
+         * (see C) but that is small over large N.
          */
         func(dm_stripes, dm_stripes_total, embedded_proportions, length, task_p);
 
         if(__builtin_expect(report_status[task_p->tid], false)) {
             sync_printf("tid:%d\tstart:%d\tstop:%d\tk:%d\ttotal:%d\n", task_p->tid, task_p->start, task_p->stop, k, (tree.nparens / 2) - 1);
             report_status[task_p->tid] = false;
-        }        
+        }
     }
-    
+
     if(unifrac_method == weighted_normalized || unifrac_method == unweighted || unifrac_method == generalized) {
         for(unsigned int i = task_p->start; i < task_p->stop; i++) {
             for(unsigned int j = 0; j < task_p->n_samples; j++) {
@@ -426,12 +435,12 @@ void su::unifrac(biom &table,
             }
         }
     }
-    
+
     free(embedded_proportions);
 }
 
 void su::unifrac_vaw(biom &table,
-                     BPTree &tree, 
+                     BPTree &tree,
                      Method unifrac_method,
                      std::vector<double*> &dm_stripes,
                      std::vector<double*> &dm_stripes_total,
@@ -479,7 +488,7 @@ void su::unifrac_vaw(biom &table,
     if(task_p->tid == 0) {
         if (signal(SIGUSR1, sig_handler) == SIG_ERR)
             fprintf(stderr, "Can't catch SIGUSR1\n");
-        
+
         report_status = (bool*)calloc(sizeof(bool), CPU_SETSIZE);
         pthread_mutex_init(&printf_mutex, NULL);
     }
@@ -495,8 +504,8 @@ void su::unifrac_vaw(biom &table,
     uint32_t node;
     double *node_proportions;
     double *node_counts;
-    double *embedded_proportions; 
-    double *embedded_counts; 
+    double *embedded_proportions;
+    double *embedded_counts;
     double *sample_total_counts;
     double length;
 
@@ -522,13 +531,13 @@ void su::unifrac_vaw(biom &table,
         embed_proportions(embedded_counts, node_counts, task_p->n_samples);
 
         func(dm_stripes, dm_stripes_total, embedded_proportions, embedded_counts, sample_total_counts, length, task_p);
-        
+
         if(__builtin_expect(report_status[task_p->tid], false)) {
             sync_printf("tid:%d\tstart:%d\tstop:%d\tk:%d\ttotal:%d\n", task_p->tid, task_p->start, task_p->stop, k, (tree.nparens / 2) - 1);
             report_status[task_p->tid] = false;
         }
     }
-    
+
     if(unifrac_method == weighted_normalized || unifrac_method == unweighted || unifrac_method == generalized) {
         for(unsigned int i = task_p->start; i < task_p->stop; i++) {
             for(unsigned int j = 0; j < task_p->n_samples; j++) {
@@ -536,16 +545,16 @@ void su::unifrac_vaw(biom &table,
             }
         }
     }
-    
+
     free(embedded_proportions);
     free(embedded_counts);
     free(sample_total_counts);
 }
 
-void su::set_proportions(double* props, 
-                         BPTree &tree, 
-                         uint32_t node, 
-                         biom &table, 
+void su::set_proportions(double* props,
+                         BPTree &tree,
+                         uint32_t node,
+                         biom &table,
                          PropStack &ps,
                          bool normalize) {
     if(tree.isleaf(node)) {
@@ -560,7 +569,7 @@ void su::set_proportions(double* props,
         unsigned int current = tree.leftchild(node);
         unsigned int right = tree.rightchild(node);
         double *vec;
-        
+
         for(unsigned int i = 0; i < table.n_samples; i++)
             props[i] = 0;
 
@@ -573,7 +582,7 @@ void su::set_proportions(double* props,
 
             current = tree.rightsibling(current);
         }
-    }    
+    }
 }
 
 std::vector<double*> su::make_strides(unsigned int n_samples) {
@@ -585,43 +594,43 @@ std::vector<double*> su::make_strides(unsigned int n_samples) {
         double* tmp;
         err = posix_memalign((void **)&tmp, 32, sizeof(double) * n_samples);
         if(tmp == NULL || err != 0) {
-            fprintf(stderr, "Failed to allocate %zd bytes, err %d; [%s]:%d\n", 
+            fprintf(stderr, "Failed to allocate %zd bytes, err %d; [%s]:%d\n",
                     sizeof(double) * n_samples, err,  __FILE__, __LINE__);
             exit(EXIT_FAILURE);
         }
         for(unsigned int j = 0; j < n_samples; j++)
             tmp[j] = 0.0;
         dm_stripes[i] = tmp;
-    }    
+    }
     return dm_stripes;
 }
 
 
-void su::process_stripes(biom &table, 
-                         BPTree &tree_sheared, 
+void su::process_stripes(biom &table,
+                         BPTree &tree_sheared,
                          Method method,
                          bool variance_adjust,
-                         std::vector<double*> &dm_stripes, 
+                         std::vector<double*> &dm_stripes,
                          std::vector<double*> &dm_stripes_total,
                          std::vector<std::thread> &threads,
                          std::vector<su::task_parameters> &tasks) {
 
     for(unsigned int tid = 0; tid < threads.size(); tid++) {
         if(variance_adjust)
-            threads[tid] = std::thread(su::unifrac_vaw, 
+            threads[tid] = std::thread(su::unifrac_vaw,
                                        std::ref(table),
-                                       std::ref(tree_sheared), 
-                                       method, 
-                                       std::ref(dm_stripes), 
-                                       std::ref(dm_stripes_total), 
+                                       std::ref(tree_sheared),
+                                       method,
+                                       std::ref(dm_stripes),
+                                       std::ref(dm_stripes_total),
                                        &tasks[tid]);
         else
-            threads[tid] = std::thread(su::unifrac, 
+            threads[tid] = std::thread(su::unifrac,
                                        std::ref(table),
-                                       std::ref(tree_sheared), 
-                                       method, 
-                                       std::ref(dm_stripes), 
-                                       std::ref(dm_stripes_total), 
+                                       std::ref(tree_sheared),
+                                       method,
+                                       std::ref(dm_stripes),
+                                       std::ref(dm_stripes_total),
                                        &tasks[tid]);
     }
 

--- a/sucpp/unifrac.hpp
+++ b/sucpp/unifrac.hpp
@@ -21,6 +21,10 @@
                 double* get(uint32_t i);
         };
 
+        void faith_pd(biom &table,
+                          BPTree &tree,
+                          double* result);
+
         std::string test_table_ids_are_subset_of_tree(biom &table, BPTree &tree);
         void unifrac(biom &table, 
                      BPTree &tree, 

--- a/sucpp/unifrac.hpp
+++ b/sucpp/unifrac.hpp
@@ -21,9 +21,7 @@
                 double* get(uint32_t i);
         };
 
-        void faith_pd(biom &table,
-                          BPTree &tree,
-                          double* result);
+        void faith_pd(biom &table, BPTree &tree, double* result);
 
         std::string test_table_ids_are_subset_of_tree(biom &table, BPTree &tree);
         void unifrac(biom &table, 

--- a/unifrac/__init__.py
+++ b/unifrac/__init__.py
@@ -17,4 +17,4 @@ from unifrac._api import ssu, stacked_faith
 
 __version__ = pkg_resources.get_distribution('unifrac').version
 __all__ = ['unweighted', 'weighted_normalized', 'weighted_unnormalized',
-           'generalized', 'meta', 'ssu']
+           'generalized', 'meta', 'ssu', 'stacked_faith']

--- a/unifrac/__init__.py
+++ b/unifrac/__init__.py
@@ -12,7 +12,7 @@ from unifrac._methods import (unweighted,
                               weighted_normalized,
                               weighted_unnormalized,
                               generalized, meta)
-from unifrac._api import ssu, sfaith
+from unifrac._api import ssu, stacked_faith
 
 
 __version__ = pkg_resources.get_distribution('unifrac').version

--- a/unifrac/__init__.py
+++ b/unifrac/__init__.py
@@ -12,7 +12,7 @@ from unifrac._methods import (unweighted,
                               weighted_normalized,
                               weighted_unnormalized,
                               generalized, meta)
-from unifrac._api import ssu
+from unifrac._api import ssu, sfaith
 
 
 __version__ = pkg_resources.get_distribution('unifrac').version

--- a/unifrac/_api.pxd
+++ b/unifrac/_api.pxd
@@ -8,6 +8,11 @@ cdef extern from "../sucpp/api.hpp":
         unsigned int cf_size
         char** sample_ids
 
+    struct results_vec:
+        unsigned int n_samples
+        double* values
+        char** sample_ids
+
     enum compute_status:
         okay, 
         tree_missing,
@@ -18,4 +23,10 @@ cdef extern from "../sucpp/api.hpp":
     compute_status one_off(const char* biom_filename, const char* tree_filename, 
                                const char* unifrac_method, bool variance_adjust, double alpha,
                                bool bypass_tips, unsigned int threads, mat** result)
+
+    compute_status faith_pd_one_off(const char* biom_filename, const char* tree_filename,
+                                    results_vec** result)
+
     void destroy_mat(mat** result)
+
+    void destroy_results_vec(results_vec** result)

--- a/unifrac/_api.pxd
+++ b/unifrac/_api.pxd
@@ -17,6 +17,7 @@ cdef extern from "../sucpp/api.hpp":
         okay, 
         tree_missing,
         table_missing,
+        table_empty,
         unknown_method,
         table_and_tree_do_not_overlap
 

--- a/unifrac/_api.pyx
+++ b/unifrac/_api.pyx
@@ -89,11 +89,28 @@ def ssu(str biom_filename, str tree_filename,
 
     return skbio.DistanceMatrix(numpy_arr, ids)
 
-def stacked_faith(str biom_filename, str tree_filename):
-    """
-    TODO: document
+def stacked_faith(str biom_filename, str tree_filename) -> np.array:
+    """Execute a call to the Stacked Faith API in UniFrac package
 
+    Parameters
+    ----------
+    biom_filename : str
+        A filepath to a BIOM 2.1 formatted table (HDF5)
+    tree_filename : str
+        A filepath to a Newick formatted tree
 
+    Returns
+    -------
+    np.array
+        Array of Faith's PD for each otu in `biom_filename`
+
+    Raises
+    ------
+    IOError
+        If the tree file is not found
+        If the table is not found
+    ValueError
+        If an unknown method is requested.
     """
     cdef:
         results_vec *result;

--- a/unifrac/_api.pyx
+++ b/unifrac/_api.pyx
@@ -2,7 +2,7 @@ import skbio
 import numpy as np
 cimport numpy as np
 
-def ssu(str biom_filename, str tree_filename, 
+def ssu(str biom_filename, str tree_filename,
         str unifrac_method, bool variance_adjust, double alpha,
         bool bypass_tips, unsigned int threads):
     """Execute a call to Strided State UniFrac via the direct API
@@ -49,9 +49,9 @@ def ssu(str biom_filename, str tree_filename,
         bytes biom_py_bytes
         bytes tree_py_bytes
         bytes met_py_bytes
-        char* biom_c_string 
-        char* tree_c_string 
-        char* met_c_string 
+        char* biom_c_string
+        char* tree_c_string
+        char* met_c_string
         list ids
 
     biom_py_bytes = biom_filename.encode()
@@ -61,13 +61,13 @@ def ssu(str biom_filename, str tree_filename,
     tree_c_string = tree_py_bytes
     met_c_string = met_py_bytes
 
-    status = one_off(biom_c_string, 
-                     tree_c_string, 
-                     met_c_string, 
-                     variance_adjust, 
+    status = one_off(biom_c_string,
+                     tree_c_string,
+                     met_c_string,
+                     variance_adjust,
                      alpha,
                      bypass_tips,
-                     threads, 
+                     threads,
                      &result)
 
     if status != okay:
@@ -81,7 +81,7 @@ def ssu(str biom_filename, str tree_filename,
     ids = []
     numpy_arr = np.zeros(result.cf_size, dtype=np.double)
     numpy_arr[:] = <np.double_t[:result.cf_size]> result.condensed_form
-    
+
     for i in range(result.n_samples):
         ids.append(result.sample_ids[i].decode('utf-8'))
 
@@ -97,7 +97,6 @@ def sfaith(str biom_filename, str tree_filename):
         results_vec *result;
         compute_status status;
         np.ndarray[np.double_t, ndim=1] numpy_arr
-        double *cf
         int i
         bytes biom_py_bytes
         bytes tree_py_bytes
@@ -127,5 +126,3 @@ def sfaith(str biom_filename, str tree_filename):
     destroy_results_vec(&result)
 
     return numpy_arr
-
-

--- a/unifrac/_api.pyx
+++ b/unifrac/_api.pyx
@@ -89,9 +89,11 @@ def ssu(str biom_filename, str tree_filename,
 
     return skbio.DistanceMatrix(numpy_arr, ids)
 
-def sfaith(str biom_filename, str tree_filename):
+def stacked_faith(str biom_filename, str tree_filename):
     """
     TODO: document
+
+
     """
     cdef:
         results_vec *result;

--- a/unifrac/_api.pyx
+++ b/unifrac/_api.pyx
@@ -122,7 +122,7 @@ def sfaith(str biom_filename, str tree_filename):
             raise ValueError("Unknown method.")
 
     numpy_arr = np.zeros(result.n_samples, dtype=np.double)
-    numpy_arr[:] = <np.double_t[:result.num_samples]> result.values
+    numpy_arr[:] = <np.double_t[:result.n_samples]> result.values
 
     destroy_results_vec(&result)
 

--- a/unifrac/_api.pyx
+++ b/unifrac/_api.pyx
@@ -88,3 +88,44 @@ def ssu(str biom_filename, str tree_filename,
     destroy_mat(&result)
 
     return skbio.DistanceMatrix(numpy_arr, ids)
+
+def sfaith(str biom_filename, str tree_filename):
+    """
+    TODO: document
+    """
+    cdef:
+        results_vec *result;
+        compute_status status;
+        np.ndarray[np.double_t, ndim=1] numpy_arr
+        double *cf
+        int i
+        bytes biom_py_bytes
+        bytes tree_py_bytes
+        char* biom_c_string
+        char* tree_c_string
+        list ids
+
+
+    biom_py_bytes = biom_filename.encode()
+    tree_py_bytes = tree_filename.encode()
+    biom_c_string = biom_py_bytes
+    tree_c_string = tree_py_bytes
+
+    status = faith_pd_one_off(biom_c_string, tree_c_string, &result)
+
+    if status != okay:
+        if status == tree_missing:
+            raise IOError("Tree file not found.")
+        if status == table_missing:
+            raise IOError("Table file not found.")
+        if status == unknown_method:
+            raise ValueError("Unknown method.")
+
+    numpy_arr = np.zeros(result.n_samples, dtype=np.double)
+    numpy_arr[:] = <np.double_t[:result.num_samples]> result.values
+
+    destroy_results_vec(&result)
+
+    return numpy_arr
+
+

--- a/unifrac/tests/test_api.py
+++ b/unifrac/tests/test_api.py
@@ -611,6 +611,18 @@ class FaithPDEdgeCasesTests(unittest.TestCase):
             except OSError:
                 pass
 
+    def test_faith_pd_zero_branches_omitted(self):
+        # also deleted branch length fo
+
+        t2 = TreeNode.read(StringIO(
+            '((OTU1:0.5,OTU2:0.5),(OTU3:1.0,(OTU4:0.5,'
+            'OTU5:0.75):1.0):1.0)root;'
+        ))
+
+        actual = self.faith_pd_work([1, 1, 0, 0, 0], self.oids1, t2)
+        expected = 1.0
+        self.assertAlmostEqual(actual[0], expected)
+
     def test_faith_pd_none_observed(self):
         # # TODO test below should theoretically be covered but currently
         # #  causes a segmentation fault
@@ -717,7 +729,7 @@ class FaithPDEdgeCasesTests(unittest.TestCase):
         self.assertRaises(IOError, stacked_faith, 'dne.biom', tr)
         self.assertRaises(IOError, stacked_faith, ta, 'dne.tre')
 
-        # TODO tests for the value errors
+        # TODO tests for the ValueError's
 
         # TODO currently does not have support for the cases below
 
@@ -778,8 +790,6 @@ class FaithPDEdgeCasesTests(unittest.TestCase):
         # otu_ids = ['OTU1', 'OTU2', 'OTU42']
         # #self.assertRaises(MissingNodeError, self.faith_pd_work, counts,
         # # otu_ids, t)
-
-
 
 
 if __name__ == "__main__":

--- a/unifrac/tests/test_api.py
+++ b/unifrac/tests/test_api.py
@@ -670,16 +670,20 @@ class FaithPDEdgeCasesTests(unittest.TestCase):
 
     def test_faith_pd_extra_tips(self):
         # results are the same despite presences of unobserved tips in tree
-        actual = self.faith_pd_work(self.b1[0], self.oids1, self.t1_w_extra_tips)
+        actual = self.faith_pd_work(self.b1[0], self.oids1,
+                                    self.t1_w_extra_tips)
         expected = self.faith_pd_work(self.b1[0], self.oids1, self.t1)
         self.assertAlmostEqual(actual.values, expected.values)
-        actual = self.faith_pd_work(self.b1[1], self.oids1, self.t1_w_extra_tips)
+        actual = self.faith_pd_work(self.b1[1], self.oids1,
+                                    self.t1_w_extra_tips)
         expected = self.faith_pd_work(self.b1[1], self.oids1, self.t1)
         self.assertAlmostEqual(actual.values, expected.values)
-        actual = self.faith_pd_work(self.b1[2], self.oids1, self.t1_w_extra_tips)
+        actual = self.faith_pd_work(self.b1[2], self.oids1,
+                                    self.t1_w_extra_tips)
         expected = self.faith_pd_work(self.b1[2], self.oids1, self.t1)
         self.assertAlmostEqual(actual.values, expected.values)
-        actual = self.faith_pd_work(self.b1[3], self.oids1, self.t1_w_extra_tips)
+        actual = self.faith_pd_work(self.b1[3], self.oids1,
+                                    self.t1_w_extra_tips)
         expected = self.faith_pd_work(self.b1[3], self.oids1, self.t1)
         self.assertAlmostEqual(actual.values, expected.values)
 

--- a/unifrac/tests/test_api.py
+++ b/unifrac/tests/test_api.py
@@ -568,10 +568,10 @@ class FaithPDEdgeCasesTests(unittest.TestCase):
 
     package = 'unifrac.tests'
 
-    def write_table_tree(self, u_counts, otu_ids, tree):
+    def write_table_tree(self, u_counts, otu_ids, sample_ids, tree):
         data = np.array([u_counts]).T
 
-        bt = Table(data, otu_ids, ['u'])
+        bt = Table(data, otu_ids, sample_ids)
 
         ta = os.path.join(gettempdir(), 'table.biom')
         tr = os.path.join(gettempdir(), 'tree.biom')
@@ -585,8 +585,8 @@ class FaithPDEdgeCasesTests(unittest.TestCase):
 
         return ta, tr
 
-    def faith_pd_work(self, u_counts, otu_ids, tree):
-        ta, tr = self.write_table_tree(u_counts, otu_ids, tree)
+    def faith_pd_work(self, u_counts, otu_ids, sample_ids, tree):
+        ta, tr = self.write_table_tree(u_counts, otu_ids, sample_ids, tree)
 
         return stacked_faith(ta, tr)
 
@@ -624,29 +624,28 @@ class FaithPDEdgeCasesTests(unittest.TestCase):
             'OTU5:0.75):1.0):1.0)root;'
         ))
 
-        actual = self.faith_pd_work([1, 1, 0, 0, 0], self.oids1, t2)
+        actual = self.faith_pd_work([1, 1, 0, 0, 0], self.oids1, ['foo'], t2)
         expected = 1.0
         self.assertAlmostEqual(actual[0], expected)
 
     def test_faith_pd_none_observed(self):
-        actual = self.faith_pd_work([0, 0, 0, 0, 0], self.oids1, self.t1)
+        actual = self.faith_pd_work([0, 0, 0, 0, 0], self.oids1, ['foo'], self.t1)
         expected = 0.0
         self.assertAlmostEqual(actual.values, expected)
 
     def test_faith_pd_biom_table_empty(self):
-        table, tree = self.write_table_tree(np.array([], dtype=int),
-                                            np.array([], dtype=int),
+        table, tree = self.write_table_tree([],[],[],
                                             self.t1)
 
         self.assertRaises(IOError, stacked_faith, table, tree)
 
     def test_faith_pd_all_observed(self):
-        actual = self.faith_pd_work([1, 1, 1, 1, 1], self.oids1, self.t1)
+        actual = self.faith_pd_work([1, 1, 1, 1, 1], self.oids1, ['foo'], self.t1)
         expected = sum(n.length for n in self.t1.traverse()
                        if n.length is not None)
         self.assertAlmostEqual(actual.values, expected)
 
-        actual = self.faith_pd_work([1, 2, 3, 4, 5], self.oids1, self.t1)
+        actual = self.faith_pd_work([1, 2, 3, 4, 5], self.oids1, ['foo'], self.t1)
         expected = sum(n.length for n in self.t1.traverse()
                        if n.length is not None)
         self.assertAlmostEqual(actual.values, expected)
@@ -655,42 +654,43 @@ class FaithPDEdgeCasesTests(unittest.TestCase):
         # expected results derived from QIIME 1.9.1, which
         # is a completely different implementation unifrac's initial
         # phylogenetic diversity implementation
-        actual = self.faith_pd_work(self.b1[0], self.oids1, self.t1)
+        actual = self.faith_pd_work(self.b1[0], self.oids1, [self.sids1[0]], self.t1)
         expected = 4.5
         self.assertAlmostEqual(actual.values, expected)
-        actual = self.faith_pd_work(self.b1[1], self.oids1, self.t1)
+        actual = self.faith_pd_work(self.b1[1], self.oids1, [self.sids1[1]], self.t1)
         expected = 4.75
         self.assertAlmostEqual(actual.values, expected)
-        actual = self.faith_pd_work(self.b1[2], self.oids1, self.t1)
+        actual = self.faith_pd_work(self.b1[2], self.oids1, [self.sids1[2]], self.t1)
         expected = 4.75
         self.assertAlmostEqual(actual.values, expected)
-        actual = self.faith_pd_work(self.b1[3], self.oids1, self.t1)
+        actual = self.faith_pd_work(self.b1[3], self.oids1, [self.sids1[3]], self.t1)
         expected = 4.75
         self.assertAlmostEqual(actual.values, expected)
 
     def test_faith_pd_extra_tips(self):
         # results are the same despite presences of unobserved tips in tree
-        actual = self.faith_pd_work(self.b1[0], self.oids1,
+        actual = self.faith_pd_work(self.b1[0], self.oids1, [self.sids1[0]],
                                     self.t1_w_extra_tips)
-        expected = self.faith_pd_work(self.b1[0], self.oids1, self.t1)
+        expected = self.faith_pd_work(self.b1[0], self.oids1, [self.sids1[0]], self.t1)
         self.assertAlmostEqual(actual.values, expected.values)
-        actual = self.faith_pd_work(self.b1[1], self.oids1,
+        actual = self.faith_pd_work(self.b1[1], self.oids1, [self.sids1[1]],
                                     self.t1_w_extra_tips)
-        expected = self.faith_pd_work(self.b1[1], self.oids1, self.t1)
+        expected = self.faith_pd_work(self.b1[1], self.oids1, [self.sids1[1]], self.t1)
         self.assertAlmostEqual(actual.values, expected.values)
-        actual = self.faith_pd_work(self.b1[2], self.oids1,
+        actual = self.faith_pd_work(self.b1[2], self.oids1, [self.sids1[2]],
                                     self.t1_w_extra_tips)
-        expected = self.faith_pd_work(self.b1[2], self.oids1, self.t1)
+        expected = self.faith_pd_work(self.b1[2], self.oids1, [self.sids1[2]], self.t1)
         self.assertAlmostEqual(actual.values, expected.values)
-        actual = self.faith_pd_work(self.b1[3], self.oids1,
+        actual = self.faith_pd_work(self.b1[3], self.oids1, [self.sids1[3]],
                                     self.t1_w_extra_tips)
-        expected = self.faith_pd_work(self.b1[3], self.oids1, self.t1)
+        expected = self.faith_pd_work(self.b1[3], self.oids1, [self.sids1[3]],
+                                    self.t1)
         self.assertAlmostEqual(actual.values, expected.values)
 
     def test_faith_pd_minimal(self):
         # two tips
         tree = TreeNode.read(StringIO('(OTU1:0.25, OTU2:0.25)root;'))
-        actual = self.faith_pd_work([1, 0], ['OTU1', 'OTU2'], tree)
+        actual = self.faith_pd_work([1, 0], ['OTU1', 'OTU2'], ['foo'], tree)
         expected = 0.25
         self.assertEqual(actual.values, expected)
 
@@ -702,13 +702,13 @@ class FaithPDEdgeCasesTests(unittest.TestCase):
         otu_ids = ['OTU%d' % i for i in range(1, 5)]
         # root node not observed, but branch between (OTU1, OTU2) and root
         # is considered observed
-        actual = self.faith_pd_work([1, 1, 0, 0], otu_ids, tree)
+        actual = self.faith_pd_work([1, 1, 0, 0], otu_ids, ['foo'], tree)
         expected = 0.6
         self.assertAlmostEqual(actual[0], expected)
 
         # root node not observed, but branch between (OTU3, OTU4) and root
         # is considered observed
-        actual = self.faith_pd_work([0, 0, 1, 1], otu_ids, tree)
+        actual = self.faith_pd_work([0, 0, 1, 1], otu_ids, ['foo'], tree)
         expected = 2.3
         self.assertAlmostEqual(actual[0], expected)
 

--- a/unifrac/tests/test_api.py
+++ b/unifrac/tests/test_api.py
@@ -629,23 +629,26 @@ class FaithPDEdgeCasesTests(unittest.TestCase):
         self.assertAlmostEqual(actual[0], expected)
 
     def test_faith_pd_none_observed(self):
-        actual = self.faith_pd_work([0, 0, 0, 0, 0], self.oids1, ['foo'], self.t1)
+        actual = self.faith_pd_work([0, 0, 0, 0, 0], self.oids1, ['foo'],
+                                    self.t1)
         expected = 0.0
         self.assertAlmostEqual(actual.values, expected)
 
     def test_faith_pd_biom_table_empty(self):
-        table, tree = self.write_table_tree([],[],[],
+        table, tree = self.write_table_tree([], [], [],
                                             self.t1)
 
         self.assertRaises(IOError, stacked_faith, table, tree)
 
     def test_faith_pd_all_observed(self):
-        actual = self.faith_pd_work([1, 1, 1, 1, 1], self.oids1, ['foo'], self.t1)
+        actual = self.faith_pd_work([1, 1, 1, 1, 1], self.oids1, ['foo'],
+                                    self.t1)
         expected = sum(n.length for n in self.t1.traverse()
                        if n.length is not None)
         self.assertAlmostEqual(actual.values, expected)
 
-        actual = self.faith_pd_work([1, 2, 3, 4, 5], self.oids1, ['foo'], self.t1)
+        actual = self.faith_pd_work([1, 2, 3, 4, 5], self.oids1, ['foo'],
+                                    self.t1)
         expected = sum(n.length for n in self.t1.traverse()
                        if n.length is not None)
         self.assertAlmostEqual(actual.values, expected)
@@ -654,16 +657,20 @@ class FaithPDEdgeCasesTests(unittest.TestCase):
         # expected results derived from QIIME 1.9.1, which
         # is a completely different implementation unifrac's initial
         # phylogenetic diversity implementation
-        actual = self.faith_pd_work(self.b1[0], self.oids1, [self.sids1[0]], self.t1)
+        actual = self.faith_pd_work(self.b1[0], self.oids1, [self.sids1[0]],
+                                    self.t1)
         expected = 4.5
         self.assertAlmostEqual(actual.values, expected)
-        actual = self.faith_pd_work(self.b1[1], self.oids1, [self.sids1[1]], self.t1)
+        actual = self.faith_pd_work(self.b1[1], self.oids1, [self.sids1[1]],
+                                    self.t1)
         expected = 4.75
         self.assertAlmostEqual(actual.values, expected)
-        actual = self.faith_pd_work(self.b1[2], self.oids1, [self.sids1[2]], self.t1)
+        actual = self.faith_pd_work(self.b1[2], self.oids1, [self.sids1[2]],
+                                    self.t1)
         expected = 4.75
         self.assertAlmostEqual(actual.values, expected)
-        actual = self.faith_pd_work(self.b1[3], self.oids1, [self.sids1[3]], self.t1)
+        actual = self.faith_pd_work(self.b1[3], self.oids1, [self.sids1[3]],
+                                    self.t1)
         expected = 4.75
         self.assertAlmostEqual(actual.values, expected)
 
@@ -671,20 +678,23 @@ class FaithPDEdgeCasesTests(unittest.TestCase):
         # results are the same despite presences of unobserved tips in tree
         actual = self.faith_pd_work(self.b1[0], self.oids1, [self.sids1[0]],
                                     self.t1_w_extra_tips)
-        expected = self.faith_pd_work(self.b1[0], self.oids1, [self.sids1[0]], self.t1)
+        expected = self.faith_pd_work(self.b1[0], self.oids1, [self.sids1[0]],
+                                      self.t1)
         self.assertAlmostEqual(actual.values, expected.values)
         actual = self.faith_pd_work(self.b1[1], self.oids1, [self.sids1[1]],
                                     self.t1_w_extra_tips)
-        expected = self.faith_pd_work(self.b1[1], self.oids1, [self.sids1[1]], self.t1)
+        expected = self.faith_pd_work(self.b1[1], self.oids1, [self.sids1[1]],
+                                      self.t1)
         self.assertAlmostEqual(actual.values, expected.values)
         actual = self.faith_pd_work(self.b1[2], self.oids1, [self.sids1[2]],
                                     self.t1_w_extra_tips)
-        expected = self.faith_pd_work(self.b1[2], self.oids1, [self.sids1[2]], self.t1)
+        expected = self.faith_pd_work(self.b1[2], self.oids1, [self.sids1[2]],
+                                      self.t1)
         self.assertAlmostEqual(actual.values, expected.values)
         actual = self.faith_pd_work(self.b1[3], self.oids1, [self.sids1[3]],
                                     self.t1_w_extra_tips)
         expected = self.faith_pd_work(self.b1[3], self.oids1, [self.sids1[3]],
-                                    self.t1)
+                                      self.t1)
         self.assertAlmostEqual(actual.values, expected.values)
 
     def test_faith_pd_minimal(self):


### PR DESCRIPTION
# Feature addition: Faith’s PD (WIP)

**NOTE**: Use this link to view diff, helpful to avoid viewing the extra whitespace:
https://github.com/biocore/unifrac/compare/master...gwarmstrong:faith_pd?w=1
Or click "hide whitespace changes" on the diff settings
My IDE made some automatic whitespace/newline changes, so there is a lot of extra junk in the diff. If you particularly care that the whitespace was removed, let me know and we can fix it.

I have added functions needed to compute Faith’s PD in C++, as well as exposed an API to python. This implementation improves upon the time and memory overhead for skbio’s faith PD computation on large-scaled datasets. See below:
![unknown](https://user-images.githubusercontent.com/19470970/57261154-80de7000-701b-11e9-9bd9-b287267651f4.png)
![unknown](https://user-images.githubusercontent.com/19470970/57261159-85a32400-701b-11e9-9034-91c37df3a485.png)

Usage, if you have a BIOM table saved in `table_file.biom` and a newick formatted tree saved in `tree_file.nwk`, the following python code will return a pandas.Series of the values for Faith’s PD for each sample in the BIOM table:

```
from unifrac import stacked_faith
stacked_faith(‘table_file.biom’, ‘tree_file.nwk’)
```
