### PR TITLE
Add OpenACC support

### DIFF
--- a/sucpp/su.cpp
+++ b/sucpp/su.cpp
@@ -289,6 +289,8 @@ int main(int argc, char **argv){
         return EXIT_SUCCESS;
     }
 
+#pragma acc init
+
     unsigned int nthreads;
     const std::string &table_filename = input.getCmdOption("-i");
     const std::string &tree_filename = input.getCmdOption("-t");

--- a/sucpp/test_su.cpp
+++ b/sucpp/test_su.cpp
@@ -1333,6 +1333,8 @@ void test_bptree_constructor_newline_bug() {
 }
 
 int main(int argc, char** argv) {
+#pragma acc init
+
     test_bptree_constructor_simple();
     test_bptree_constructor_newline_bug();
     test_bptree_constructor_from_existing();

--- a/sucpp/unifrac.cpp
+++ b/sucpp/unifrac.cpp
@@ -382,15 +382,14 @@ inline void unifracTT(biom &table,
         double * const dm_stripes_buf = taskObj.dm_stripes.buf;
         const double * const dm_stripes_total_buf = taskObj.dm_stripes_total.buf;
 
-#pragma acc parallel loop present(dm_stripes_buf,dm_stripes_total_buf)
-        for(unsigned int i = start_idx; i < stop_idx; i++) {
-#pragma acc loop
+#pragma acc parallel loop collapse(2) present(dm_stripes_buf,dm_stripes_total_buf)
+        for(unsigned int i = start_idx; i < stop_idx; i++)
             for(unsigned int j = 0; j < n_samples; j++) {
                 unsigned int idx = (i-start_idx)*n_samples+j;
                 dm_stripes_buf[idx]=dm_stripes_buf[idx]/dm_stripes_total_buf[idx];
                 // taskObj.dm_stripes[i][j] = taskObj.dm_stripes[i][j] / taskObj.dm_stripes_total[i][j];
             }
-        }
+        
     }
 
 #pragma acc exit data delete(embedded_proportions)

--- a/sucpp/unifrac.cpp
+++ b/sucpp/unifrac.cpp
@@ -193,13 +193,16 @@ void progressbar(float progress) {
 }
 
 void initialize_embedded(double*& prop, const su::task_parameters* task_p) {
-    int err = 0;
-    err = posix_memalign((void **)&prop, 32, sizeof(double) * task_p->n_samples * 2);
-    if(prop == NULL || err != 0) {
+    const unsigned int n_samples = task_p->n_samples;
+    double* buf = NULL;
+    int err = posix_memalign((void **)&buf, 32, sizeof(double) * n_samples * 2);
+    if(buf == NULL || err != 0) {
         fprintf(stderr, "Failed to allocate %zd bytes, err %d; [%s]:%d\n",
-                sizeof(double) * task_p->n_samples * 2, err, __FILE__, __LINE__);
+                sizeof(double) * n_samples * 2, err, __FILE__, __LINE__);
         exit(EXIT_FAILURE);
     }
+#pragma acc enter data create(buf[:n_samples*2])
+   prop=buf;
 }
 
 void initialize_sample_counts(double*& counts, const su::task_parameters* task_p, biom &table) {
@@ -369,13 +372,25 @@ inline void unifracTT(biom &table,
     }
 
     if(unifrac_method == weighted_normalized || unifrac_method == unweighted || unifrac_method == generalized) {
-        for(unsigned int i = task_p->start; i < task_p->stop; i++) {
-            for(unsigned int j = 0; j < taskObj.dm_stripes.n_samples; j++) {
-                taskObj.dm_stripes[i][j] = taskObj.dm_stripes[i][j] / taskObj.dm_stripes_total[i][j];
+        const unsigned int start_idx = task_p->start;
+        const unsigned int stop_idx = task_p->stop;
+        const unsigned int n_samples = task_p->n_samples;
+
+        double * const dm_stripes_buf = taskObj.dm_stripes.buf;
+        const double * const dm_stripes_total_buf = taskObj.dm_stripes_total.buf;
+
+#pragma acc parallel loop present(dm_stripes_buf,dm_stripes_total_buf)
+        for(unsigned int i = start_idx; i < stop_idx; i++) {
+#pragma acc loop
+            for(unsigned int j = 0; j < n_samples; j++) {
+                unsigned int idx = (i-start_idx)*n_samples+j;
+                dm_stripes_buf[idx]=dm_stripes_buf[idx]/dm_stripes_total_buf[idx];
+                // taskObj.dm_stripes[i][j] = taskObj.dm_stripes[i][j] / taskObj.dm_stripes_total[i][j];
             }
         }
     }
 
+#pragma acc exit data delete(embedded_proportions)
     free(embedded_proportions);
 }
 
@@ -475,6 +490,8 @@ inline void unifrac_vawTT(biom &table,
         }
     }
 
+
+#pragma acc exit data delete(embedded_proportions)
     free(embedded_proportions);
     free(embedded_counts);
     free(sample_total_counts);

--- a/sucpp/unifrac.cpp
+++ b/sucpp/unifrac.cpp
@@ -370,8 +370,8 @@ inline void unifracTT(biom &table,
 
     if(unifrac_method == weighted_normalized || unifrac_method == unweighted || unifrac_method == generalized) {
         for(unsigned int i = task_p->start; i < task_p->stop; i++) {
-            for(unsigned int j = 0; j < task_p->n_samples; j++) {
-                dm_stripes[i][j] = dm_stripes[i][j] / dm_stripes_total[i][j];
+            for(unsigned int j = 0; j < taskObj.dm_stripes.n_samples; j++) {
+                taskObj.dm_stripes[i][j] = taskObj.dm_stripes[i][j] / taskObj.dm_stripes_total[i][j];
             }
         }
     }
@@ -469,8 +469,8 @@ inline void unifrac_vawTT(biom &table,
 
     if(unifrac_method == weighted_normalized || unifrac_method == unweighted || unifrac_method == generalized) {
         for(unsigned int i = task_p->start; i < task_p->stop; i++) {
-            for(unsigned int j = 0; j < task_p->n_samples; j++) {
-                dm_stripes[i][j] = dm_stripes[i][j] / dm_stripes_total[i][j];
+            for(unsigned int j = 0; j < taskObj.dm_stripes.n_samples; j++) {
+                taskObj.dm_stripes[i][j] = taskObj.dm_stripes[i][j] / taskObj.dm_stripes_total[i][j];
             }
         }
     }

--- a/sucpp/unifrac.cpp
+++ b/sucpp/unifrac.cpp
@@ -614,10 +614,6 @@ void su::process_stripes(biom &table,
     report_status = (bool*)calloc(sizeof(bool), CPU_SETSIZE);
     pthread_mutex_init(&printf_mutex, NULL);
 
-    time_t now = time(0);
-    int inow = now;
-
-    //printf("process_stripes start: %i\n",inow);
 #ifdef _OPENACC
     // cannot use threading with openacc
     for(unsigned int tid = 0; tid < threads.size(); tid++) {
@@ -662,11 +658,6 @@ void su::process_stripes(biom &table,
         threads[tid].join();
     }
 #endif
-    time_t now2 = time(0);
-    int inow2 = now2;
-    int idt = now2-now;
-
-    //printf("process_stripes end: %i dt %i\n",inow2,idt);
 
     if(report_status != NULL) {
         pthread_mutex_destroy(&printf_mutex);

--- a/sucpp/unifrac.hpp
+++ b/sucpp/unifrac.hpp
@@ -48,9 +48,9 @@
                              bool normalize = true);
         std::vector<double*> make_strides(unsigned int n_samples);
         inline void embed_proportions(double* out, double* in, uint32_t n) {
-            double val;
+#pragma acc parallel loop present(out) copyin(in[:n])
             for(unsigned int i = 0; i < n; i++) {
-                val = in[i];
+                double val = in[i];
                 out[i] = val;
                 out[i + n] = val;
             }

--- a/sucpp/unifrac_task.cpp
+++ b/sucpp/unifrac_task.cpp
@@ -48,13 +48,7 @@ void su::UnifracUnnormalizedWeightedTask::_run(double length) {
     }
 }
 
-void su::_vaw_unnormalized_weighted_unifrac_task(std::vector<double*> &__restrict__ dm_stripes, 
-                                                 std::vector<double*> &__restrict__ dm_stripes_total,
-                                                 double* __restrict__ embedded_proportions,
-                                                 double* __restrict__ embedded_counts,
-                                                 double* __restrict__ sample_total_counts,
-                                                 double length,
-                                                 const su::task_parameters* task_p) {
+void su::UnifracVawUnnormalizedWeightedTask::_run(double length) {
     double *dm_stripe;
     for(unsigned int stripe=task_p->start; stripe < task_p->stop; stripe++) {
         dm_stripe = dm_stripes[stripe];
@@ -129,13 +123,7 @@ void su::UnifracNormalizedWeightedTask::_run(double length) {
     }
 }
 
-void su::_vaw_normalized_weighted_unifrac_task(std::vector<double*> &__restrict__ dm_stripes, 
-                                               std::vector<double*> &__restrict__ dm_stripes_total,
-                                               double* __restrict__ embedded_proportions, 
-                                               double* __restrict__ embedded_counts, 
-                                               double* __restrict__ sample_total_counts,
-                                               double length, 
-                                               const su::task_parameters* task_p) {
+void su::UnifracVawNormalizedWeightedTask::_run(double length) {
     double *dm_stripe;
     double *dm_stripe_total;
 
@@ -210,13 +198,7 @@ void su::UnifracGeneralizedTask::_run(double length) {
     }
 }
 
-void su::_vaw_generalized_unifrac_task(std::vector<double*> &__restrict__ dm_stripes, 
-                                       std::vector<double*> &__restrict__ dm_stripes_total,
-                                       double* __restrict__ embedded_proportions, 
-                                       double* __restrict__ embedded_counts, 
-                                       double* __restrict__ sample_total_counts,
-                                       double length, 
-                                       const su::task_parameters* task_p) {
+void su::UnifracVawGeneralizedTask::_run(double length) {
     double *dm_stripe;
     double *dm_stripe_total;
 
@@ -286,13 +268,7 @@ void su::UnifracUnweightedTask::_run(double length) {
     }
 }
 
-void su::_vaw_unweighted_unifrac_task(std::vector<double*> &__restrict__ dm_stripes, 
-                                      std::vector<double*> &__restrict__ dm_stripes_total,
-                                      double* __restrict__ embedded_proportions, 
-                                      double* __restrict__ embedded_counts, 
-                                      double* __restrict__ sample_total_counts,
-                                      double length,  
-                                      const su::task_parameters* task_p) {
+void su::UnifracVawUnweightedTask::_run(double length) {
     double *dm_stripe;
     double *dm_stripe_total;
     

--- a/sucpp/unifrac_task.cpp
+++ b/sucpp/unifrac_task.cpp
@@ -2,11 +2,7 @@
 #include <cstdlib>
 
 
-void su::_unnormalized_weighted_unifrac_task(std::vector<double*> &__restrict__ dm_stripes, 
-                                             std::vector<double*> &__restrict__ dm_stripes_total,
-                                             double* __restrict__ embedded_proportions,
-                                             double length,
-                                             const su::task_parameters* task_p) {
+void su::UnifracUnnormalizedWeightedTask::_run(double length) {
     double *dm_stripe;
     for(unsigned int stripe=task_p->start; stripe < task_p->stop; stripe++) {
         dm_stripe = dm_stripes[stripe];
@@ -76,11 +72,7 @@ void su::_vaw_unnormalized_weighted_unifrac_task(std::vector<double*> &__restric
         }
     }
 }
-void su::_normalized_weighted_unifrac_task(std::vector<double*> &__restrict__ dm_stripes, 
-                                           std::vector<double*> &__restrict__ dm_stripes_total,
-                                           double* __restrict__ embedded_proportions, 
-                                           double length, 
-                                           const su::task_parameters* task_p) {
+void su::UnifracNormalizedWeightedTask::_run(double length) {
     double *dm_stripe;
     double *dm_stripe_total;
     unsigned int trailing = task_p->n_samples - (task_p->n_samples % 4);
@@ -174,11 +166,7 @@ void su::_vaw_normalized_weighted_unifrac_task(std::vector<double*> &__restrict_
                                    dm_stripe[j] += sum_pow1 * (sub1 / s); \
                                    dm_stripe_total[j] += sum_pow1; \
                                }
-void su::_generalized_unifrac_task(std::vector<double*> &__restrict__ dm_stripes, 
-                                   std::vector<double*> &__restrict__ dm_stripes_total,
-                                   double* __restrict__ embedded_proportions, 
-                                   double length, 
-                                   const su::task_parameters* task_p) {
+void su::UnifracGeneralizedTask::_run(double length) {
     double *dm_stripe;
     double *dm_stripe_total;
     unsigned int trailing = task_p->n_samples - (task_p->n_samples % 4);
@@ -255,11 +243,7 @@ void su::_vaw_generalized_unifrac_task(std::vector<double*> &__restrict__ dm_str
         }
     }
 }
-void su::_unweighted_unifrac_task(std::vector<double*> &__restrict__ dm_stripes, 
-                                  std::vector<double*> &__restrict__ dm_stripes_total,
-                                  double* __restrict__ embedded_proportions, 
-                                  double length,  
-                                  const su::task_parameters* task_p) {
+void su::UnifracUnweightedTask::_run(double length) {
     double *dm_stripe;
     double *dm_stripe_total;
     

--- a/sucpp/unifrac_task.cpp
+++ b/sucpp/unifrac_task.cpp
@@ -8,7 +8,7 @@ void su::UnifracUnnormalizedWeightedTask::_run(double length) {
     const unsigned int n_samples = task_p->n_samples;
     const unsigned int trailing = n_samples - (n_samples % 4);
 
-    // openacc only works weel with local variables
+    // openacc only works well with local variables
     const double * const embedded_proportions = this->embedded_proportions;
     double * const dm_stripes_buf = this->dm_stripes.buf;
 
@@ -62,7 +62,7 @@ void su::UnifracVawUnnormalizedWeightedTask::_run(double length) {
     const unsigned int stop_idx = task_p->stop;
     const unsigned int n_samples = task_p->n_samples;
 
-    // openacc only works weel with local variables
+    // openacc only works well with local variables
     const double * const embedded_proportions = this->embedded_proportions;
     const double * const embedded_counts = this->embedded_counts;
     const double * const sample_total_counts = this->sample_total_counts;
@@ -95,7 +95,7 @@ void su::UnifracNormalizedWeightedTask::_run(double length) {
     const unsigned int n_samples = task_p->n_samples;
     const unsigned int trailing = n_samples - (n_samples % 4);
 
-    // openacc only works weel with local variables
+    // openacc only works well with local variables
     const double * const embedded_proportions = this->embedded_proportions;
     double * const dm_stripes_buf = this->dm_stripes.buf;
     double * const dm_stripes_total_buf = this->dm_stripes_total.buf;
@@ -175,7 +175,7 @@ void su::UnifracVawNormalizedWeightedTask::_run(double length) {
     const unsigned int stop_idx = task_p->stop;
     const unsigned int n_samples = task_p->n_samples;
 
-    // openacc only works weel with local variables
+    // openacc only works well with local variables
     const double * const embedded_proportions = this->embedded_proportions;
     const double * const embedded_counts = this->embedded_counts;
     const double * const sample_total_counts = this->sample_total_counts;
@@ -221,7 +221,7 @@ void su::UnifracGeneralizedTask::_run(double length) {
 
     const double g_unifrac_alpha = task_p->g_unifrac_alpha;
 
-    // openacc only works weel with local variables
+    // openacc only works well with local variables
     const double * const embedded_proportions = this->embedded_proportions;
     double * const dm_stripes_buf = this->dm_stripes.buf;
     double * const dm_stripes_total_buf = this->dm_stripes_total.buf;
@@ -290,7 +290,7 @@ void su::UnifracVawGeneralizedTask::_run(double length) {
 
     const double g_unifrac_alpha = task_p->g_unifrac_alpha;
 
-    // openacc only works weel with local variables
+    // openacc only works well with local variables
     const double * const embedded_proportions = this->embedded_proportions;
     const double * const embedded_counts = this->embedded_counts;
     const double * const sample_total_counts = this->sample_total_counts;
@@ -330,7 +330,7 @@ void su::UnifracUnweightedTask::_run(double length) {
     const unsigned int n_samples = task_p->n_samples;
     const unsigned int trailing = n_samples - (n_samples % 4);
 
-    // openacc only works weel with local variables
+    // openacc only works well with local variables
     const double * const embedded_proportions = this->embedded_proportions;
     double * const dm_stripes_buf = this->dm_stripes.buf;
     double * const dm_stripes_total_buf = this->dm_stripes_total.buf;
@@ -395,7 +395,7 @@ void su::UnifracVawUnweightedTask::_run(double length) {
     const unsigned int stop_idx = task_p->stop;
     const unsigned int n_samples = task_p->n_samples;
 
-    // openacc only works weel with local variables
+    // openacc only works well with local variables
     const double * const embedded_proportions = this->embedded_proportions;
     const double * const embedded_counts = this->embedded_counts;
     const double * const sample_total_counts = this->sample_total_counts;

--- a/sucpp/unifrac_task.hpp
+++ b/sucpp/unifrac_task.hpp
@@ -2,6 +2,7 @@
 #include <math.h>
 #include <vector>
 #include <stdint.h>
+#include <stddef.h>
 
 namespace su {
 

--- a/sucpp/unifrac_task.hpp
+++ b/sucpp/unifrac_task.hpp
@@ -25,7 +25,9 @@ namespace su {
       , buf((dm_stripes[start_idx]==NULL) ? NULL : new double[n_samples*(task_p->stop-start_idx)]) // dm_stripes could be null, in which case keep it null
       {
         if (buf != NULL) {
+#ifdef _OPENACC
           unsigned int bufels = n_samples*(task_p->stop-start_idx);
+#endif
           for(unsigned int stripe=start_idx; stripe < task_p->stop; stripe++) {
              double * dm_stripe = dm_stripes[stripe];
              double * buf_stripe = this->operator[](stripe);
@@ -34,7 +36,9 @@ namespace su {
                 buf_stripe[j] = dm_stripe[j];
              }
            }
+#ifdef _OPENACC
 #pragma acc enter data copyin(buf[:bufels])
+#endif    
         }
       }
 
@@ -45,8 +49,10 @@ namespace su {
       ~UnifracTaskVector()
       {
         if (buf != NULL) {
+#ifdef _OPENACC
           unsigned int bufels = n_samples*(task_p->stop-start_idx);
 #pragma acc exit data copyout(buf[:bufels])
+#endif    
           for(unsigned int stripe=start_idx; stripe < task_p->stop; stripe++) {
              double * dm_stripe = dm_stripes[stripe];
              double * buf_stripe = this->operator[](stripe);

--- a/sucpp/unifrac_task.hpp
+++ b/sucpp/unifrac_task.hpp
@@ -4,6 +4,26 @@
 #include <stdint.h>
 
 namespace su {
+
+    // Base task class to be shared by all tasks
+    class UnifracTaskBase {
+      public:
+        std::vector<double*> &dm_stripes;
+        std::vector<double*> &dm_stripes_total;
+
+        const su::task_parameters* task_p;
+
+        UnifracTaskBase(std::vector<double*> &_dm_stripes, std::vector<double*> &_dm_stripes_total, const su::task_parameters* _task_p)
+        : dm_stripes(_dm_stripes), dm_stripes_total(_dm_stripes_total), task_p(_task_p) {}
+
+        // Note: not const, since they share a mutable state
+        UnifracTaskBase(UnifracTaskBase &baseObj)
+        : dm_stripes(baseObj.dm_stripes), dm_stripes_total(baseObj.dm_stripes_total), task_p(baseObj.task_p) {}
+
+        virtual ~UnifracTaskBase() {}
+
+    };
+
     /* void su::unifrac tasks
      *
      * all methods utilize the same function signature. that signature is as follows:
@@ -19,27 +39,64 @@ namespace su {
      * length <double> the branch length of the current node to its parent.
      * task_p <task_parameters*> task specific parameters.
      */
-    void _unnormalized_weighted_unifrac_task(std::vector<double*> &__restrict__ dm_stripes, 
-                                             std::vector<double*> &__restrict__ dm_stripes_total,
-                                             double* __restrict__ embedded_proportions,
-                                             double length,
-                                             const su::task_parameters* task_p);
-    void _normalized_weighted_unifrac_task(std::vector<double*> &__restrict__ dm_stripes, 
-                                           std::vector<double*> &__restrict__ dm_stripes_total,
-                                           double* __restrict__ embedded_proportions,
-                                           double length,
-                                           const su::task_parameters* task_p);
-    void _unweighted_unifrac_task(std::vector<double*> &__restrict__ dm_stripes, 
-                                  std::vector<double*> &__restrict__ dm_stripes_total,
-                                  double* __restrict__ embedded_proportions,
-                                  double length,
-                                  const su::task_parameters* task_p);
-    void _generalized_unifrac_task(std::vector<double*> &__restrict__ dm_stripes, 
-                                   std::vector<double*> &__restrict__ dm_stripes_total,
-                                   double* __restrict__ embedded_proportions,
-                                   double length,
-                                   const su::task_parameters* task_p);
-    
+
+    class UnifracTask : public UnifracTaskBase {
+      public:
+        const double * const embedded_proportions;
+
+        UnifracTask(std::vector<double*> &_dm_stripes, std::vector<double*> &_dm_stripes_total, const double * _embedded_proportions, const su::task_parameters* _task_p)
+        : UnifracTaskBase(_dm_stripes, _dm_stripes_total, _task_p)
+        , embedded_proportions(_embedded_proportions) {}
+
+        UnifracTask(UnifracTaskBase &baseObj, const double * _embedded_proportions)
+        : UnifracTaskBase(baseObj)
+        , embedded_proportions(_embedded_proportions) {}
+
+      
+
+       virtual ~UnifracTask() {}
+
+       virtual void run(double length) = 0;
+    };
+
+
+    class UnifracUnnormalizedWeightedTask : public UnifracTask {
+      public:
+        UnifracUnnormalizedWeightedTask(std::vector<double*> &_dm_stripes, std::vector<double*> &_dm_stripes_total, const double * _embedded_proportions, const su::task_parameters* _task_p)
+        : UnifracTask(_dm_stripes,_dm_stripes_total,_embedded_proportions,_task_p) {}
+
+        virtual void run(double length) {_run(length);}
+
+        void _run(double length);
+    };
+    class UnifracNormalizedWeightedTask : public UnifracTask {
+      public:
+        UnifracNormalizedWeightedTask(std::vector<double*> &_dm_stripes, std::vector<double*> &_dm_stripes_total, const double * _embedded_proportions, const su::task_parameters* _task_p)
+        : UnifracTask(_dm_stripes,_dm_stripes_total,_embedded_proportions,_task_p) {}
+
+        virtual void run(double length) {_run(length);}
+
+        void _run(double length);
+    };
+    class UnifracUnweightedTask : public UnifracTask {
+      public:
+        UnifracUnweightedTask(std::vector<double*> &_dm_stripes, std::vector<double*> &_dm_stripes_total, const double * _embedded_proportions, const su::task_parameters* _task_p)
+        : UnifracTask(_dm_stripes,_dm_stripes_total,_embedded_proportions,_task_p) {}
+
+        virtual void run(double length) {_run(length);}
+
+        void _run(double length);
+    };
+    class UnifracGeneralizedTask : public UnifracTask {
+      public:
+        UnifracGeneralizedTask(std::vector<double*> &_dm_stripes, std::vector<double*> &_dm_stripes_total, const double * _embedded_proportions, const su::task_parameters* _task_p)
+        : UnifracTask(_dm_stripes,_dm_stripes_total,_embedded_proportions,_task_p) {}
+
+        virtual void run(double length) {_run(length);}
+
+        void _run(double length);
+    };
+
     /* void su::unifrac_vaw tasks
      *
      * all methods utilize the same function signature. that signature is as follows:

--- a/sucpp/unifrac_task.hpp
+++ b/sucpp/unifrac_task.hpp
@@ -117,32 +117,73 @@ namespace su {
      * length <double> the branch length of the current node to its parent.
      * task_p <task_parameters*> task specific parameters.
      */
-    void _vaw_unnormalized_weighted_unifrac_task(std::vector<double*> &__restrict__ dm_stripes, 
-                                                 std::vector<double*> &__restrict__ dm_stripes_total,
-                                                 double* __restrict__ embedded_proportions,
-                                                 double* __restrict__ embedded_counts,
-                                                 double* __restrict__ sample_total_counts,
-                                                 double length,
-                                                 const su::task_parameters* task_p);
-    void _vaw_normalized_weighted_unifrac_task(std::vector<double*> &__restrict__ dm_stripes, 
-                                               std::vector<double*> &__restrict__ dm_stripes_total,
-                                               double* __restrict__ embedded_proportions,
-                                               double* __restrict__ embedded_counts,
-                                               double* __restrict__ sample_total_counts,
-                                               double length,
-                                               const su::task_parameters* task_p);
-    void _vaw_unweighted_unifrac_task(std::vector<double*> &__restrict__ dm_stripes, 
-                                      std::vector<double*> &__restrict__ dm_stripes_total,
-                                      double* __restrict__ embedded_proportions,
-                                      double* __restrict__ embedded_counts,
-                                      double* __restrict__ sample_total_counts,
-                                      double length,
-                                      const su::task_parameters* task_p);
-    void _vaw_generalized_unifrac_task(std::vector<double*> &__restrict__ dm_stripes, 
-                                       std::vector<double*> &__restrict__ dm_stripes_total,
-                                       double* __restrict__ embedded_proportions,
-                                       double* __restrict__ embedded_counts,
-                                       double* __restrict__ sample_total_counts,
-                                       double length,
-                                       const su::task_parameters* task_p);
+    class UnifracVawTask : public UnifracTaskBase {
+      public:
+        const double * const embedded_proportions;
+        const double * const embedded_counts;
+        const double * const sample_total_counts;
+
+        UnifracVawTask(std::vector<double*> &_dm_stripes, std::vector<double*> &_dm_stripes_total, 
+                    const double * _embedded_proportions, const double * _embedded_counts, const double * _sample_total_counts,
+                    const su::task_parameters* _task_p)
+        : UnifracTaskBase(_dm_stripes, _dm_stripes_total, _task_p)
+        , embedded_proportions(_embedded_proportions), embedded_counts(_embedded_counts), sample_total_counts(_sample_total_counts) {}
+
+        UnifracVawTask(UnifracTaskBase &baseObj, 
+                    const double * _embedded_proportions, const double * _embedded_counts, const double * _sample_total_counts)
+        : UnifracTaskBase(baseObj)
+        , embedded_proportions(_embedded_proportions), embedded_counts(_embedded_counts), sample_total_counts(_sample_total_counts) {}
+
+
+
+       virtual ~UnifracVawTask() {}
+
+       virtual void run(double length) = 0;
+    };
+
+    class UnifracVawUnnormalizedWeightedTask : public UnifracVawTask {
+      public:
+        UnifracVawUnnormalizedWeightedTask(std::vector<double*> &_dm_stripes, std::vector<double*> &_dm_stripes_total, 
+                    const double * _embedded_proportions, const double * _embedded_counts, const double * _sample_total_counts, 
+                    const su::task_parameters* _task_p)
+        : UnifracVawTask(_dm_stripes,_dm_stripes_total,_embedded_proportions,_embedded_counts,_sample_total_counts,_task_p) {}
+
+        virtual void run(double length) {_run(length);}
+
+        void _run(double length);
+    };
+    class UnifracVawNormalizedWeightedTask : public UnifracVawTask {
+      public:
+        UnifracVawNormalizedWeightedTask(std::vector<double*> &_dm_stripes, std::vector<double*> &_dm_stripes_total, 
+                    const double * _embedded_proportions, const double * _embedded_counts, const double * _sample_total_counts, 
+                    const su::task_parameters* _task_p)
+        : UnifracVawTask(_dm_stripes,_dm_stripes_total,_embedded_proportions,_embedded_counts,_sample_total_counts,_task_p) {}
+
+        virtual void run(double length) {_run(length);}
+
+        void _run(double length);
+    };
+    class UnifracVawUnweightedTask : public UnifracVawTask {
+      public:
+        UnifracVawUnweightedTask(std::vector<double*> &_dm_stripes, std::vector<double*> &_dm_stripes_total, 
+                    const double * _embedded_proportions, const double * _embedded_counts, const double * _sample_total_counts, 
+                    const su::task_parameters* _task_p)
+        : UnifracVawTask(_dm_stripes,_dm_stripes_total,_embedded_proportions,_embedded_counts,_sample_total_counts,_task_p) {}
+
+        virtual void run(double length) {_run(length);}
+
+        void _run(double length);
+    };
+    class UnifracVawGeneralizedTask : public UnifracVawTask {
+      public:
+        UnifracVawGeneralizedTask(std::vector<double*> &_dm_stripes, std::vector<double*> &_dm_stripes_total,
+                    const double * _embedded_proportions, const double * _embedded_counts, const double * _sample_total_counts, 
+                    const su::task_parameters* _task_p)
+        : UnifracVawTask(_dm_stripes,_dm_stripes_total,_embedded_proportions,_embedded_counts,_sample_total_counts,_task_p) {}
+
+        virtual void run(double length) {_run(length);}
+
+        void _run(double length);
+    };
+
 }

--- a/sucpp/unifrac_task.hpp
+++ b/sucpp/unifrac_task.hpp
@@ -24,6 +24,7 @@ namespace su {
       , buf((dm_stripes[start_idx]==NULL) ? NULL : new double[n_samples*(task_p->stop-start_idx)]) // dm_stripes could be null, in which case keep it null
       {
         if (buf != NULL) {
+          unsigned int bufels = n_samples*(task_p->stop-start_idx);
           for(unsigned int stripe=start_idx; stripe < task_p->stop; stripe++) {
              double * dm_stripe = dm_stripes[stripe];
              double * buf_stripe = this->operator[](stripe);
@@ -32,6 +33,7 @@ namespace su {
                 buf_stripe[j] = dm_stripe[j];
              }
            }
+#pragma acc enter data copyin(buf[:bufels])
         }
       }
 
@@ -42,6 +44,8 @@ namespace su {
       ~UnifracTaskVector()
       {
         if (buf != NULL) {
+          unsigned int bufels = n_samples*(task_p->stop-start_idx);
+#pragma acc exit data copyout(buf[:bufels])
           for(unsigned int stripe=start_idx; stripe < task_p->stop; stripe++) {
              double * dm_stripe = dm_stripes[stripe];
              double * buf_stripe = this->operator[](stripe);


### PR DESCRIPTION
Add OpenACC support in unifrac.
Adds a memory buffer copy, which can add up to a 10% performance hit in non-acc code.