### PR TITLE
Adds validation to other Unifracs

### DIFF
--- a/unifrac/_methods.py
+++ b/unifrac/_methods.py
@@ -47,6 +47,16 @@ def _validate(table, phylogeny):
         raise ValueError("The phylogeny does not appear to be newick")
 
 
+def _validate_meta(tables, phylogenies):
+    for idx, (table, phylogeny) in enumerate(zip(tables, phylogenies)):
+        if not is_biom_v210(table):
+            raise ValueError(f"Table at position {idx} does not appear to be a "
+                             "BIOM-Format v2.1")
+        if not is_newick(phylogeny):
+            raise ValueError(f"The phylogeny at position {idx} does not appear "
+                             "to be newick")
+
+
 def unweighted(table: str,
                phylogeny: str,
                threads: int = 1,
@@ -153,6 +163,7 @@ def weighted_normalized(table: str,
        powerful beta diversity measure for comparing communities based on
        phylogeny. BMC Bioinformatics 12:118 (2011).
     """
+    _validate(table, phylogeny)
     return qsu.ssu(str(table), str(phylogeny), 'weighted_normalized',
                    variance_adjusted, 1.0, bypass_tips, threads)
 
@@ -208,6 +219,7 @@ def weighted_unnormalized(table: str,
        powerful beta diversity measure for comparing communities based on
        phylogeny. BMC Bioinformatics 12:118 (2011).
     """
+    _validate(table, phylogeny)
     return qsu.ssu(str(table), str(phylogeny), 'weighted_unnormalized',
                    variance_adjusted, 1.0, bypass_tips, threads)
 
@@ -274,6 +286,7 @@ def generalized(table: str,
        powerful beta diversity measure for comparing communities based on
        phylogeny. BMC Bioinformatics 12:118 (2011).
     """
+    _validate(table, phylogeny)
     if alpha == 1.0:
         warn("alpha of 1.0 is weighted-normalized UniFrac. "
              "Weighted-normalized is being used instead as it is more "
@@ -378,6 +391,8 @@ def meta(tables: tuple, phylogenies: tuple, weights: tuple = None,
 
     if len(tables) != len(phylogenies):
         raise ValueError("Number of trees and tables must be the same.")
+
+    _validate_meta(tables, phylogenies)
 
     if weights is None:
         weights = tuple(1 for _ in phylogenies)

--- a/unifrac/_methods.py
+++ b/unifrac/_methods.py
@@ -392,8 +392,6 @@ def meta(tables: tuple, phylogenies: tuple, weights: tuple = None,
     if len(tables) != len(phylogenies):
         raise ValueError("Number of trees and tables must be the same.")
 
-    _validate_meta(tables, phylogenies)
-
     if weights is None:
         weights = tuple(1 for _ in phylogenies)
     else:
@@ -420,6 +418,8 @@ def meta(tables: tuple, phylogenies: tuple, weights: tuple = None,
         raise ValueError("The alpha parameter can only be set when the method "
                          "is set as 'generalized', the selected method is "
                          "'%s'." % method)
+
+    _validate_meta(tables, phylogenies)
 
     kwargs = {'threads': threads,
               'bypass_tips': bypass_tips,

--- a/unifrac/_methods.py
+++ b/unifrac/_methods.py
@@ -50,11 +50,11 @@ def _validate(table, phylogeny):
 def _validate_meta(tables, phylogenies):
     for idx, (table, phylogeny) in enumerate(zip(tables, phylogenies)):
         if not is_biom_v210(table):
-            raise ValueError(f"Table at position {idx} does not appear to be a "
-                             "BIOM-Format v2.1")
+            raise ValueError(f"Table at position {idx} does not appear to be a"
+                             " BIOM-Format v2.1")
         if not is_newick(phylogeny):
-            raise ValueError(f"The phylogeny at position {idx} does not appear "
-                             "to be newick")
+            raise ValueError(f"The phylogeny at position {idx} does not appear"
+                             " to be newick")
 
 
 def unweighted(table: str,
@@ -315,10 +315,10 @@ def meta(tables: tuple, phylogenies: tuple, weights: tuple = None,
     Parameters
     ----------
     tables : tuple of str
-        Filepaths to a BIOM-Format 2.1 files. This tuple is expected to be in
+        Filepaths to BIOM-Format 2.1 files. This tuple is expected to be in
         index order with phylogenies.
     phylogenies : tuple of str
-        Filepaths to a Newick formatted trees. This tuple is expected to be in
+        Filepaths to Newick formatted trees. This tuple is expected to be in
         index order with tables.
     weights : tuple of float, optional
         The weight applied to each tree/table pair. This tuple is expected to

--- a/unifrac/tests/test_methods.py
+++ b/unifrac/tests/test_methods.py
@@ -66,6 +66,19 @@ class StateUnifracTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "No tables specified."):
             meta(tuple(), ('a', ))
 
+    def test_meta_validation(self):
+        t1 = self.get_data_path('t1.newick')
+        t2 = self.get_data_path('t2.newick')
+        e1 = self.get_data_path('e1.biom')
+        e2 = self.get_data_path('e2.biom')
+        not_a_table = e1
+        not_a_tree = t1
+        with self.assertRaisesRegex(ValueError, "position 1.*not.*BIOM"):
+            meta((t1, not_a_table), (e1, e2))
+
+        with self.assertRaisesRegex(ValueError, "position 1.*not.*newick"):
+            meta((t1, t2), (e1, not_a_tree))
+
     def test_meta_unifrac_no_method(self):
         with self.assertRaisesRegex(ValueError, "No method specified."):
             meta(('a', ), ('b', ))

--- a/unifrac/tests/test_methods.py
+++ b/unifrac/tests/test_methods.py
@@ -17,6 +17,15 @@ from unifrac import meta
 class StateUnifracTests(unittest.TestCase):
     package = 'unifrac.tests'
 
+    def setUp(self):
+        super().setUp()
+        self.table1 = self.get_data_path('e1.biom')
+        self.table2 = self.get_data_path('e2.biom')
+        self.tree1 = self.get_data_path('t1.newick')
+        self.tree2 = self.get_data_path('t2.newick')
+        self.not_a_table = self.tree1
+        self.not_a_tree = self.table1
+
     def get_data_path(self, filename):
         # adapted from qiime2.plugin.testing.TestPluginBase
         return pkg_resources.resource_filename(self.package,
@@ -24,12 +33,7 @@ class StateUnifracTests(unittest.TestCase):
 
     def test_meta_unifrac(self):
         """meta_unifrac should give correct result on sample trees"""
-        t1 = self.get_data_path('t1.newick')
-        t2 = self.get_data_path('t2.newick')
-        e1 = self.get_data_path('e1.biom')
-        e2 = self.get_data_path('e2.biom')
-
-        result = meta([e1, e2], [t1, t2],
+        result = meta([self.table1, self.table2], [self.tree1, self.tree2],
                       weights=[1, 1],
                       consolidation='skipping-missing-values',
                       method='unweighted')
@@ -47,56 +51,56 @@ class StateUnifracTests(unittest.TestCase):
     def test_meta_unifrac_unbalanced(self):
         with self.assertRaisesRegex(ValueError, ("Number of trees and tables "
                                                  "must be the same.")):
-            meta(('a', ), ('a', 'b'))
+            meta((self.table1, ), (self.tree1, self.tree2),
+                 method='unweighted')
 
         with self.assertRaisesRegex(ValueError, ("Number of trees and tables "
                                                  "must be the same.")):
-            meta(('a', 'b'), ('a', ))
+            meta((self.table1, self.table2), (self.tree1, ),
+                 method='unweighted')
 
     def test_meta_unifrac_unbalanced_weights(self):
         with self.assertRaisesRegex(ValueError, "Number of weights does not "
                                                 "match number of trees and "
                                                 "tables."):
-            meta(('c', 'd'), ('a', 'b'), weights=(1, 2, 3))
+            meta((self.table1, self.table2), (self.tree1, self.tree2),
+                 weights=(1, 2, 3), )
 
     def test_meta_unifrac_missing(self):
         with self.assertRaisesRegex(ValueError, "No trees specified."):
-            meta(('a', ), tuple())
+            meta((self.table1, ), tuple(), method='unweighted')
 
         with self.assertRaisesRegex(ValueError, "No tables specified."):
-            meta(tuple(), ('a', ))
+            meta(tuple(), (self.tree1, ), method='unweighted')
 
     def test_meta_validation(self):
-        tree1 = self.get_data_path('t1.newick')
-        tree2 = self.get_data_path('t2.newick')
-        table1 = self.get_data_path('e1.biom')
-        table2 = self.get_data_path('e2.biom')
-        not_a_table = tree1
-        not_a_tree = table1
         with self.assertRaisesRegex(ValueError, "position 1.*not.*BIOM"):
-            meta((table1, not_a_table), (tree1, tree2))
+            meta((self.table1, self.not_a_table), (self.tree1, self.tree2),
+                 method='unweighted')
 
         with self.assertRaisesRegex(ValueError, "position 1.*not.*newick"):
-            meta((table1, table2), (tree1, not_a_tree))
+            meta((self.table1, self.table2), (self.tree1, self.not_a_tree),
+                 method='unweighted')
 
     def test_meta_unifrac_no_method(self):
         with self.assertRaisesRegex(ValueError, "No method specified."):
-            meta(('a', ), ('b', ))
+            meta((self.table1, ), (self.tree1, ))
 
     def test_meta_unifrac_bad_method(self):
         with self.assertRaisesRegex(ValueError, r"Method \(bar\) "
                                                 "unrecognized."):
-            meta(('a', ), ('b', ), method='bar')
+            meta((self.table1, ), (self.tree1, ), method='bar')
 
     def test_meta_unifrac_bad_consolidation(self):
         with self.assertRaisesRegex(ValueError,
                                     r"Consolidation \(foo\) unrecognized."):
-            meta(('a', ), ('b', ), method='unweighted', consolidation='foo')
+            meta((self.table1, ), (self.tree1, ), method='unweighted',
+                 consolidation='foo')
 
     def test_meta_unifrac_alpha_not_generalized(self):
         with self.assertRaisesRegex(ValueError,
                                     "The alpha parameter can"):
-            meta(('a', ), ('b', ), method='generalized',
+            meta((self.table1, ), (self.tree1, ), method='generalized',
                  alpha=1, consolidation='skipping_missing_matrices')
 
 

--- a/unifrac/tests/test_methods.py
+++ b/unifrac/tests/test_methods.py
@@ -67,17 +67,17 @@ class StateUnifracTests(unittest.TestCase):
             meta(tuple(), ('a', ))
 
     def test_meta_validation(self):
-        t1 = self.get_data_path('t1.newick')
-        t2 = self.get_data_path('t2.newick')
-        e1 = self.get_data_path('e1.biom')
-        e2 = self.get_data_path('e2.biom')
-        not_a_table = e1
-        not_a_tree = t1
+        tree1 = self.get_data_path('t1.newick')
+        tree2 = self.get_data_path('t2.newick')
+        table1 = self.get_data_path('e1.biom')
+        table2 = self.get_data_path('e2.biom')
+        not_a_table = tree1
+        not_a_tree = table1
         with self.assertRaisesRegex(ValueError, "position 1.*not.*BIOM"):
-            meta((t1, not_a_table), (e1, e2))
+            meta((table1, not_a_table), (tree1, tree2))
 
         with self.assertRaisesRegex(ValueError, "position 1.*not.*newick"):
-            meta((t1, t2), (e1, not_a_tree))
+            meta((table1, table2), (tree1, not_a_tree))
 
     def test_meta_unifrac_no_method(self):
         with self.assertRaisesRegex(ValueError, "No method specified."):


### PR DESCRIPTION
This PR adds `_validate()` calls to the other unifracs, and creates a `_validate_meta()` function to check tree and table inputs to _meta_unifrac() and raise appropriate error messages. Closes #105.

Though I did some hacky playtesting in iPython, *this code has not been tested properly*. Sorry! My time's pretty tight right now, and I won't be able to build and test properly in the next few days.  Here's hoping Travis smiles upon me. :crossed_fingers: 