### PR TITLE
reformat readme so citation is in pre-formatted version

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repository produces a C API exposed via a shared library which can be linke
 
 A detailed description of the Strided State UniFrac algorithm can be found in [McDonald et al. 2018 Nature Methods](https://www.nature.com/articles/s41592-018-0187-8). Please note that this package implements multiple UniFrac variants, which may have their own citation. Details can be found in the help output from the command line interface in the citations section, and is included immediately below:
 
-ssu
+    ssu
     For UniFrac, please see:
         McDonald et al. Nature Methods 2018; DOI: 10.1038/s41592-018-0187-8
         Lozupone and Knight Appl Environ Microbiol 2005; DOI: 10.1128/AEM.71.12.8228-8235.2005
@@ -23,7 +23,8 @@ ssu
         Chen et al. Bioinformatics 2012; DOI: 10.1093/bioinformatics/bts342
     For Variance Adjusted UniFrac, please see: 
         Chang et al. BMC Bioinformatics 2011; DOI: 10.1186/1471-2105-12-118
-faithpd
+
+    faithpd
     For Faith's PD, please see:
         Faith Biological Conservation 1992; DOI: 10.1016/0006-3207(92)91201-3
 


### PR DESCRIPTION
The lack of tabs cause the README to not be rendered properly.
Fixes #82 