### PR TITLE
changes for conda build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,11 +54,21 @@ install:
   # it is unclear why at this time.
   - conda create --yes -n test-env python=$PYTHON_VERSION
   - source activate test-env
+  - conda install --yes libtool zlib
+  - export LIBRARY_PATH="${PREFIX}/lib"
+  - 'export CC=$(basename ${CC})
+     export CXX=$(basename ${CXX})
+     export F95=$(basename ${F95})
+     export FC=$(basename ${FC})'
   - conda install --yes numpy h5py "scikit-bio>=0.5.1" flake8 nose
   # needed for the hdf5 dev tools
   - conda install --yes -c conda-forge cython "hdf5==1.10.4" biom-format
   - sed -i "s|^CXXBASE=.*|CXXBASE=$CXX_FOR_BUILD|" `which h5c++` # make sure hdf5 is using right compiler
   - sed -i "s|^CXXLINKERBASE=.*|CXXLINKERBASE=$CXX_FOR_BUILD|" `which h5c++` # make sure hdf5 is using right compiler
+  - sed -i 's/H5BLD_CXXFLAGS.*//' `which h5c++`
+  - sed -i 's/H5BLD_CPPFLAGS.*//' `which h5c++`
+  - sed -i 's/H5BLD_LDFLAGS.*//' `which h5c++`
+  - sed -i 's/H5BLD_LIBS.*//' `which h5c++`
     #- sed -i 's/-fno-plt //' `which h5c++`
   - echo $LD_LIBRARY_PATH
   - export CC=`which h5c++`

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ install:
   - source activate test-env
   - conda install --yes numpy h5py "scikit-bio>=0.5.1" flake8 nose
   # needed for the hdf5 dev tools
-  - conda install --yes -c conda-forge cython "hdf5==1.8.17" biom-format
+  - conda install --yes -c conda-forge cython "hdf5==1.10.4" biom-format
   - sed -i "s|^CXXBASE=.*|CXXBASE=$CXX_FOR_BUILD|" `which h5c++` # make sure hdf5 is using right compiler
   - sed -i "s|^CXXLINKERBASE=.*|CXXLINKERBASE=$CXX_FOR_BUILD|" `which h5c++` # make sure hdf5 is using right compiler
   - echo $LD_LIBRARY_PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,11 +32,13 @@ before_install:
   - export PATH=/usr/lib/binutils-2.26/bin:${PATH}
   - export CC_FOR_BUILD=/usr/local/bin/gcc
   - export CXX_FOR_BUILD=/usr/local/bin/g++
-
+  - export PERFORMING_CONDA_BUILD=True
   - $CC_FOR_BUILD -v # verify gcc version
   - $CXX_FOR_BUILD -v # verify g++ version
+  - ls /usr/lib/binutils-2.26/bin
   - which ld
   - ld -v
+  - echo 
 
  # https://github.com/springmeyer/travis-coredump/blob/master/.travis.yml
   - ulimit -c

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,13 +39,13 @@ install:
   - sed -i 's/^CXXBASE=.*/CXXBASE=clang++/' `which h5c++`
   - sed -i 's/^CXXLINKERBASE=.*/CXXLINKERBASE=clang++/' `which h5c++`
   - export CC=`which h5c++`
+  - pushd sucpp; make test; make main; make api; make capi_test; make rapi_test; popd 
   # verify both installation methods
   - 'if [ ${EDITABLE_PIP} ]; then
         pip install -e . || travis_terminate 1;
      else
         pip install . || travis_terminate 1;
      fi'
-  - pushd sucpp; make test; make main; make api; make capi_test; make rapi_test; popd 
 script:
   - ulimit -c unlimited -S
   - pushd sucpp; ./test_su; ./test_api; popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ matrix:
             - apport
             - libhdf5-serial-dev
             - g++-4.9
+        env:
+            - MATRIX_EVAL="USEGCC=gcc-4.9 && USECXX=g++-4.9"
 
 language: 
   - python
@@ -25,6 +27,7 @@ env:
   - PYTHON_VERSION=3.5 EDITABLE_PIP=1
   - PYTHON_VERSION=3.5 EDITABLE_PIP=0
 before_install:
+  - eval "${MATRIX_EVAL}"
  # https://github.com/springmeyer/travis-coredump/blob/master/.travis.yml
   - ulimit -c
   - ulimit -a -S
@@ -41,8 +44,8 @@ install:
   - conda install --yes numpy h5py "scikit-bio>=0.5.1" flake8 nose
   # needed for the hdf5 dev tools
   - conda install --yes -c conda-forge cython "hdf5==1.10.4" biom-format
-  - sed -i 's/^CXXBASE=.*/CXXBASE=g++-4.9/' `which h5c++`
-  - sed -i 's/^CXXLINKERBASE=.*/CXXLINKERBASE=g++-4.9/' `which h5c++`
+  - sed -i "s/^CXXBASE=.*/CXXBASE=$USECXX/" `which h5c++`
+  - sed -i "s/^CXXLINKERBASE=.*/CXXLINKERBASE=$USECXX/" `which h5c++`
   - export CC=`which h5c++`
   # verify both installation methods
   - 'if [ ${EDITABLE_PIP} ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,11 @@
+sudo: required
 dist: trusty
-matrix: 
-  include:
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - gdb
-            - apport
-            - libhdf5-serial-dev
-            - g++-4.9
-        env:
-            - MATRIX_EVAL="USEGCC=gcc-4.9 && USECXX=g++-4.9"
+addons:
+  apt:
+    packages:
+      - gdb
+      - apport
+      - libhdf5-serial-dev
 
 language: 
   - python
@@ -20,14 +13,13 @@ language:
 
 cache: packages
 
-# compiler:
-#   - gcc
+compiler:
+  - gcc
 
 env:
   - PYTHON_VERSION=3.5 EDITABLE_PIP=1
   - PYTHON_VERSION=3.5 EDITABLE_PIP=0
 before_install:
-  - eval "${MATRIX_EVAL}"
  # https://github.com/springmeyer/travis-coredump/blob/master/.travis.yml
   - ulimit -c
   - ulimit -a -S
@@ -44,8 +36,8 @@ install:
   - conda install --yes numpy h5py "scikit-bio>=0.5.1" flake8 nose
   # needed for the hdf5 dev tools
   - conda install --yes -c conda-forge cython "hdf5==1.10.4" biom-format
-  - sed -i "s/^CXXBASE=.*/CXXBASE=$USECXX/" `which h5c++`
-  - sed -i "s/^CXXLINKERBASE=.*/CXXLINKERBASE=$USECXX/" `which h5c++`
+  - sed -i 's/^CXXBASE=.*/CXXBASE=clang++/' `which h5c++`
+  - sed -i 's/^CXXLINKERBASE=.*/CXXLINKERBASE=clang++/' `which h5c++`
   - export CC=`which h5c++`
   # verify both installation methods
   - 'if [ ${EDITABLE_PIP} ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ env:
   - PYTHON_VERSION=3.5 EDITABLE_PIP=0
 before_install:
     #  - sudo apt-get install binutils-2.25
+  - echo $LD_LIBRARY_PATH
   - sudo ln -s /usr/bin/gcc-4.9 /usr/local/bin/gcc
   - sudo ln -s /usr/bin/g++-4.9 /usr/local/bin/g++
 
@@ -44,6 +45,7 @@ before_install:
   - chmod +x miniconda.sh
   - ./miniconda.sh -b
   - export PATH=/home/travis/miniconda3/bin:$PATH
+  - echo $LD_LIBRARY_PATH
 install:
   # linking against libhdf5_cpp fails right now if we do not use this conda environment.
   # it is unclear why at this time.
@@ -54,6 +56,7 @@ install:
   - conda install --yes -c conda-forge cython "hdf5==1.8.17" biom-format
   - sed -i "s|^CXXBASE=.*|CXXBASE=$CXX_FOR_BUILD|" `which h5c++` # make sure hdf5 is using right compiler
   - sed -i "s|^CXXLINKERBASE=.*|CXXLINKERBASE=$CXX_FOR_BUILD|" `which h5c++` # make sure hdf5 is using right compiler
+  - echo $LD_LIBRARY_PATH
   - export CC=`which h5c++`
   - pushd sucpp; make test; make main; make api; make capi_test; make rapi_test; popd 
   # verify both installation methods

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,9 @@ before_install:
   - export CC_FOR_BUILD=/usr/local/bin/gcc
   - export CXX_FOR_BUILD=/usr/local/bin/g++
   - export PERFORMING_CONDA_BUILD=True
-  - $CC_FOR_BUILD -v # verify gcc version
-  - $CXX_FOR_BUILD -v # verify g++ version
+  # verify compilter versions
+  - $CC_FOR_BUILD -v 
+  - $CXX_FOR_BUILD -v 
   # https://github.com/springmeyer/travis-coredump/blob/master/.travis.yml
   - ulimit -c
   - ulimit -a -S
@@ -33,20 +34,20 @@ before_install:
   - ./miniconda.sh -b
   - export PATH=/home/travis/miniconda3/bin:$PATH
 install:
-  # linking against libhdf5_cpp fails right now if we do not use this conda environment.
-  # it is unclear why at this time.
-  # I think I fixed this, let me know if I should remove the above comment
   - conda create --yes -n test-env python=$PYTHON_VERSION
   - source activate test-env
   - conda install --yes numpy "h5py==2.7.0" "scikit-bio>=0.5.1" flake8 nose
   # needed for the hdf5 dev tools
   - conda install --yes -c conda-forge cython "hdf5==1.8.17" biom-format
-  - sed -i "s|^CXXBASE=.*|CXXBASE=$CXX_FOR_BUILD|" `which h5c++` # make sure hdf5 is using compiler we want to use for this build
-  - sed -i "s|^CXXLINKERBASE=.*|CXXLINKERBASE=$CXX_FOR_BUILD|" `which h5c++` # make sure hdf5 is using compiler we want to use for this build
-  - sed -i 's/\(H5BLD_CXXFLAGS="\)\(.*\)\("\)/\1 \3/' `which h5c++` # remove these flags for compiling with gcc
-  - sed -i 's/\(H5BLD_CPPFLAGS="\)\(.*\)\("\)/\1 \3/' `which h5c++` # remove these flags for compiling with gcc
-  - sed -i 's/\(H5BLD_LDFLAGS="\)\(.*\)\("\)/\1 \3/' `which h5c++` # remove these flags for compiling with gcc
-  - sed -i 's/^STATIC_AVAILABLE=.*/STATIC_AVAILABLE="no"/' `which h5c++` # make sure dynamic linking to shared libraries is enabled
+  # make sure hdf5 is using the compiler we want to use for this build
+  - sed -i "s|^CXXBASE=.*|CXXBASE=$CXX_FOR_BUILD|" `which h5c++` 
+  - sed -i "s|^CXXLINKERBASE=.*|CXXLINKERBASE=$CXX_FOR_BUILD|" `which h5c++` 
+  # remove these flags for compiling with gcc
+  - sed -i 's/\(H5BLD_CXXFLAGS="\)\(.*\)\("\)/\1 \3/' `which h5c++` 
+  - sed -i 's/\(H5BLD_CPPFLAGS="\)\(.*\)\("\)/\1 \3/' `which h5c++` 
+  - sed -i 's/\(H5BLD_LDFLAGS="\)\(.*\)\("\)/\1 \3/' `which h5c++`
+  # make sure dynamic linking to shared libraries is enabled
+  - sed -i 's/^STATIC_AVAILABLE=.*/STATIC_AVAILABLE="no"/' `which h5c++` 
   - export CC=`which h5c++`
   - pushd sucpp; make test; make main; make api; make capi_test; make rapi_test; popd 
   # verify both installation methods

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,39 +9,22 @@ addons:
       - gcc-4.9
       - g++-4.9
       - libhdf5-serial-dev
-#      - gdb
-#      - apport
-#      - libhdf5-serial-dev
 
 language: cpp
-
-# cache: packages
-
-# compiler:
-#   - gcc
 
 env:
   - PYTHON_VERSION=3.5 EDITABLE_PIP=1
   - PYTHON_VERSION=3.5 EDITABLE_PIP=0
 before_install:
-    #  - sudo apt-get install binutils-2.25
   - echo $LD_LIBRARY_PATH
   - sudo ln -s /usr/bin/gcc-4.9 /usr/local/bin/gcc
   - sudo ln -s /usr/bin/g++-4.9 /usr/local/bin/g++
-
-    #- export PATH=/usr/lib/binutils-2.26/bin:${PATH}
   - export CC_FOR_BUILD=/usr/local/bin/gcc
   - export CXX_FOR_BUILD=/usr/local/bin/g++
-  - export CC=$CC_FOR_BUILD
-  - export CXX=$CXX_FOR_BUILD
   - export PERFORMING_CONDA_BUILD=True
   - $CC_FOR_BUILD -v # verify gcc version
   - $CXX_FOR_BUILD -v # verify g++ version
-  - which ld
-  - ld -v
-  - echo 
-
- # https://github.com/springmeyer/travis-coredump/blob/master/.travis.yml
+  # https://github.com/springmeyer/travis-coredump/blob/master/.travis.yml
   - ulimit -c
   - ulimit -a -S
   - ulimit -a -H
@@ -52,21 +35,18 @@ before_install:
 install:
   # linking against libhdf5_cpp fails right now if we do not use this conda environment.
   # it is unclear why at this time.
+  # I think I fixed this, let me know if I should remove the above comment
   - conda create --yes -n test-env python=$PYTHON_VERSION
   - source activate test-env
   - conda install --yes numpy "h5py==2.7.0" "scikit-bio>=0.5.1" flake8 nose
   # needed for the hdf5 dev tools
   - conda install --yes -c conda-forge cython "hdf5==1.8.17" biom-format
-  - sed -i "s|^CXXBASE=.*|CXXBASE=$CXX_FOR_BUILD|" `which h5c++` # make sure hdf5 is using right compiler
-  - sed -i "s|^CXXLINKERBASE=.*|CXXLINKERBASE=$CXX_FOR_BUILD|" `which h5c++` # make sure hdf5 is using right compiler
-  - sed -i 's/\(H5BLD_CXXFLAGS="\)\(.*\)\("\)/\1 \3/' `which h5c++`
-  - sed -i 's/\(H5BLD_CPPFLAGS="\)\(.*\)\("\)/\1 \3/' `which h5c++`
-  - sed -i 's/\(H5BLD_LDFLAGS="\)\(.*\)\("\)/\1 \3/' `which h5c++`
-  - sed -i 's/^STATIC_AVAILABLE=.*/STATIC_AVAILABLE="no"/' `which h5c++`
-  - cat `which h5c++`
-  - printenv
-    #- sed -i 's/-fno-plt //' `which h5c++`
-  - echo $LD_LIBRARY_PATH
+  - sed -i "s|^CXXBASE=.*|CXXBASE=$CXX_FOR_BUILD|" `which h5c++` # make sure hdf5 is using compiler we want to use for this build
+  - sed -i "s|^CXXLINKERBASE=.*|CXXLINKERBASE=$CXX_FOR_BUILD|" `which h5c++` # make sure hdf5 is using compiler we want to use for this build
+  - sed -i 's/\(H5BLD_CXXFLAGS="\)\(.*\)\("\)/\1 \3/' `which h5c++` # remove these flags for compiling with gcc
+  - sed -i 's/\(H5BLD_CPPFLAGS="\)\(.*\)\("\)/\1 \3/' `which h5c++` # remove these flags for compiling with gcc
+  - sed -i 's/\(H5BLD_LDFLAGS="\)\(.*\)\("\)/\1 \3/' `which h5c++` # remove these flags for compiling with gcc
+  - sed -i 's/^STATIC_AVAILABLE=.*/STATIC_AVAILABLE="no"/' `which h5c++` # make sure dynamic linking to shared libraries is enabled
   - export CC=`which h5c++`
   - pushd sucpp; make test; make main; make api; make capi_test; make rapi_test; popd 
   # verify both installation methods

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,10 +65,10 @@ install:
   - conda install --yes -c conda-forge cython "hdf5==1.10.4" biom-format
   - sed -i "s|^CXXBASE=.*|CXXBASE=$CXX_FOR_BUILD|" `which h5c++` # make sure hdf5 is using right compiler
   - sed -i "s|^CXXLINKERBASE=.*|CXXLINKERBASE=$CXX_FOR_BUILD|" `which h5c++` # make sure hdf5 is using right compiler
-  - sed -i 's/H5BLD_CXXFLAGS.*//' `which h5c++`
-  - sed -i 's/H5BLD_CPPFLAGS.*//' `which h5c++`
-  - sed -i 's/H5BLD_LDFLAGS.*//' `which h5c++`
-  - sed -i 's/H5BLD_LIBS.*//' `which h5c++`
+  - sed -i 's/\(H5BLD_CXXFLAGS="\)\(.*\)\("\)/\1 \3/' `which h5c++`
+  - sed -i 's/\(H5BLD_CPPFLAGS="\)\(.*\)\("\)/\1 \3/' `which h5c++`
+  - sed -i 's/\(H5BLD_LDFLAGS="\)\(.*\)\("\)/\1 \3/' `which h5c++`
+  - cat `which h5c++`
     #- sed -i 's/-fno-plt //' `which h5c++`
   - echo $LD_LIBRARY_PATH
   - export CC=`which h5c++`

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_install:
 install:
   # linking against libhdf5_cpp fails right now if we do not use this conda environment.
   # it is unclear why at this time.
-  - conda create -n test-env python=$PYTHON_VERSION
+  - conda create --yes -n test-env python=$PYTHON_VERSION
   - source activate test-env
   - conda install --yes numpy h5py "scikit-bio>=0.5.1" flake8 nose
   # needed for the hdf5 dev tools

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
   - sudo ln -s /usr/bin/gcc-4.9 /usr/local/bin/gcc
   - sudo ln -s /usr/bin/g++-4.9 /usr/local/bin/g++
 
-  - export PATH=/usr/lib/binutils-2.26/bin:${PATH}
+    #- export PATH=/usr/lib/binutils-2.26/bin:${PATH}
   - export CC_FOR_BUILD=/usr/local/bin/gcc
   - export CXX_FOR_BUILD=/usr/local/bin/g++
   - export PERFORMING_CONDA_BUILD=True

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ before_install:
 
   - $CC_FOR_BUILD -v # verify gcc version
   - $CXX_FOR_BUILD -v # verify g++ version
+  - which ld
   - ld -v
 
  # https://github.com/springmeyer/travis-coredump/blob/master/.travis.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,12 +54,6 @@ install:
   # it is unclear why at this time.
   - conda create --yes -n test-env python=$PYTHON_VERSION
   - source activate test-env
-  - conda install --yes libtool zlib
-  - export LIBRARY_PATH="${PREFIX}/lib"
-  - 'export CC=$(basename ${CC})
-     export CXX=$(basename ${CXX})
-     export F95=$(basename ${F95})
-     export FC=$(basename ${FC})'
   - conda install --yes numpy h5py "scikit-bio>=0.5.1" flake8 nose
   # needed for the hdf5 dev tools
   - conda install --yes -c conda-forge cython "hdf5==1.10.4" biom-format

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ env:
   - PYTHON_VERSION=3.5 EDITABLE_PIP=1
   - PYTHON_VERSION=3.5 EDITABLE_PIP=0
 before_install:
-  - sudo apt-get install binutils-2.26
+  - sudo apt-get install binutils-2.25
   - sudo ln -s /usr/bin/gcc-4.9 /usr/local/bin/gcc
   - sudo ln -s /usr/bin/g++-4.9 /usr/local/bin/g++
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,7 @@ install:
   - conda install --yes -c conda-forge cython "hdf5==1.10.4" biom-format
   - sed -i "s|^CXXBASE=.*|CXXBASE=$CXX_FOR_BUILD|" `which h5c++` # make sure hdf5 is using right compiler
   - sed -i "s|^CXXLINKERBASE=.*|CXXLINKERBASE=$CXX_FOR_BUILD|" `which h5c++` # make sure hdf5 is using right compiler
+  - sed -i 's/-fno-plt //' `which h5c++`
   - echo $LD_LIBRARY_PATH
   - export CC=`which h5c++`
   - pushd sucpp; make test; make main; make api; make capi_test; make rapi_test; popd 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
   - PYTHON_VERSION=3.5 EDITABLE_PIP=1
   - PYTHON_VERSION=3.5 EDITABLE_PIP=0
 before_install:
-  - sudo apt-get install binutils-2.25
+    #  - sudo apt-get install binutils-2.25
   - sudo ln -s /usr/bin/gcc-4.9 /usr/local/bin/gcc
   - sudo ln -s /usr/bin/g++-4.9 /usr/local/bin/g++
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,7 @@ install:
   - sed -i 's/\(H5BLD_CXXFLAGS="\)\(.*\)\("\)/\1 \3/' `which h5c++`
   - sed -i 's/\(H5BLD_CPPFLAGS="\)\(.*\)\("\)/\1 \3/' `which h5c++`
   - sed -i 's/\(H5BLD_LDFLAGS="\)\(.*\)\("\)/\1 \3/' `which h5c++`
+  - sed -i 's/^STATIC_AVAILABLE=.*/STATIC_AVAILABLE="no"/' `which h5c++`
   - cat `which h5c++`
   - printenv
     #- sed -i 's/-fno-plt //' `which h5c++`

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,9 +54,9 @@ install:
   # it is unclear why at this time.
   - conda create --yes -n test-env python=$PYTHON_VERSION
   - source activate test-env
-  - conda install --yes numpy h5py "scikit-bio>=0.5.1" flake8 nose
+  - conda install --yes numpy "h5py==2.7.0" "scikit-bio>=0.5.1" flake8 nose
   # needed for the hdf5 dev tools
-  - conda install --yes -c conda-forge cython "hdf5==1.10.4" biom-format
+  - conda install --yes -c conda-forge cython "hdf5==1.8.17" biom-format
   - sed -i "s|^CXXBASE=.*|CXXBASE=$CXX_FOR_BUILD|" `which h5c++` # make sure hdf5 is using right compiler
   - sed -i "s|^CXXLINKERBASE=.*|CXXLINKERBASE=$CXX_FOR_BUILD|" `which h5c++` # make sure hdf5 is using right compiler
   - sed -i 's/\(H5BLD_CXXFLAGS="\)\(.*\)\("\)/\1 \3/' `which h5c++`

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ addons:
     packages:
       - gcc-4.9
       - g++-4.9
+      - binutils-2.25
 #      - gdb
 #      - apport
 #      - libhdf5-serial-dev
@@ -26,6 +27,7 @@ before_install:
   - sudo ln -s /usr/bin/gcc-4.9 /usr/local/bin/gcc
   - sudo ln -s /usr/bin/g++-4.9 /usr/local/bin/g++
 
+  - export PATH=/usr/lib/binutils-2.26/bin:${PATH}
   - export CC_FOR_BUILD=/usr/local/bin/gcc
   - export CXX_FOR_BUILD=/usr/local/bin/g++
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,11 +31,11 @@ before_install:
 install:
   # linking against libhdf5_cpp fails right now if we do not use this conda environment.
   # it is unclear why at this time.
-  - conda create -n test-env --file https://data.qiime2.org/distro/core/qiime2-2017.5-conda-linux-64.txt python=$PYTHON_VERSION
+  - conda create -n test-env python=$PYTHON_VERSION
   - source activate test-env
+  - conda install --yes numpy h5py "scikit-bio>=0.5.1" flake8 nose
   # needed for the hdf5 dev tools
-  - conda install --yes -c conda-forge cython
-  - conda install --yes flake8 nose
+  - conda install --yes -c conda-forge cython "hdf5==1.10.4" biom-format
   - sed -i 's/^CXXBASE=.*/CXXBASE=clang++/' `which h5c++`
   - sed -i 's/^CXXLINKERBASE=.*/CXXLINKERBASE=clang++/' `which h5c++`
   - export CC=`which h5c++`

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ install:
   - source activate test-env
   - conda install --yes numpy h5py "scikit-bio>=0.5.1" flake8 nose
   # needed for the hdf5 dev tools
-  - conda install --yes -c conda-forge cython "hdf5==1.10.4" biom-format
+  - conda install --yes -c conda-forge cython "hdf5==1.8.17" biom-format
   - sed -i 's/^CXXBASE=.*/CXXBASE=clang++/' `which h5c++`
   - sed -i 's/^CXXLINKERBASE=.*/CXXLINKERBASE=clang++/' `which h5c++`
   - export CC=`which h5c++`

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,8 @@ before_install:
     #- export PATH=/usr/lib/binutils-2.26/bin:${PATH}
   - export CC_FOR_BUILD=/usr/local/bin/gcc
   - export CXX_FOR_BUILD=/usr/local/bin/g++
+  - export CC=$CC_FOR_BUILD
+  - export CXX=$CXX_FOR_BUILD
   - export PERFORMING_CONDA_BUILD=True
   - $CC_FOR_BUILD -v # verify gcc version
   - $CXX_FOR_BUILD -v # verify g++ version
@@ -47,7 +49,6 @@ before_install:
   - chmod +x miniconda.sh
   - ./miniconda.sh -b
   - export PATH=/home/travis/miniconda3/bin:$PATH
-  - echo $LD_LIBRARY_PATH
 install:
   # linking against libhdf5_cpp fails right now if we do not use this conda environment.
   # it is unclear why at this time.
@@ -58,7 +59,7 @@ install:
   - conda install --yes -c conda-forge cython "hdf5==1.10.4" biom-format
   - sed -i "s|^CXXBASE=.*|CXXBASE=$CXX_FOR_BUILD|" `which h5c++` # make sure hdf5 is using right compiler
   - sed -i "s|^CXXLINKERBASE=.*|CXXLINKERBASE=$CXX_FOR_BUILD|" `which h5c++` # make sure hdf5 is using right compiler
-  - sed -i 's/-fno-plt //' `which h5c++`
+    #- sed -i 's/-fno-plt //' `which h5c++`
   - echo $LD_LIBRARY_PATH
   - export CC=`which h5c++`
   - pushd sucpp; make test; make main; make api; make capi_test; make rapi_test; popd 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ addons:
       - gdb
       - apport
       - libhdf5-serial-dev
-      - g++-4.9.2
+      - g++-4.9
 
 language: 
   - python
@@ -37,8 +37,8 @@ install:
   - conda install --yes numpy h5py "scikit-bio>=0.5.1" flake8 nose
   # needed for the hdf5 dev tools
   - conda install --yes -c conda-forge cython "hdf5==1.10.4" biom-format
-  - sed -i 's/^CXXBASE=.*/CXXBASE=g++/' `which h5c++`
-  - sed -i 's/^CXXLINKERBASE=.*/CXXLINKERBASE=g++/' `which h5c++`
+  - sed -i 's/^CXXBASE=.*/CXXBASE=g++-4.9/' `which h5c++`
+  - sed -i 's/^CXXLINKERBASE=.*/CXXLINKERBASE=g++-4.9/' `which h5c++`
   - export CC=`which h5c++`
   # verify both installation methods
   - 'if [ ${EDITABLE_PIP} ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ addons:
       - gdb
       - apport
       - libhdf5-serial-dev
+      - g++-4.9.2
 
 language: 
   - python
@@ -36,8 +37,8 @@ install:
   - conda install --yes numpy h5py "scikit-bio>=0.5.1" flake8 nose
   # needed for the hdf5 dev tools
   - conda install --yes -c conda-forge cython "hdf5==1.10.4" biom-format
-  - sed -i 's/^CXXBASE=.*/CXXBASE=clang++/' `which h5c++`
-  - sed -i 's/^CXXLINKERBASE=.*/CXXLINKERBASE=clang++/' `which h5c++`
+  - sed -i 's/^CXXBASE=.*/CXXBASE=g++/' `which h5c++`
+  - sed -i 's/^CXXLINKERBASE=.*/CXXLINKERBASE=g++/' `which h5c++`
   - export CC=`which h5c++`
   # verify both installation methods
   - 'if [ ${EDITABLE_PIP} ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,6 @@ before_install:
   - export PERFORMING_CONDA_BUILD=True
   - $CC_FOR_BUILD -v # verify gcc version
   - $CXX_FOR_BUILD -v # verify g++ version
-  - ls /usr/lib/binutils-2.26/bin
   - which ld
   - ld -v
   - echo 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,37 @@
 sudo: required
 dist: trusty
+os: linux
 addons:
   apt:
+    sources:
+      - ubuntu-toolchain-r-test
     packages:
-      - gdb
-      - apport
-      - libhdf5-serial-dev
+      - gcc-4.9
+      - g++-4.9
+#      - gdb
+#      - apport
+#      - libhdf5-serial-dev
 
-language: 
-  - python
-  - r
+language: cpp
 
-cache: packages
+# cache: packages
 
-compiler:
-  - gcc
+# compiler:
+#   - gcc
 
 env:
   - PYTHON_VERSION=3.5 EDITABLE_PIP=1
   - PYTHON_VERSION=3.5 EDITABLE_PIP=0
 before_install:
+  - sudo ln -s /usr/bin/gcc-4.9 /usr/local/bin/gcc
+  - sudo ln -s /usr/bin/g++-4.9 /usr/local/bin/g++
+
+  - export CC_FOR_BUILD=/usr/local/bin/gcc
+  - export CXX_FOR_BUILD=/usr/local/bin/g++
+
+  - $CC_FOR_BUILD -v
+  - $CXX_FOR_BUILD -v
+
  # https://github.com/springmeyer/travis-coredump/blob/master/.travis.yml
   - ulimit -c
   - ulimit -a -S
@@ -36,8 +48,8 @@ install:
   - conda install --yes numpy h5py "scikit-bio>=0.5.1" flake8 nose
   # needed for the hdf5 dev tools
   - conda install --yes -c conda-forge cython "hdf5==1.8.17" biom-format
-  - sed -i 's/^CXXBASE=.*/CXXBASE=clang++/' `which h5c++`
-  - sed -i 's/^CXXLINKERBASE=.*/CXXLINKERBASE=clang++/' `which h5c++`
+  - sed -i "s/^CXXBASE=.*/CXXBASE=$CXX_FOR_BUILD/" `which h5c++`
+  - sed -i "s/^CXXLINKERBASE=.*/CXXLINKERBASE=$CXX_FOR_BUILD/" `which h5c++`
   - export CC=`which h5c++`
   - pushd sucpp; make test; make main; make api; make capi_test; make rapi_test; popd 
   # verify both installation methods

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,6 +63,7 @@ install:
   - sed -i 's/\(H5BLD_CPPFLAGS="\)\(.*\)\("\)/\1 \3/' `which h5c++`
   - sed -i 's/\(H5BLD_LDFLAGS="\)\(.*\)\("\)/\1 \3/' `which h5c++`
   - cat `which h5c++`
+  - printenv
     #- sed -i 's/-fno-plt //' `which h5c++`
   - echo $LD_LIBRARY_PATH
   - export CC=`which h5c++`

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,11 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            packages:
-              - gdb
-              - apport
-              - libhdf5-serial-dev
-              - g++-4.9
+          packages:
+            - gdb
+            - apport
+            - libhdf5-serial-dev
+            - g++-4.9
 
 language: 
   - python

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ addons:
     packages:
       - gcc-4.9
       - g++-4.9
+      - libhdf5-serial-dev
 #      - gdb
 #      - apport
 #      - libhdf5-serial-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,9 @@ before_install:
   - export CC_FOR_BUILD=/usr/local/bin/gcc
   - export CXX_FOR_BUILD=/usr/local/bin/g++
 
-  - $CC_FOR_BUILD -v
-  - $CXX_FOR_BUILD -v
+  - $CC_FOR_BUILD -v # verify gcc version
+  - $CXX_FOR_BUILD -v # verify g++ version
+  - ld -v
 
  # https://github.com/springmeyer/travis-coredump/blob/master/.travis.yml
   - ulimit -c
@@ -48,8 +49,8 @@ install:
   - conda install --yes numpy h5py "scikit-bio>=0.5.1" flake8 nose
   # needed for the hdf5 dev tools
   - conda install --yes -c conda-forge cython "hdf5==1.8.17" biom-format
-  - sed -i "s|^CXXBASE=.*|CXXBASE=$CXX_FOR_BUILD|" `which h5c++`
-  - sed -i "s|^CXXLINKERBASE=.*|CXXLINKERBASE=$CXX_FOR_BUILD|" `which h5c++`
+  - sed -i "s|^CXXBASE=.*|CXXBASE=$CXX_FOR_BUILD|" `which h5c++` # make sure hdf5 is using right compiler
+  - sed -i "s|^CXXLINKERBASE=.*|CXXLINKERBASE=$CXX_FOR_BUILD|" `which h5c++` # make sure hdf5 is using right compiler
   - export CC=`which h5c++`
   - pushd sucpp; make test; make main; make api; make capi_test; make rapi_test; popd 
   # verify both installation methods
@@ -58,6 +59,7 @@ install:
      else
         pip install . || travis_terminate 1;
      fi'
+
 script:
   - ulimit -c unlimited -S
   - pushd sucpp; ./test_su; ./test_api; popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,8 +48,8 @@ install:
   - conda install --yes numpy h5py "scikit-bio>=0.5.1" flake8 nose
   # needed for the hdf5 dev tools
   - conda install --yes -c conda-forge cython "hdf5==1.8.17" biom-format
-  - sed -i "s/^CXXBASE=.*/CXXBASE=$CXX_FOR_BUILD/" `which h5c++`
-  - sed -i "s/^CXXLINKERBASE=.*/CXXLINKERBASE=$CXX_FOR_BUILD/" `which h5c++`
+  - sed -i "s|^CXXBASE=.*|CXXBASE=$CXX_FOR_BUILD|" `which h5c++`
+  - sed -i "s|^CXXLINKERBASE=.*|CXXLINKERBASE=$CXX_FOR_BUILD|" `which h5c++`
   - export CC=`which h5c++`
   - pushd sucpp; make test; make main; make api; make capi_test; make rapi_test; popd 
   # verify both installation methods

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ addons:
     packages:
       - gcc-4.9
       - g++-4.9
-      - binutils=2.25
 #      - gdb
 #      - apport
 #      - libhdf5-serial-dev
@@ -24,6 +23,7 @@ env:
   - PYTHON_VERSION=3.5 EDITABLE_PIP=1
   - PYTHON_VERSION=3.5 EDITABLE_PIP=0
 before_install:
+  - sudo apt-get install binutils-2.26
   - sudo ln -s /usr/bin/gcc-4.9 /usr/local/bin/gcc
   - sudo ln -s /usr/bin/g++-4.9 /usr/local/bin/g++
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ addons:
     packages:
       - gcc-4.9
       - g++-4.9
-      - binutils-2.25
+      - binutils=2.25
 #      - gdb
 #      - apport
 #      - libhdf5-serial-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,16 @@
-sudo: required
 dist: trusty
-addons:
-  apt:
-    packages:
-      - gdb
-      - apport
-      - libhdf5-serial-dev
-      - g++-4.9
+matrix: 
+  include:
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            packages:
+              - gdb
+              - apport
+              - libhdf5-serial-dev
+              - g++-4.9
 
 language: 
   - python
@@ -14,8 +18,8 @@ language:
 
 cache: packages
 
-compiler:
-  - gcc
+# compiler:
+#   - gcc
 
 env:
   - PYTHON_VERSION=3.5 EDITABLE_PIP=1

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ class build_ext(build_ext_orig):
     def run(self):
         self.run_compile_ssu()
         super().run()
-    
+
     def run_compile_ssu(self):
         self.execute(compile_ssu, [], 'Compiling SSU')
         if PREFIX:

--- a/sucpp/Makefile
+++ b/sucpp/Makefile
@@ -28,6 +28,7 @@ endif
 
 ifeq ($(PERFORMING_CONDA_BUILD),True)
 	CPPFLAGS += -mtune=generic
+	LDDFLAGS += -fPIC
 else
 	CPPFLAGS += -mfma -march=native
 endif
@@ -57,7 +58,7 @@ rapi_test: main
 	
 api: tree.o biom.o unifrac.o cmd.o unifrac_task.o
 	$(CXX) $(CPPFLAGS) api.cpp -c -o api.o -fPIC
-	$(CXX) $(LDDFLAGS) -o libssu.so tree.o biom.o unifrac.o cmd.o unifrac_task.o api.o -lc -lhdf5_cpp -L$(PREFIX)/lib -fPIC
+	$(CXX) $(LDDFLAGS) -o libssu.so tree.o biom.o unifrac.o cmd.o unifrac_task.o api.o -lc -lhdf5_cpp -L$(PREFIX)/lib
 	cp libssu.so ${PREFIX}/lib/
 
 capi_test: api

--- a/sucpp/Makefile
+++ b/sucpp/Makefile
@@ -28,7 +28,6 @@ endif
 
 ifeq ($(PERFORMING_CONDA_BUILD),True)
 	CPPFLAGS += -mtune=generic
-	LDDFLAGS +=
 else
 	CPPFLAGS += -mfma -march=native
 endif

--- a/sucpp/Makefile
+++ b/sucpp/Makefile
@@ -57,7 +57,7 @@ rapi_test: main
 	
 api: tree.o biom.o unifrac.o cmd.o unifrac_task.o
 	$(CXX) $(CPPFLAGS) api.cpp -c -o api.o -fPIC
-	$(CXX) $(LDDFLAGS) -o libssu.so tree.o biom.o unifrac.o cmd.o unifrac_task.o api.o -lc -lhdf5_cpp -L$(PREFIX)/lib
+	$(CXX) $(LDDFLAGS) -o libssu.so tree.o biom.o unifrac.o cmd.o unifrac_task.o api.o -lc -lhdf5_cpp -L$(PREFIX)/lib -fPIC
 	cp libssu.so ${PREFIX}/lib/
 
 capi_test: api

--- a/sucpp/Makefile
+++ b/sucpp/Makefile
@@ -28,7 +28,7 @@ endif
 
 ifeq ($(PERFORMING_CONDA_BUILD),True)
 	CPPFLAGS += -mtune=generic -fPIC
-	CPPFLAGS=$(echo $CPPFLAGS | sed 's/-fno-plt //')
+	#CPPFLAGS=$(echo $CPPFLAGS | sed 's/-fno-plt //')
 	LDDFLAGS += -fPIC
 else
 	CPPFLAGS += -mfma -march=native

--- a/sucpp/Makefile
+++ b/sucpp/Makefile
@@ -27,9 +27,8 @@ else
 endif
 
 ifeq ($(PERFORMING_CONDA_BUILD),True)
-	CPPFLAGS += -mtune=generic -fPIC
-	#CPPFLAGS=$(echo $CPPFLAGS | sed 's/-fno-plt //')
-	LDDFLAGS += -fPIC
+	CPPFLAGS += -mtune=generic
+	LDDFLAGS +=
 else
 	CPPFLAGS += -mfma -march=native
 endif
@@ -58,8 +57,8 @@ rapi_test: main
 	pushd R_interface && Rscript rapi_test.R; popd
 	
 api: tree.o biom.o unifrac.o cmd.o unifrac_task.o
-	$(CXX) $(CPPFLAGS) -v api.cpp -c -o api.o -fPIC
-	$(CXX) $(LDDFLAGS) -v -o libssu.so tree.o biom.o unifrac.o cmd.o unifrac_task.o api.o -lc -lhdf5_cpp -L$(PREFIX)/lib
+	$(CXX) $(CPPFLAGS) api.cpp -c -o api.o -fPIC
+	$(CXX) $(LDDFLAGS) -o libssu.so tree.o biom.o unifrac.o cmd.o unifrac_task.o api.o -lc -lhdf5_cpp -L$(PREFIX)/lib
 	cp libssu.so ${PREFIX}/lib/
 
 capi_test: api

--- a/sucpp/Makefile
+++ b/sucpp/Makefile
@@ -27,7 +27,8 @@ else
 endif
 
 ifeq ($(PERFORMING_CONDA_BUILD),True)
-	CPPFLAGS += -mtune=generic
+	CPPFLAGS += -mtune=generic -fPIC
+	CPPFLAGS=$(echo $CPPFLAGS | sed 's/-fno-plt //')
 	LDDFLAGS += -fPIC
 else
 	CPPFLAGS += -mfma -march=native
@@ -57,8 +58,8 @@ rapi_test: main
 	pushd R_interface && Rscript rapi_test.R; popd
 	
 api: tree.o biom.o unifrac.o cmd.o unifrac_task.o
-	$(CXX) $(CPPFLAGS) api.cpp -c -o api.o -fPIC
-	$(CXX) $(LDDFLAGS) -o libssu.so tree.o biom.o unifrac.o cmd.o unifrac_task.o api.o -lc -lhdf5_cpp -L$(PREFIX)/lib
+	$(CXX) $(CPPFLAGS) -v api.cpp -c -o api.o -fPIC
+	$(CXX) $(LDDFLAGS) -v -o libssu.so tree.o biom.o unifrac.o cmd.o unifrac_task.o api.o -lc -lhdf5_cpp -L$(PREFIX)/lib
 	cp libssu.so ${PREFIX}/lib/
 
 capi_test: api

--- a/sucpp/test_api.cpp
+++ b/sucpp/test_api.cpp
@@ -247,36 +247,38 @@ void test_merge_partial_mat() {
 
     exp = mat_three_rep();
 
-    pms[2] = pm1;
-    pms[0] = pm2;
-    pms[1] = pm3;
+    partial_mat_t* pms_err[3];
 
-    err = merge_partial(pms, 3, 1, &obs);
+    pms_err[2] = pm1;
+    pms_err[0] = pm2;
+    pms_err[1] = pm3;
+
+    err = merge_partial(pms_err, 3, 1, &obs);
     ASSERT(err == incomplete_stripe_set);
 
     pm2->stripe_start = 2;
     pm2->stripe_stop = 6;
-    err = merge_partial(pms, 3, 1, &obs);
+    err = merge_partial(pms_err, 3, 1, &obs);
     ASSERT(err == stripes_overlap);
 
     pm2->stripe_start = 3;
     pm2->sample_ids[2][0] = 'X';
-    err = merge_partial(pms, 3, 1, &obs);
+    err = merge_partial(pms_err, 3, 1, &obs);
     ASSERT(err == sample_id_consistency);
 
     pm2->sample_ids[2][0] = 'C';
     pm3->n_samples = 2;
-    err = merge_partial(pms, 3, 1, &obs);
+    err = merge_partial(pms_err, 3, 1, &obs);
     ASSERT(err == partials_mismatch);
 
     pm3->n_samples = 6;
     pm3->stripe_total = 12;
-    err = merge_partial(pms, 3, 1, &obs);
+    err = merge_partial(pms_err, 3, 1, &obs);
     ASSERT(err == partials_mismatch);
     
     pm3->is_upper_triangle = false;
     pm3->stripe_total = 9;
-    err = merge_partial(pms, 3, 1, &obs);
+    err = merge_partial(pms_err, 3, 1, &obs);
     ASSERT(err == square_mismatch);
     
     SUITE_END();


### PR DESCRIPTION
# Highlights:

## setup.py
- changed `install` and `develop` commands for calling `make` into a more general `build_ext` which runs any time the `Extension` is built

## sucpp/test_api.cpp
- fixed a bug that caused an abort trap on some systems/environments

## .travis.yml
- removed dependencies on qiime build and specified packages