### PR TITLE
Fix R build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ addons:
 language: 
   - cpp
 
+build: 0
+
 env:
   - PYTHON_VERSION=3.6 EDITABLE_PIP=1
   - PYTHON_VERSION=3.6 EDITABLE_PIP=0
@@ -75,7 +77,7 @@ install:
     else
         brew install r ;
     fi
-  - sudo R -e 'install.packages("Rcpp", repos="http://cran.us.r-project.org")'
+  - sudo R -e 'install.packages("Rcpp", repos="http://lib.stat.cmu.edu/R/CRAN/")'
   - pushd sucpp
   # make c api for testing 
   - make capi_test


### PR DESCRIPTION
Closes #101 

It addresses a failed Rcpp installation by changing the CRAN repo.

As a bonus, I have added a variable `build: 0` to the bonus. In the future, if builds need to be restarted for some reason, without changing other code, you can increment or decrement this variable.