### PR TITLE
BUG: format string missing value producing arbitrary values

### DIFF
--- a/sucpp/api.cpp
+++ b/sucpp/api.cpp
@@ -258,7 +258,7 @@ compute_status partial(const char* biom_filename, const char* tree_filename,
     std::vector<double*> dm_stripes_total((table.n_samples + 1) / 2);
 
     if(nthreads > dm_stripes.size()) {
-        fprintf(stderr, "More threads were requested than stripes. Using %d threads.\n");
+        fprintf(stderr, "More threads were requested than stripes. Using %d threads.\n", (table.n_samples +1) / 2);
         nthreads = dm_stripes.size();
     }
 


### PR DESCRIPTION
This `fprintf` was producing really interesting numbers because it wasn't being told what value to plug into `%d`.
![image](https://user-images.githubusercontent.com/39198770/84538893-4bd53000-aca7-11ea-8c5c-ee4258d6ab6f.png)

NOTE: this PR has not been tested locally. Sorry!