### PR TITLE
Fix stochastic segfault #63

### DIFF
--- a/sucpp/su.cpp
+++ b/sucpp/su.cpp
@@ -3,6 +3,7 @@
 #include <string>
 #include <iomanip>
 #include <glob.h>
+#include <signal.h>
 #include "api.hpp"
 #include "cmd.hpp"
 #include "tree.hpp"
@@ -274,7 +275,14 @@ int mode_one_off(std::string table_filename, std::string tree_filename,
     return EXIT_SUCCESS;
 }
 
+void ssu_sig_handler(int signo) {
+    if (signo == SIGUSR1) {
+        printf("Status cannot be reported.\n");
+    }
+}
+
 int main(int argc, char **argv){
+    signal(SIGUSR1, ssu_sig_handler);
     InputParser input(argc, argv);
     if(input.cmdOptionExists("-h") || input.cmdOptionExists("--help") || argc == 1) {
         usage();

--- a/sucpp/unifrac.cpp
+++ b/sucpp/unifrac.cpp
@@ -602,7 +602,7 @@ void su::process_stripes(biom &table,
         threads[tid].join();
     }
 
-	if(report_status != NULL) {
+    if(report_status != NULL) {
         pthread_mutex_destroy(&printf_mutex);
         free(report_status);
     }

--- a/sucpp/unifrac.cpp
+++ b/sucpp/unifrac.cpp
@@ -11,6 +11,7 @@
 #include <pthread.h>
 
 static pthread_mutex_t printf_mutex;
+static bool* report_status;
 
 std::string su::test_table_ids_are_subset_of_tree(su::biom &table, su::BPTree &tree) {
     std::unordered_set<std::string> tip_names = tree.get_tip_names();
@@ -39,8 +40,6 @@ int sync_printf(const char *format, ...) {
 
     va_end(args);
 }
-
-static bool* report_status;
 
 void sig_handler(int signo) {
     // http://www.thegeekstuff.com/2012/03/catch-signals-sample-c-code
@@ -317,16 +316,6 @@ void su::unifrac(biom &table,
             break;
     }
 
-    // register a signal handler so we can ask the master thread for its
-    // progress
-    if(task_p->tid == 0) {
-        if (signal(SIGUSR1, sig_handler) == SIG_ERR)
-            fprintf(stderr, "Can't catch SIGUSR1\n");
-
-        report_status = (bool*)calloc(sizeof(bool), CPU_SETSIZE);
-        pthread_mutex_init(&printf_mutex, NULL);
-    }
-
     if(func == NULL) {
         fprintf(stderr, "Unknown unifrac task\n");
         exit(1);
@@ -460,16 +449,6 @@ void su::unifrac_vaw(biom &table,
             break;
     }
 
-    // register a signal handler so we can ask the master thread for its
-    // progress
-    if(task_p->tid == 0) {
-        if (signal(SIGUSR1, sig_handler) == SIG_ERR)
-            fprintf(stderr, "Can't catch SIGUSR1\n");
-
-        report_status = (bool*)calloc(sizeof(bool), CPU_SETSIZE);
-        pthread_mutex_init(&printf_mutex, NULL);
-    }
-
     if(func == NULL) {
         fprintf(stderr, "Unknown unifrac task\n");
         exit(1);
@@ -592,6 +571,14 @@ void su::process_stripes(biom &table,
                          std::vector<std::thread> &threads,
                          std::vector<su::task_parameters> &tasks) {
 
+    // register a signal handler so we can ask the master thread for its
+    // progress
+    if (signal(SIGUSR1, sig_handler) == SIG_ERR)
+        fprintf(stderr, "Can't catch SIGUSR1\n");
+
+    report_status = (bool*)calloc(sizeof(bool), CPU_SETSIZE);
+    pthread_mutex_init(&printf_mutex, NULL);
+
     for(unsigned int tid = 0; tid < threads.size(); tid++) {
         if(variance_adjust)
             threads[tid] = std::thread(su::unifrac_vaw,
@@ -616,6 +603,7 @@ void su::process_stripes(biom &table,
     }
 
 	if(report_status != NULL) {
-		free(report_status);
+        pthread_mutex_destroy(&printf_mutex);
+        free(report_status);
     }
 }


### PR DESCRIPTION
Should resolve #63 . Before these changes if I ran something like `for run in {1..100}; do ssu -i table.biom -t tree.nwk -m unweighted -o foo -n 8 & done` (thanks @thermokarst ) I would get around 0-5 exiting with a segfault. With these changes, I can do 1000 runs several times and get no seg faults, so I think we've pinned it down for now.

As an added bonus, I have wrapped the `ssu` CLI in a signal handler so users don't accidentally kill the process when trying to check the status before the program enters `process_stripes`

## Old behavior
```
$ ssu -i table.biom -t tree.nwk -m unweighted -o foo -n 2                                                                                  
^Z                                                                                                                                                            
[2]  + 78708 suspended  ssu -i table.biom -t tree.nwk -m unweighted -o foo -n 2 
$ bg
[2]  - 78708 continued  ssu -i table.biom -t tree.nwk -m unweighted -o foo -n 2
$ kill -SIGUSR1 78708 # program has not reached `process_stripes`
[2]  - 78708 terminated  ssu -i table.biom -t tree.nwk -m unweighted -o foo -n 2
```
If the program has not reached `process_stripes`, (and potentially after exiting `process_stripes` but before finishing execution)

## New behavrior
```
$ ssu -i table.biom -t tree.nwk -m unweighted -o foo -n 2                                                                                  
^Z                                                                                                                                                            
[2]  + 78708 suspended  ssu -i table.biom -t tree.nwk -m unweighted -o foo -n 2  
$ bg
[2]  - 78708 continued  ssu -i table.biom -t tree.nwk -m unweighted -o foo -n 2
$ kill -SIGUSR1 78708 # program has not reached `process_stripes`
Status cannot be reported.
$ kill -SIGUSR1 78708 # program is currently in `process_stripes`
tid:1   start:2000      stop:4000       k:62    total:497947                                                                                                  
tid:0   start:0 stop:2000       k:62    total:497947
```
