### PR TITLE
Improve merge performance

### DIFF
--- a/sucpp/api.cpp
+++ b/sucpp/api.cpp
@@ -144,6 +144,7 @@ void initialize_mat_full_no_biom_T(TMat* &result, const char* const * sample_ids
 
     result->sample_ids = (char**)malloc(sizeof(char*) * n_samples_64);
     result->matrix = (TReal*)malloc(sizeof(TReal) * n_samples_64 * n_samples_64);
+    result->flags=0;
 
     for(unsigned int i = 0; i < n_samples; i++) {
         result->sample_ids[i] = strdup(sample_ids[i]);
@@ -195,26 +196,25 @@ void destroy_mat(mat_t** result) {
     free(*result);
 }
 
+template<class TMat>
+void destroy_mat_full_T(TMat** result) {
+    for(uint32_t i = 0; i < (*result)->n_samples; i++) {
+        free((*result)->sample_ids[i]);   
+    };                                        
+    free((*result)->sample_ids);          
+    if (((*result)->matrix)!=NULL) {          
+      free((*result)->matrix);            
+    }                                         
+    free(*result);                        
+}
+
+
 void destroy_mat_full_fp64(mat_full_fp64_t** result) {
-    for(unsigned int i = 0; i < (*result)->n_samples; i++) {
-        free((*result)->sample_ids[i]);
-    };
-    free((*result)->sample_ids);
-    if (((*result)->matrix)!=NULL) {
-      free((*result)->matrix);
-    }
-    free(*result);
+    destroy_mat_full_T(result);
 }
 
 void destroy_mat_full_fp32(mat_full_fp32_t** result) {
-    for(unsigned int i = 0; i < (*result)->n_samples; i++) {
-        free((*result)->sample_ids[i]);
-    };
-    free((*result)->sample_ids);
-    if (((*result)->matrix)!=NULL) {
-      free((*result)->matrix);
-    }
-    free(*result);
+    destroy_mat_full_T(result);
 }
 
 void destroy_partial_mat(partial_mat_t** result) {
@@ -586,6 +586,7 @@ IOStatus write_mat_hdf5_T(const char* output_filename, mat_t* result,hid_t real_
      mat_full.n_samples = result->n_samples;
 
      const uint64_t n_samples = result->n_samples;
+     mat_full.flags = 0;
      mat_full.matrix = (TReal*) malloc(n_samples*n_samples*sizeof(TReal));
      if (mat_full.matrix==NULL) {
        return open_error; // we don't have a better error code

--- a/sucpp/api.cpp
+++ b/sucpp/api.cpp
@@ -387,7 +387,7 @@ IOStatus write_mat(const char* output_filename, mat_t* result) {
     return write_okay;
 }
 
-IOStatus write_mat_from_buf(const char* output_filename, mat_t* result, const double *buf2d) {
+IOStatus write_mat_from_mtrix(const char* output_filename, mat_t* result, const double *buf2d) {
     std::ofstream output;
     output.open(output_filename);
 
@@ -436,7 +436,7 @@ herr_t write_hdf5_string(hid_t output_file_id,const char *dname, const char *str
 
 // Internal: Make sure TReal and real_id match
 template<class TReal>
-IOStatus write_mat_from_buf_hdf5_T(const char* output_filename, mat_t* result, const TReal *buf2d, hid_t real_id, unsigned int compress_level) {
+IOStatus write_mat_from_matrix_hdf5_T(const char* output_filename, mat_t* result, const TReal *buf2d, hid_t real_id, unsigned int compress_level) {
    /* Create a new file using default properties. */
    hid_t output_file_id = H5Fcreate(output_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
    if (output_file_id<0) return open_error;
@@ -540,8 +540,8 @@ IOStatus write_mat_hdf5_T(const char* output_filename, mat_t* result,hid_t real_
        return open_error; // we don't have a better error code
      }
 
-     condensed_form_to_buf_T(result->condensed_form, n_samples, buf2d);
-     IOStatus err =  write_mat_from_buf_hdf5_T(output_filename, result, buf2d, real_id, compress_level);
+     condensed_form_to_matrix_T(result->condensed_form, n_samples, buf2d);
+     IOStatus err =  write_mat_from_matrix_hdf5_T(output_filename, result, buf2d, real_id, compress_level);
 
      free(buf2d);
      return err;
@@ -563,20 +563,20 @@ IOStatus write_mat_hdf5_fp32_compressed(const char* output_filename, mat_t* resu
   return write_mat_hdf5_T<float>(output_filename,result,H5T_IEEE_F32LE,compress_level);
 }
 
-IOStatus write_mat_from_buf_hdf5(const char* output_filename, mat_t* result, const double *buf2d) {
-  return write_mat_from_buf_hdf5_T<double>(output_filename,result,buf2d,H5T_IEEE_F64LE,0);
+IOStatus write_mat_from_matrix_hdf5(const char* output_filename, mat_t* result, const double *buf2d) {
+  return write_mat_from_matrix_hdf5_T<double>(output_filename,result,buf2d,H5T_IEEE_F64LE,0);
 }
 
-IOStatus write_mat_from_buf_hdf5_fp32(const char* output_filename, mat_t* result, const float *buf2d) {
-  return write_mat_from_buf_hdf5_T<float>(output_filename,result,buf2d,H5T_IEEE_F32LE,0);
+IOStatus write_mat_from_matrix_hdf5_fp32(const char* output_filename, mat_t* result, const float *buf2d) {
+  return write_mat_from_matrix_hdf5_T<float>(output_filename,result,buf2d,H5T_IEEE_F32LE,0);
 }
 
-IOStatus write_mat_from_buf_hdf5_compressed(const char* output_filename, mat_t* result, const double *buf2d, unsigned int compress_level) {
-  return write_mat_from_buf_hdf5_T<double>(output_filename,result,buf2d,H5T_IEEE_F64LE,compress_level);
+IOStatus write_mat_from_matrix_hdf5_compressed(const char* output_filename, mat_t* result, const double *buf2d, unsigned int compress_level) {
+  return write_mat_from_matrix_hdf5_T<double>(output_filename,result,buf2d,H5T_IEEE_F64LE,compress_level);
 }
 
-IOStatus write_mat_from_buf_hdf5_fp32_compressed(const char* output_filename, mat_t* result, const float *buf2d, unsigned int compress_level) {
-  return write_mat_from_buf_hdf5_T<float>(output_filename,result,buf2d,H5T_IEEE_F32LE,compress_level);
+IOStatus write_mat_from_matrix_hdf5_fp32_compressed(const char* output_filename, mat_t* result, const float *buf2d, unsigned int compress_level) {
+  return write_mat_from_matrix_hdf5_T<float>(output_filename,result,buf2d,H5T_IEEE_F32LE,compress_level);
 }
 
 IOStatus write_vec(const char* output_filename, r_vec* result) {
@@ -879,7 +879,7 @@ MergeStatus merge_partial(partial_mat_t** partial_mats, int n_partials, unsigned
 }
 
 template<class TReal>
-MergeStatus merge_partial_to_buf_T(partial_mat_t** partial_mats, int n_partials, unsigned int nthreads, mat_t** result, TReal **buf2d) {
+MergeStatus merge_partial_to_matrix_T(partial_mat_t** partial_mats, int n_partials, unsigned int nthreads, mat_t** result, TReal **buf2d) {
     MergeStatus err = check_partial(partial_mats, n_partials);
     if (err!=merge_okay) return err;
 
@@ -898,18 +898,18 @@ MergeStatus merge_partial_to_buf_T(partial_mat_t** partial_mats, int n_partials,
 
     *buf2d = (TReal*) malloc(n_samples*n_samples*sizeof(TReal));
 
-    su::stripes_to_buf_T(stripes, n_samples, *buf2d, 0, partial_mats[0]->stripe_total);
+    su::stripes_to_matrix_T(stripes, n_samples, *buf2d, 0, partial_mats[0]->stripe_total);
 
     destroy_stripes(stripes, stripes_totals, n_samples, 0, n_partials);
 
     return merge_okay;
 }
 
-MergeStatus merge_partial_to_buf(partial_mat_t** partial_mats, int n_partials, unsigned int nthreads, mat_t** result, double **buf2d) {
-  return merge_partial_to_buf_T<double>(partial_mats, n_partials, nthreads, result, buf2d);
+MergeStatus merge_partial_to_matrix(partial_mat_t** partial_mats, int n_partials, unsigned int nthreads, mat_t** result, double **buf2d) {
+  return merge_partial_to_matrix_T<double>(partial_mats, n_partials, nthreads, result, buf2d);
 }
 
-MergeStatus merge_partial_to_buf_fp32(partial_mat_t** partial_mats, int n_partials, unsigned int nthreads, mat_t** result, float **buf2d) {
-  return merge_partial_to_buf_T<float>(partial_mats, n_partials, nthreads, result, buf2d);
+MergeStatus merge_partial_to_matrix_fp32(partial_mat_t** partial_mats, int n_partials, unsigned int nthreads, mat_t** result, float **buf2d) {
+  return merge_partial_to_matrix_T<float>(partial_mats, n_partials, nthreads, result, buf2d);
 }
 

--- a/sucpp/api.cpp
+++ b/sucpp/api.cpp
@@ -898,7 +898,7 @@ MergeStatus merge_partial_to_matrix_T(partial_mat_t** partial_mats, int n_partia
 
     *buf2d = (TReal*) malloc(n_samples*n_samples*sizeof(TReal));
 
-    su::stripes_to_matrix_T(stripes, n_samples, *buf2d, 0, partial_mats[0]->stripe_total);
+    su::stripes_to_matrix_T(stripes, n_samples, partial_mats[0]->stripe_total, *buf2d);
 
     destroy_stripes(stripes, stripes_totals, n_samples, 0, n_partials);
 

--- a/sucpp/api.cpp
+++ b/sucpp/api.cpp
@@ -387,7 +387,7 @@ IOStatus write_mat(const char* output_filename, mat_t* result) {
     return write_okay;
 }
 
-IOStatus write_mat_from_mtrix(const char* output_filename, mat_t* result, const double *buf2d) {
+IOStatus write_mat_from_matrix(const char* output_filename, mat_t* result, const double *buf2d) {
     std::ofstream output;
     output.open(output_filename);
 

--- a/sucpp/api.cpp
+++ b/sucpp/api.cpp
@@ -371,6 +371,29 @@ IOStatus write_mat(const char* output_filename, mat_t* result) {
     return write_okay;
 }
 
+IOStatus write_mat_from_buf(const char* output_filename, mat_t* result, const double *buf2d) {
+    std::ofstream output;
+    output.open(output_filename);
+
+    double v;
+
+    for(unsigned int i = 0; i < result->n_samples; i++)
+        output << "\t" << result->sample_ids[i];
+    output << std::endl;
+
+    for(unsigned int i = 0; i < result->n_samples; i++) {
+        output << result->sample_ids[i];
+        for(unsigned int j = 0; j < result->n_samples; j++) {
+            v = buf2d[i*result->n_samples+j];
+            output << std::setprecision(16) << "\t" << v;
+        }
+        output << std::endl;
+    }
+    output.close();
+
+    return write_okay;
+}
+
 herr_t write_hdf5_string(hid_t output_file_id,const char *dname, const char *str)
 {
   // this is the convoluted way to store a string

--- a/sucpp/api.cpp
+++ b/sucpp/api.cpp
@@ -926,7 +926,7 @@ MergeStatus merge_partial_to_matrix_T(const partial_mat_t* const * partial_mats,
 
     initialize_mat_full_no_biom_T<TReal,TMat>(*result, partial_mats[0]->sample_ids, n_samples);
 
-    su::stripes_to_matrix_T(stripes.data(), n_samples, partial_mats[0]->stripe_total, (*result)->matrix);
+    su::stripes_to_matrix_T<TReal>(MemoryStripes(stripes), n_samples, partial_mats[0]->stripe_total, (*result)->matrix);
 
     return merge_okay;
 }

--- a/sucpp/api.cpp
+++ b/sucpp/api.cpp
@@ -1012,7 +1012,7 @@ IOStatus read_partial_header(const char* input_filename, partial_dyn_mat_t** res
     const uint32_t n_stripes = result->stripe_stop-result->stripe_start;
     result->stripes = (double**) calloc(n_stripes,sizeof(double*));
     result->offsets = (uint64_t*) calloc(n_stripes,sizeof(uint64_t));
-    result->offsets[0] = lseek(fd,0,SEEK_CUR);;
+    result->offsets[0] = lseek(fd,0,SEEK_CUR);
     
     close(fd);
 

--- a/sucpp/api.cpp
+++ b/sucpp/api.cpp
@@ -162,7 +162,7 @@ void initialize_mat_full_no_biom_T(TMat* &result, const char* const * sample_ids
     } else {
       std::string mmap_template(mmap_dir);
       mmap_template+="/su_mmap_XXXXXX";
-      int fd=mkostemp((char *) mmap_template.c_str(), O_RDWR | O_CREAT | O_TRUNC |O_NOATIME ); 
+      int fd=mkostemp((char *) mmap_template.c_str(), O_NOATIME ); 
       if (fd<0) {
          result->matrix = NULL;
          // leave error handling to the caller

--- a/sucpp/api.cpp
+++ b/sucpp/api.cpp
@@ -898,9 +898,6 @@ MergeStatus merge_partial_to_buf_T(partial_mat_t** partial_mats, int n_partials,
 
     *buf2d = (TReal*) malloc(n_samples*n_samples*sizeof(TReal));
 
-    // initialize diagonal
-    for (uint64_t i=0; i<n_samples; i++) (*buf2d)[i*n_samples+i]=0.0;
-
     su::stripes_to_buf_T(stripes, n_samples, *buf2d, 0, partial_mats[0]->stripe_total);
 
     destroy_stripes(stripes, stripes_totals, n_samples, 0, n_partials);

--- a/sucpp/api.cpp
+++ b/sucpp/api.cpp
@@ -1167,7 +1167,10 @@ MergeStatus merge_partial_to_matrix_T(partial_dyn_mat_t* * partial_mats, int n_p
     if ((*result)->sample_ids==NULL) return incomplete_stripe_set;
 
     PartialStripes ps(n_partials,partial_mats);
-    su::stripes_to_matrix_T<TReal>(ps, partial_mats[0]->n_samples, partial_mats[0]->stripe_total, (*result)->matrix);
+    const uint32_t tile_size = (mmap_dir==NULL) ? \
+                                  (128/sizeof(TReal)) : /* keep it small for memory access, to fit in chip cache */ \
+                                  (4096/sizeof(TReal)); /* make it larger for mmap, as the limiting factor is swapping */
+    su::stripes_to_matrix_T<TReal>(ps, partial_mats[0]->n_samples, partial_mats[0]->stripe_total, (*result)->matrix, tile_size);
 
     return merge_okay;
 }

--- a/sucpp/api.cpp
+++ b/sucpp/api.cpp
@@ -1181,11 +1181,11 @@ MergeStatus merge_partial_to_matrix_fp32(partial_dyn_mat_t* * partial_mats, int 
 }
 
 MergeStatus merge_partial_to_mmap_matrix(partial_dyn_mat_t* * partial_mats, int n_partials, const char *mmap_dir, mat_full_fp64_t** result) {
-  return merge_partial_to_matrix_T<double,mat_full_fp64_t>(partial_mats, n_partials, NULL, result);
+  return merge_partial_to_matrix_T<double,mat_full_fp64_t>(partial_mats, n_partials, mmap_dir, result);
 }
 
 MergeStatus merge_partial_to_mmap_matrix_fp32(partial_dyn_mat_t* * partial_mats, int n_partials, const char *mmap_dir, mat_full_fp32_t** result) {
-  return merge_partial_to_matrix_T<float,mat_full_fp32_t>(partial_mats, n_partials, NULL, result);
+  return merge_partial_to_matrix_T<float,mat_full_fp32_t>(partial_mats, n_partials, mmap_dir, result);
 }
 
 

--- a/sucpp/api.cpp
+++ b/sucpp/api.cpp
@@ -16,6 +16,12 @@
 #define MMAP_FD_MASK 0x0fff
 #define MMAP_FLAG    0x1000
 
+/* O_NOATIME is defined at fcntl.h when supported */
+#ifndef O_NOATIME
+#define O_NOATIME 0
+#endif
+
+
 #define CHECK_FILE(filename, err) if(!is_file_exists(filename)) { \
                                       return err;                 \
                                   }

--- a/sucpp/api.hpp
+++ b/sucpp/api.hpp
@@ -173,64 +173,64 @@ EXTERN IOStatus write_mat_hdf5_fp32_compressed(const char* filename, mat_t* resu
  *
  * filename <const char*> the file to write into
  * result <mat_t*> the results object
- * buf <double *> buffer to write (must be NN size)
+ * buf <double *> buffer to write (must be NxN size)
  *
  * The following error codes are returned:
  *
  * write_okay : no problems
  */
-EXTERN IOStatus write_mat_from_buf(const char* filename, mat_t* result, const double *buf);
+EXTERN IOStatus write_mat_from_matrix(const char* filename, mat_t* result, const double *buf);
 
 
 /* Write a matrix object from buffer using hdf5 format
  *
  * filename <const char*> the file to write into
  * result <mat_t*> the results object
- * buf <double *> buffer to write (must be NN size)
+ * buf <double *> buffer to write (must be NxN size)
  *
  * The following error codes are returned:
  *
  * write_okay : no problems
  */
-EXTERN IOStatus write_mat_from_buf_hdf5(const char* filename, mat_t* result, const double *buf);
+EXTERN IOStatus write_mat_from_mtrix_hdf5(const char* filename, mat_t* result, const double *buf);
 
 /* Write a matrix object from buffer using hdf5 format, using fp32 precision
  *
  * filename <const char*> the file to write into
  * result <mat_t*> the results object
- * buf <float *> buffer to write (must be NN size)
+ * buf <float *> buffer to write (must be NxN size)
  *
  * The following error codes are returned:
  *
  * write_okay : no problems
  */
-EXTERN IOStatus write_mat_from_buf_hdf5_fp32(const char* filename, mat_t* result, const float *buf);
+EXTERN IOStatus write_mat_from_matrix_hdf5_fp32(const char* filename, mat_t* result, const float *buf);
 
 /* Write a matrix object from buffer using hdf5 format
  *
  * filename <const char*> the file to write into
  * result <mat_t*> the results object
- * buf <double *> buffer to write (must be NN size)
+ * buf <double *> buffer to write (must be NxN size)
  * compress_level - 0=no compression, 1-9 higher is slower
  *
  * The following error codes are returned:
  *
  * write_okay : no problems
  */
-EXTERN IOStatus write_mat_from_buf_hdf5_compressed(const char* filename, mat_t* result, const double *buf, unsigned int compress_level);
+EXTERN IOStatus write_mat_from_matrix_hdf5_compressed(const char* filename, mat_t* result, const double *buf, unsigned int compress_level);
 
 /* Write a matrix object from buffer using hdf5 format, using fp32 precision
  *
  * filename <const char*> the file to write into
  * result <mat_t*> the results object
- * buf <float *> buffer to write (must be NN size)
+ * buf <float *> buffer to write (must be NxN size)
  * compress_level - 0=no compression, 1-9 higher is slower
  *
  * The following error codes are returned:
  *
  * write_okay : no problems
  */
-EXTERN IOStatus write_mat_from_buf_hdf5_fp32_compressed(const char* filename, mat_t* result, const float *buf, unsigned int compress_level);
+EXTERN IOStatus write_mat_from_matrix_hdf5_fp32_compressed(const char* filename, mat_t* result, const float *buf, unsigned int compress_level);
 
 /* Write a series
  *
@@ -365,7 +365,7 @@ EXTERN MergeStatus merge_partial(partial_mat_t** partial_mats, int n_partials, u
  * results <partial_mat_t**> an array of partial_mat_t*
  * n_partials <int> number of partial mats
  * merged <mat_t**> the full matrix, output parameters, this is initialized in the method so using **
- * buf <double**> the buffer, output parameters, this is initialized in the method so using **
+ * buf <double**> the matrix, output parameters, this is initialized in the method so using **
  *
  * The following error codes are returned:
  *
@@ -374,14 +374,14 @@ EXTERN MergeStatus merge_partial(partial_mat_t** partial_mats, int n_partials, u
  * sample_id_consistency : samples described by stripes are inconsistent
  * square_mismatch       : inconsistency on denotation of square matrix
  */
-EXTERN MergeStatus merge_partial_to_buf(partial_mat_t** partial_mats, int n_partials, unsigned int nthreads, mat_t** result, double **buf);
+EXTERN MergeStatus merge_partial_to_mtrix(partial_mat_t** partial_mats, int n_partials, unsigned int nthreads, mat_t** result, double **buf);
 
 /* Merge partial results
  *
  * results <partial_mat_t**> an array of partial_mat_t*
  * n_partials <int> number of partial mats
  * merged <mat_t**> the full matrix, output parameters, this is initialized in the method so using **
- * buf <double**> the buffer, output parameters, this is initialized in the method so using **
+ * buf <double**> the matrix, output parameters, this is initialized in the method so using **
  *
  * The following error codes are returned:
  *             
@@ -390,7 +390,7 @@ EXTERN MergeStatus merge_partial_to_buf(partial_mat_t** partial_mats, int n_part
  * sample_id_consistency : samples described by stripes are inconsistent
  * square_mismatch       : inconsistency on denotation of square matrix
  */
-EXTERN MergeStatus merge_partial_to_buf_fp32(partial_mat_t** partial_mats, int n_partials, unsigned int nthreads, mat_t** result, float **buf);
+EXTERN MergeStatus merge_partial_to_matrix_fp32(partial_mat_t** partial_mats, int n_partials, unsigned int nthreads, mat_t** result, float **buf);
 
 
 #ifdef __cplusplus

--- a/sucpp/api.hpp
+++ b/sucpp/api.hpp
@@ -476,6 +476,39 @@ MergeStatus merge_partial_to_matrix(partial_dyn_mat_t* * partial_mats, int n_par
 MergeStatus merge_partial_to_matrix_fp32(partial_dyn_mat_t* * partial_mats, int n_partials, mat_full_fp32_t** result);
 
 
+/* Merge partial results
+ *
+ * partial_mats <partial_dyn_mat_t**> an array of partial_dyn_mat_t*
+ * n_partials <int> number of partial mats
+ * mmap_dir <const char *> Where to host the mmap file
+ * result <mat_full_fp64_t**> the full matrix, output parameters, this is initialized in the method so using **
+ *
+ * The following error codes are returned:
+ *
+ * merge_okay            : no problems
+ * incomplete_stripe_set : not all stripes needed to create a full matrix were foun
+ * sample_id_consistency : samples described by stripes are inconsistent
+ * square_mismatch       : inconsistency on denotation of square matrix
+ */
+MergeStatus merge_partial_to_mmap_matrix(partial_dyn_mat_t* * partial_mats, int n_partials, const char *mmap_dir, mat_full_fp64_t** result);
+
+/* Merge partial results
+ *
+ * partial_mats <partial_dyn_mat_t**> an array of partial_dyn_mat_t*
+ * n_partials <int> number of partial mats
+ * mmap_dir <const char *> Where to host the mmap file
+ * result <mat_full_fp32_t**> the full matrix, output parameters, this is initialized in the method so using **
+ *
+ * The following error codes are returned:
+ *
+ * merge_okay            : no problems
+ * incomplete_stripe_set : not all stripes needed to create a full matrix were foun
+ * sample_id_consistency : samples described by stripes are inconsistent
+ * square_mismatch       : inconsistency on denotation of square matrix
+ */
+MergeStatus merge_partial_to_mmap_matrix_fp32(partial_dyn_mat_t* * partial_mats, int n_partials, const char *mmap_dir, mat_full_fp32_t** result);
+
+
 #ifdef __cplusplus
 // TODO: only needed for testing, should be encased in a macro
 void set_tasks(std::vector<su::task_parameters> &tasks,

--- a/sucpp/api.hpp
+++ b/sucpp/api.hpp
@@ -347,7 +347,7 @@ EXTERN IOStatus read_partial(const char* filename, partial_mat_t** result);
 
 /* Merge partial results
  *
- * results <partial_mat_t**> an array of partial_mat_t*
+ * results <partial_mat_t**> an array of partial_mat_t*, the buffers will be destroyed in the process
  * n_partials <int> number of partial mats
  * merged <mat_t**> the full matrix, output parameters, this is initialized in the method so using **
  *
@@ -362,9 +362,9 @@ EXTERN MergeStatus merge_partial(partial_mat_t** partial_mats, int n_partials, u
 
 /* Merge partial results
  *
- * results <partial_mat_t**> an array of partial_mat_t*
+ * partial_mats <partial_mat_t**> an array of partial_mat_t*
  * n_partials <int> number of partial mats
- * merged <mat_t**> the full matrix, output parameters, this is initialized in the method so using **
+ * result <mat_t**> the full matrix, output parameters, this is initialized in the method so using **
  * buf <double**> the matrix, output parameters, this is initialized in the method so using **
  *
  * The following error codes are returned:
@@ -374,13 +374,13 @@ EXTERN MergeStatus merge_partial(partial_mat_t** partial_mats, int n_partials, u
  * sample_id_consistency : samples described by stripes are inconsistent
  * square_mismatch       : inconsistency on denotation of square matrix
  */
-EXTERN MergeStatus merge_partial_to_matrix(partial_mat_t** partial_mats, int n_partials, unsigned int nthreads, mat_t** result, double **buf);
+EXTERN MergeStatus merge_partial_to_matrix(const partial_mat_t*  const * partial_mats, int n_partials, mat_t** result, double **buf);
 
 /* Merge partial results
  *
- * results <partial_mat_t**> an array of partial_mat_t*
+ * partial_mats <partial_mat_t**> an array of partial_mat_t*
  * n_partials <int> number of partial mats
- * merged <mat_t**> the full matrix, output parameters, this is initialized in the method so using **
+ * result <mat_t**> the full matrix, output parameters, this is initialized in the method so using **
  * buf <double**> the matrix, output parameters, this is initialized in the method so using **
  *
  * The following error codes are returned:
@@ -390,7 +390,7 @@ EXTERN MergeStatus merge_partial_to_matrix(partial_mat_t** partial_mats, int n_p
  * sample_id_consistency : samples described by stripes are inconsistent
  * square_mismatch       : inconsistency on denotation of square matrix
  */
-EXTERN MergeStatus merge_partial_to_matrix_fp32(partial_mat_t** partial_mats, int n_partials, unsigned int nthreads, mat_t** result, float **buf);
+EXTERN MergeStatus merge_partial_to_matrix_fp32(const partial_mat_t* const * partial_mats, int n_partials, mat_t** result, float **buf);
 
 
 #ifdef __cplusplus

--- a/sucpp/api.hpp
+++ b/sucpp/api.hpp
@@ -43,7 +43,8 @@ typedef struct mat {
  * sample_ids <char**> the sample IDs of length n_samples.
  */
 typedef struct mat_full_fp64 {
-    unsigned int n_samples;
+    uint32_t n_samples;
+    uint32_t flags; //opaque, 0 for default behavior
     double* matrix;
     char** sample_ids;
 } mat_full_fp64_t;
@@ -55,7 +56,8 @@ typedef struct mat_full_fp64 {
  * sample_ids <char**> the sample IDs of length n_samples.
  */
 typedef struct mat_full_fp32 {
-    unsigned int n_samples;
+    uint32_t n_samples;
+    uint32_t flags; //opaque, 0 for default behavior
     float* matrix;
     char** sample_ids;
 } mat_full_fp32_t;

--- a/sucpp/api.hpp
+++ b/sucpp/api.hpp
@@ -36,6 +36,32 @@ typedef struct mat {
     char** sample_ids;
 } mat_t;
 
+/* a result matrix, full, fp64
+ *
+ * n_samples <uint> the number of samples.
+ * matrix <double*> the matrix values, n_sample**2 size
+ * sample_ids <char**> the sample IDs of length n_samples.
+ */
+typedef struct mat_full_fp64 {
+    unsigned int n_samples;
+    double* matrix;
+    char** sample_ids;
+} mat_full_fp64_t;
+
+/* a result matrix, full, fp32
+ *
+ * n_samples <uint> the number of samples.
+ * matrix <float*> the matrix values, n_sample**2 size
+ * sample_ids <char**> the sample IDs of length n_samples.
+ */
+typedef struct mat_full_fp32 {
+    unsigned int n_samples;
+    float* matrix;
+    char** sample_ids;
+} mat_full_fp32_t;
+
+
+
 /* a result vector
  *
  * n_samples <uint> the number of samples.
@@ -70,6 +96,8 @@ typedef struct partial_mat {
 } partial_mat_t;
 
 void destroy_mat(mat_t** result);
+void destroy_mat_full_fp64(mat_full_fp64_t** result);
+void destroy_mat_full_fp32(mat_full_fp32_t** result);
 void destroy_partial_mat(partial_mat_t** result);
 void destroy_results_vec(r_vec** result);
 
@@ -172,65 +200,60 @@ EXTERN IOStatus write_mat_hdf5_fp32_compressed(const char* filename, mat_t* resu
 /* Write a matrix object
  *
  * filename <const char*> the file to write into
- * result <mat_t*> the results object
- * buf <double *> buffer to write (must be NxN size)
+ * result <mat_full_t*> the results object
  *
  * The following error codes are returned:
  *
  * write_okay : no problems
  */
-EXTERN IOStatus write_mat_from_matrix(const char* filename, mat_t* result, const double *buf);
+EXTERN IOStatus write_mat_from_matrix(const char* filename, const mat_full_fp64_t* result);
 
 
 /* Write a matrix object from buffer using hdf5 format
  *
  * filename <const char*> the file to write into
- * result <mat_t*> the results object
- * buf <double *> buffer to write (must be NxN size)
+ * result <mat_full_t*> the results object
  *
  * The following error codes are returned:
  *
  * write_okay : no problems
  */
-EXTERN IOStatus write_mat_from_matrix_hdf5(const char* filename, mat_t* result, const double *buf);
+EXTERN IOStatus write_mat_from_matrix_hdf5(const char* filename, const mat_full_fp64_t* result);
 
 /* Write a matrix object from buffer using hdf5 format, using fp32 precision
  *
  * filename <const char*> the file to write into
- * result <mat_t*> the results object
- * buf <float *> buffer to write (must be NxN size)
+ * result <mat_full_fp32_t*> the results object
  *
  * The following error codes are returned:
  *
  * write_okay : no problems
  */
-EXTERN IOStatus write_mat_from_matrix_hdf5_fp32(const char* filename, mat_t* result, const float *buf);
+EXTERN IOStatus write_mat_from_matrix_hdf5_fp32(const char* filename, const mat_full_fp32_t* result);
 
 /* Write a matrix object from buffer using hdf5 format
  *
  * filename <const char*> the file to write into
- * result <mat_t*> the results object
- * buf <double *> buffer to write (must be NxN size)
+ * result <mat_full_fp64_t*> the results object
  * compress_level - 0=no compression, 1-9 higher is slower
  *
  * The following error codes are returned:
  *
  * write_okay : no problems
  */
-EXTERN IOStatus write_mat_from_matrix_hdf5_compressed(const char* filename, mat_t* result, const double *buf, unsigned int compress_level);
+EXTERN IOStatus write_mat_from_matrix_hdf5_compressed(const char* filename, const mat_full_fp64_t* result, unsigned int compress_level);
 
 /* Write a matrix object from buffer using hdf5 format, using fp32 precision
  *
  * filename <const char*> the file to write into
- * result <mat_t*> the results object
- * buf <float *> buffer to write (must be NxN size)
+ * result <mat_full_fp32_t*> the results object
  * compress_level - 0=no compression, 1-9 higher is slower
  *
  * The following error codes are returned:
  *
  * write_okay : no problems
  */
-EXTERN IOStatus write_mat_from_matrix_hdf5_fp32_compressed(const char* filename, mat_t* result, const float *buf, unsigned int compress_level);
+EXTERN IOStatus write_mat_from_matrix_hdf5_fp32_compressed(const char* filename, const mat_full_fp32_t* result, unsigned int compress_level);
 
 /* Write a series
  *
@@ -328,7 +351,7 @@ EXTERN ComputeStatus partial(const char* biom_filename, const char* tree_filenam
  * ### FOOTER ###
  * <MAGIC>              : char, e.g., SSU-PARTIAL-01, same as starting magic
  */
-EXTERN IOStatus write_partial(const char* filename, partial_mat_t* result);
+EXTERN IOStatus write_partial(const char* filename, const partial_mat_t* result);
 
 /* Read a partial matrix object
  *
@@ -364,8 +387,7 @@ EXTERN MergeStatus merge_partial(partial_mat_t** partial_mats, int n_partials, u
  *
  * partial_mats <partial_mat_t**> an array of partial_mat_t*
  * n_partials <int> number of partial mats
- * result <mat_t**> the full matrix, output parameters, this is initialized in the method so using **
- * buf <double**> the matrix, output parameters, this is initialized in the method so using **
+ * result <mat_full_fp64_t**> the full matrix, output parameters, this is initialized in the method so using **
  *
  * The following error codes are returned:
  *
@@ -374,14 +396,13 @@ EXTERN MergeStatus merge_partial(partial_mat_t** partial_mats, int n_partials, u
  * sample_id_consistency : samples described by stripes are inconsistent
  * square_mismatch       : inconsistency on denotation of square matrix
  */
-EXTERN MergeStatus merge_partial_to_matrix(const partial_mat_t*  const * partial_mats, int n_partials, mat_t** result, double **buf);
+MergeStatus merge_partial_to_matrix(const partial_mat_t*  const * partial_mats, int n_partials, mat_full_fp64_t** result);
 
 /* Merge partial results
  *
  * partial_mats <partial_mat_t**> an array of partial_mat_t*
  * n_partials <int> number of partial mats
- * result <mat_t**> the full matrix, output parameters, this is initialized in the method so using **
- * buf <double**> the matrix, output parameters, this is initialized in the method so using **
+ * result <mat_full_fp32_t**> the full matrix, output parameters, this is initialized in the method so using **
  *
  * The following error codes are returned:
  *             
@@ -390,7 +411,7 @@ EXTERN MergeStatus merge_partial_to_matrix(const partial_mat_t*  const * partial
  * sample_id_consistency : samples described by stripes are inconsistent
  * square_mismatch       : inconsistency on denotation of square matrix
  */
-EXTERN MergeStatus merge_partial_to_matrix_fp32(const partial_mat_t* const * partial_mats, int n_partials, mat_t** result, float **buf);
+MergeStatus merge_partial_to_matrix_fp32(const partial_mat_t* const * partial_mats, int n_partials, mat_full_fp32_t** result);
 
 
 #ifdef __cplusplus

--- a/sucpp/api.hpp
+++ b/sucpp/api.hpp
@@ -192,7 +192,7 @@ EXTERN IOStatus write_mat_from_matrix(const char* filename, mat_t* result, const
  *
  * write_okay : no problems
  */
-EXTERN IOStatus write_mat_from_mtrix_hdf5(const char* filename, mat_t* result, const double *buf);
+EXTERN IOStatus write_mat_from_matrix_hdf5(const char* filename, mat_t* result, const double *buf);
 
 /* Write a matrix object from buffer using hdf5 format, using fp32 precision
  *
@@ -374,7 +374,7 @@ EXTERN MergeStatus merge_partial(partial_mat_t** partial_mats, int n_partials, u
  * sample_id_consistency : samples described by stripes are inconsistent
  * square_mismatch       : inconsistency on denotation of square matrix
  */
-EXTERN MergeStatus merge_partial_to_mtrix(partial_mat_t** partial_mats, int n_partials, unsigned int nthreads, mat_t** result, double **buf);
+EXTERN MergeStatus merge_partial_to_matrix(partial_mat_t** partial_mats, int n_partials, unsigned int nthreads, mat_t** result, double **buf);
 
 /* Merge partial results
  *

--- a/sucpp/api.hpp
+++ b/sucpp/api.hpp
@@ -170,6 +170,56 @@ EXTERN IOStatus write_mat_hdf5_compressed(const char* filename, mat_t* result, u
 EXTERN IOStatus write_mat_hdf5_fp32_compressed(const char* filename, mat_t* result, unsigned int compress_level);
 
 
+/* Write a matrix object from buffer using hdf5 format
+ *
+ * filename <const char*> the file to write into
+ * result <mat_t*> the results object
+ * buf <double *> buffer to write (must be NN size)
+ *
+ * The following error codes are returned:
+ *
+ * write_okay : no problems
+ */
+EXTERN IOStatus write_mat_from_buf_hdf5(const char* filename, mat_t* result, const double *buf);
+
+/* Write a matrix object from buffer using hdf5 format, using fp32 precision
+ *
+ * filename <const char*> the file to write into
+ * result <mat_t*> the results object
+ * buf <double *> buffer to write (must be NN size)
+ *
+ * The following error codes are returned:
+ *
+ * write_okay : no problems
+ */
+EXTERN IOStatus write_mat_from_buf_hdf5_fp32(const char* filename, mat_t* result, const float *buf);
+
+/* Write a matrix object from buffer using hdf5 format
+ *
+ * filename <const char*> the file to write into
+ * result <mat_t*> the results object
+ * buf <double *> buffer to write (must be NN size)
+ * compress_level - 0=no compression, 1-9 higher is slower
+ *
+ * The following error codes are returned:
+ *
+ * write_okay : no problems
+ */
+EXTERN IOStatus write_mat_from_buf_hdf5_compressed(const char* filename, mat_t* result, const double *buf, unsigned int compress_level);
+
+/* Write a matrix object from buffer using hdf5 format, using fp32 precision
+ *
+ * filename <const char*> the file to write into
+ * result <mat_t*> the results object
+ * buf <double *> buffer to write (must be NN size)
+ * compress_level - 0=no compression, 1-9 higher is slower
+ *
+ * The following error codes are returned:
+ *
+ * write_okay : no problems
+ */
+EXTERN IOStatus write_mat_from_buf_hdf5_fp32_compressed(const char* filename, mat_t* result, const float *buf, unsigned int compress_level);
+
 /* Write a series
  *
  * filename <const char*> the file to write into

--- a/sucpp/api.hpp
+++ b/sucpp/api.hpp
@@ -445,7 +445,7 @@ EXTERN MergeStatus merge_partial(partial_mat_t** partial_mats, int n_partials, u
 
 /* Merge partial results
  *
- * partial_mats <partial_mat_t**> an array of partial_mat_t*
+ * partial_mats <partial_dyn_mat_t**> an array of partial_dyn_mat_t*
  * n_partials <int> number of partial mats
  * result <mat_full_fp64_t**> the full matrix, output parameters, this is initialized in the method so using **
  *
@@ -456,11 +456,11 @@ EXTERN MergeStatus merge_partial(partial_mat_t** partial_mats, int n_partials, u
  * sample_id_consistency : samples described by stripes are inconsistent
  * square_mismatch       : inconsistency on denotation of square matrix
  */
-MergeStatus merge_partial_to_matrix(const partial_mat_t*  const * partial_mats, int n_partials, mat_full_fp64_t** result);
+MergeStatus merge_partial_to_matrix(partial_dyn_mat_t* * partial_mats, int n_partials, mat_full_fp64_t** result);
 
 /* Merge partial results
  *
- * partial_mats <partial_mat_t**> an array of partial_mat_t*
+ * partial_mats <partial_dyn_mat_t**> an array of partial_dyn_mat_t*
  * n_partials <int> number of partial mats
  * result <mat_full_fp32_t**> the full matrix, output parameters, this is initialized in the method so using **
  *
@@ -471,7 +471,7 @@ MergeStatus merge_partial_to_matrix(const partial_mat_t*  const * partial_mats, 
  * sample_id_consistency : samples described by stripes are inconsistent
  * square_mismatch       : inconsistency on denotation of square matrix
  */
-MergeStatus merge_partial_to_matrix_fp32(const partial_mat_t* const * partial_mats, int n_partials, mat_full_fp32_t** result);
+MergeStatus merge_partial_to_matrix_fp32(partial_dyn_mat_t* * partial_mats, int n_partials, mat_full_fp32_t** result);
 
 
 #ifdef __cplusplus

--- a/sucpp/api.hpp
+++ b/sucpp/api.hpp
@@ -360,6 +360,39 @@ EXTERN IOStatus read_partial(const char* filename, partial_mat_t** result);
  */
 EXTERN MergeStatus merge_partial(partial_mat_t** partial_mats, int n_partials, unsigned int nthreads, mat_t** result);
 
+/* Merge partial results
+ *
+ * results <partial_mat_t**> an array of partial_mat_t*
+ * n_partials <int> number of partial mats
+ * merged <mat_t**> the full matrix, output parameters, this is initialized in the method so using **
+ * buf <double**> the buffer, output parameters, this is initialized in the method so using **
+ *
+ * The following error codes are returned:
+ *
+ * merge_okay            : no problems
+ * incomplete_stripe_set : not all stripes needed to create a full matrix were foun
+ * sample_id_consistency : samples described by stripes are inconsistent
+ * square_mismatch       : inconsistency on denotation of square matrix
+ */
+EXTERN MergeStatus merge_partial_to_buf(partial_mat_t** partial_mats, int n_partials, unsigned int nthreads, mat_t** result, double **buf);
+
+/* Merge partial results
+ *
+ * results <partial_mat_t**> an array of partial_mat_t*
+ * n_partials <int> number of partial mats
+ * merged <mat_t**> the full matrix, output parameters, this is initialized in the method so using **
+ * buf <double**> the buffer, output parameters, this is initialized in the method so using **
+ *
+ * The following error codes are returned:
+ *             
+ * merge_okay            : no problems
+ * incomplete_stripe_set : not all stripes needed to create a full matrix were foun
+ * sample_id_consistency : samples described by stripes are inconsistent
+ * square_mismatch       : inconsistency on denotation of square matrix
+ */
+EXTERN MergeStatus merge_partial_to_buf_fp32(partial_mat_t** partial_mats, int n_partials, unsigned int nthreads, mat_t** result, float **buf);
+
+
 #ifdef __cplusplus
 // TODO: only needed for testing, should be encased in a macro
 void set_tasks(std::vector<su::task_parameters> &tasks,
@@ -369,4 +402,5 @@ void set_tasks(std::vector<su::task_parameters> &tasks,
                unsigned int stripe_stop,
                bool bypass_tips,
                unsigned int nthreads);
+
 #endif

--- a/sucpp/api.hpp
+++ b/sucpp/api.hpp
@@ -169,6 +169,18 @@ EXTERN IOStatus write_mat_hdf5_compressed(const char* filename, mat_t* result, u
  */
 EXTERN IOStatus write_mat_hdf5_fp32_compressed(const char* filename, mat_t* result, unsigned int compress_level);
 
+/* Write a matrix object
+ *
+ * filename <const char*> the file to write into
+ * result <mat_t*> the results object
+ * buf <double *> buffer to write (must be NN size)
+ *
+ * The following error codes are returned:
+ *
+ * write_okay : no problems
+ */
+EXTERN IOStatus write_mat_from_buf(const char* filename, mat_t* result, const double *buf);
+
 
 /* Write a matrix object from buffer using hdf5 format
  *
@@ -186,7 +198,7 @@ EXTERN IOStatus write_mat_from_buf_hdf5(const char* filename, mat_t* result, con
  *
  * filename <const char*> the file to write into
  * result <mat_t*> the results object
- * buf <double *> buffer to write (must be NN size)
+ * buf <float *> buffer to write (must be NN size)
  *
  * The following error codes are returned:
  *
@@ -211,7 +223,7 @@ EXTERN IOStatus write_mat_from_buf_hdf5_compressed(const char* filename, mat_t* 
  *
  * filename <const char*> the file to write into
  * result <mat_t*> the results object
- * buf <double *> buffer to write (must be NN size)
+ * buf <float *> buffer to write (must be NN size)
  * compress_level - 0=no compression, 1-9 higher is slower
  *
  * The following error codes are returned:

--- a/sucpp/su.cpp
+++ b/sucpp/su.cpp
@@ -139,12 +139,10 @@ int mode_partial_report(const std::string table_filename, int npartials, bool ba
 } 
 
 int mode_merge_partial_fp32(const char * output_filename, Format format_val,
-                            size_t partials_size, partial_mat_t** partial_mats,
-                            unsigned int nthreads) {
-    mat_t *result = NULL;
-    float *buf2d = NULL;
+                            size_t partials_size, const partial_mat_t* const * partial_mats) {
+    mat_full_fp32_t *result = NULL;
 
-    MergeStatus status = merge_partial_to_matrix_fp32(partial_mats, partials_size, &result, &buf2d);
+    MergeStatus status = merge_partial_to_matrix_fp32(partial_mats, partials_size, &result);
 
     if(status != merge_okay) {
         std::ostringstream msg;
@@ -155,12 +153,11 @@ int mode_merge_partial_fp32(const char * output_filename, Format format_val,
 
     IOStatus iostatus;
     if (format_val==format_hdf5c_fp32) {
-     iostatus = write_mat_from_matrix_hdf5_fp32_compressed(output_filename, result, buf2d, 5);
+     iostatus = write_mat_from_matrix_hdf5_fp32_compressed(output_filename, result, 5);
     } else {           
-     iostatus = write_mat_from_matrix_hdf5_fp32(output_filename, result, buf2d);
+     iostatus = write_mat_from_matrix_hdf5_fp32(output_filename, result);
     }   
-    free(buf2d);
-    destroy_mat(&result);
+    destroy_mat_full_fp32(&result);
     
     if(iostatus != write_okay) {
         std::ostringstream msg; 
@@ -173,12 +170,10 @@ int mode_merge_partial_fp32(const char * output_filename, Format format_val,
 }
 
 int mode_merge_partial_fp64(const char * output_filename, Format format_val,
-                            size_t partials_size, partial_mat_t** partial_mats,
-                            unsigned int nthreads) {
-    mat_t *result = NULL;
-    double *buf2d = NULL;
+                            size_t partials_size, const partial_mat_t* const * partial_mats) {
+    mat_full_fp64_t *result = NULL;
 
-    MergeStatus status = merge_partial_to_matrix(partial_mats, partials_size, &result, &buf2d);
+    MergeStatus status = merge_partial_to_matrix(partial_mats, partials_size, &result);
 
     if(status != merge_okay) {
         std::ostringstream msg;
@@ -189,14 +184,13 @@ int mode_merge_partial_fp64(const char * output_filename, Format format_val,
 
     IOStatus iostatus;
     if (format_val==format_hdf5_fp64) {
-     iostatus = write_mat_from_matrix_hdf5(output_filename, result, buf2d);
+     iostatus = write_mat_from_matrix_hdf5(output_filename, result);
     } else if (format_val==format_hdf5c_fp64) {
-     iostatus = write_mat_from_matrix_hdf5_compressed(output_filename, result, buf2d, 5);
+     iostatus = write_mat_from_matrix_hdf5_compressed(output_filename, result, 5);
     } else {
-     iostatus = write_mat(output_filename, result);
+     iostatus = write_mat_from_matrix(output_filename, result);
     }
-    free(buf2d);
-    destroy_mat(&result);
+    destroy_mat_full_fp64(&result);
 
     if(iostatus != write_okay) {
         std::ostringstream msg;
@@ -209,8 +203,8 @@ int mode_merge_partial_fp64(const char * output_filename, Format format_val,
 }
 
 
-int mode_merge_partial(std::string output_filename, Format format_val,
-                       std::string partial_pattern,
+int mode_merge_partial(const std::string &output_filename, Format format_val,
+                       const std::string &partial_pattern,
                        unsigned int nthreads) {
     if(output_filename.empty()) {
         err("output filename missing");
@@ -239,11 +233,11 @@ int mode_merge_partial(std::string output_filename, Format format_val,
 
     int status;
     if ((format_val==format_hdf5_fp64) || (format_val==format_hdf5c_fp64)) {
-     status = mode_merge_partial_fp64(output_filename.c_str(), format_val, partials.size(), partial_mats, nthreads);
+     status = mode_merge_partial_fp64(output_filename.c_str(), format_val, partials.size(), partial_mats);
     } else if ((format_val==format_hdf5_fp32) || (format_val==format_hdf5c_fp32)) {
-     status = mode_merge_partial_fp32(output_filename.c_str(), format_val, partials.size(), partial_mats, nthreads);
+     status = mode_merge_partial_fp32(output_filename.c_str(), format_val, partials.size(), partial_mats);
     } else {
-     status = mode_merge_partial_fp64(output_filename.c_str(), format_val, partials.size(), partial_mats, nthreads);
+     status = mode_merge_partial_fp64(output_filename.c_str(), format_val, partials.size(), partial_mats);
     }
 
     for(size_t i = 0; i < partials.size(); i++) {

--- a/sucpp/su.cpp
+++ b/sucpp/su.cpp
@@ -144,7 +144,7 @@ int mode_merge_partial_fp32(const char * output_filename, Format format_val,
     mat_t *result = NULL;
     float *buf2d = NULL;
 
-    MergeStatus status = merge_partial_to_matrix_fp32(partial_mats, partials_size, nthreads, &result, &buf2d);
+    MergeStatus status = merge_partial_to_matrix_fp32(partial_mats, partials_size, &result, &buf2d);
 
     if(status != merge_okay) {
         std::ostringstream msg;
@@ -178,7 +178,7 @@ int mode_merge_partial_fp64(const char * output_filename, Format format_val,
     mat_t *result = NULL;
     double *buf2d = NULL;
 
-    MergeStatus status = merge_partial_to_matrix(partial_mats, partials_size, nthreads, &result, &buf2d);
+    MergeStatus status = merge_partial_to_matrix(partial_mats, partials_size, &result, &buf2d);
 
     if(status != merge_okay) {
         std::ostringstream msg;
@@ -244,6 +244,10 @@ int mode_merge_partial(std::string output_filename, Format format_val,
      status = mode_merge_partial_fp32(output_filename.c_str(), format_val, partials.size(), partial_mats, nthreads);
     } else {
      status = mode_merge_partial_fp64(output_filename.c_str(), format_val, partials.size(), partial_mats, nthreads);
+    }
+
+    for(size_t i = 0; i < partials.size(); i++) {
+      destroy_partial_mat(&partial_mats[i]);
     }
 
     return status;

--- a/sucpp/su.cpp
+++ b/sucpp/su.cpp
@@ -139,7 +139,7 @@ int mode_partial_report(const std::string table_filename, int npartials, bool ba
 } 
 
 int mode_merge_partial_fp32(const char * output_filename, Format format_val,
-                            size_t partials_size, const partial_mat_t* const * partial_mats) {
+                            size_t partials_size, partial_dyn_mat_t* * partial_mats) {
     mat_full_fp32_t *result = NULL;
 
     MergeStatus status = merge_partial_to_matrix_fp32(partial_mats, partials_size, &result);
@@ -170,7 +170,7 @@ int mode_merge_partial_fp32(const char * output_filename, Format format_val,
 }
 
 int mode_merge_partial_fp64(const char * output_filename, Format format_val,
-                            size_t partials_size, const partial_mat_t* const * partial_mats) {
+                            size_t partials_size, partial_dyn_mat_t* * partial_mats) {
     mat_full_fp64_t *result = NULL;
 
     MergeStatus status = merge_partial_to_matrix(partial_mats, partials_size, &result);
@@ -220,9 +220,9 @@ int mode_merge_partial(const std::string &output_filename, Format format_val,
     }
     
     std::vector<std::string> partials = glob(partial_pattern);
-    partial_mat_t** partial_mats = (partial_mat_t**)malloc(sizeof(partial_mat_t*) * partials.size());
+    partial_dyn_mat_t** partial_mats = (partial_dyn_mat_t**)malloc(sizeof(partial_dyn_mat_t*) * partials.size());
     for(size_t i = 0; i < partials.size(); i++) {
-        IOStatus io_err = read_partial(partials[i].c_str(), &partial_mats[i]);
+        IOStatus io_err = read_partial_header(partials[i].c_str(), &partial_mats[i]);
         if(io_err != read_okay) {
             std::ostringstream msg;
             msg << "Unable to parse file (" << partials[i] << "); err " << io_err;
@@ -241,7 +241,7 @@ int mode_merge_partial(const std::string &output_filename, Format format_val,
     }
 
     for(size_t i = 0; i < partials.size(); i++) {
-      destroy_partial_mat(&partial_mats[i]);
+      destroy_partial_dyn_mat(&partial_mats[i]);
     }
 
     return status;

--- a/sucpp/su.cpp
+++ b/sucpp/su.cpp
@@ -144,7 +144,7 @@ int mode_merge_partial_fp32(const char * output_filename, Format format_val,
     mat_t *result = NULL;
     float *buf2d = NULL;
 
-    MergeStatus status = merge_partial_to_buf_fp32(partial_mats, partials_size, nthreads, &result, &buf2d);
+    MergeStatus status = merge_partial_to_matrix_fp32(partial_mats, partials_size, nthreads, &result, &buf2d);
 
     if(status != merge_okay) {
         std::ostringstream msg;
@@ -155,9 +155,9 @@ int mode_merge_partial_fp32(const char * output_filename, Format format_val,
 
     IOStatus iostatus;
     if (format_val==format_hdf5c_fp32) {
-     iostatus = write_mat_from_buf_hdf5_fp32_compressed(output_filename, result, buf2d, 5);
+     iostatus = write_mat_from_matrix_hdf5_fp32_compressed(output_filename, result, buf2d, 5);
     } else {           
-     iostatus = write_mat_from_buf_hdf5_fp32(output_filename, result, buf2d);
+     iostatus = write_mat_from_matrix_hdf5_fp32(output_filename, result, buf2d);
     }   
     free(buf2d);
     destroy_mat(&result);
@@ -178,7 +178,7 @@ int mode_merge_partial_fp64(const char * output_filename, Format format_val,
     mat_t *result = NULL;
     double *buf2d = NULL;
 
-    MergeStatus status = merge_partial_to_buf(partial_mats, partials_size, nthreads, &result, &buf2d);
+    MergeStatus status = merge_partial_to_matrix(partial_mats, partials_size, nthreads, &result, &buf2d);
 
     if(status != merge_okay) {
         std::ostringstream msg;
@@ -189,9 +189,9 @@ int mode_merge_partial_fp64(const char * output_filename, Format format_val,
 
     IOStatus iostatus;
     if (format_val==format_hdf5_fp64) {
-     iostatus = write_mat_from_buf_hdf5(output_filename, result, buf2d);
+     iostatus = write_mat_from_matrix_hdf5(output_filename, result, buf2d);
     } else if (format_val==format_hdf5c_fp64) {
-     iostatus = write_mat_from_buf_hdf5_compressed(output_filename, result, buf2d, 5);
+     iostatus = write_mat_from_matrix_hdf5_compressed(output_filename, result, buf2d, 5);
     } else {
      iostatus = write_mat(output_filename, result);
     }

--- a/sucpp/test_api.cpp
+++ b/sucpp/test_api.cpp
@@ -424,6 +424,12 @@ void test_merge_partial_dyn_mat() {
     ASSERT(pm2->stripes[0]==NULL);
     ASSERT(pm1->stripes[0]==NULL);
     ASSERT(pm1->stripes[1]==NULL);
+    destroy_partial_dyn_mat(&pm1);
+    destroy_partial_dyn_mat(&pm2);
+
+
+    pm1 = make_test_pdm(1);
+    pm2 = make_test_pdm(2);
 
 
     // error checking
@@ -481,9 +487,7 @@ void test_merge_partial_dyn_mat() {
     */
    
     destroy_mat_full_fp64(&obs);
-    destroy_partial_dyn_mat(&pm1);
-    destroy_partial_dyn_mat(&pm2);
-    destroy_partial_dyn_mat(&pm3);
+    // note, we cannot cleanly destroy the partial_dyn_mat_t structures that have been hacked by hand
 
     SUITE_END();
 }

--- a/sucpp/test_api.cpp
+++ b/sucpp/test_api.cpp
@@ -48,7 +48,7 @@ void SUITE_END() {
 //    SUITE_END();
 //}
 //
-partial_mat_t* make_test_pm() {
+partial_mat_t* make_test_pm(int case) {
     partial_mat_t* pm = (partial_mat_t*)malloc(sizeof(partial_mat_t));
     pm->n_samples = 6;
     pm->sample_ids = (char**)malloc(sizeof(char*) * 6);
@@ -64,14 +64,38 @@ partial_mat_t* make_test_pm() {
     pm->sample_ids[4][0] = 'E'; pm->sample_ids[4][1] = '\0';
     pm->sample_ids[5] = (char*)malloc(sizeof(char) * 2);
     pm->sample_ids[5][0] = 'F'; pm->sample_ids[5][1] = '\0';
-    pm->stripes = (double**)malloc(sizeof(double*) * 3);
-    pm->stripes[0] = (double*)malloc(sizeof(double) * 6);
-    pm->stripes[0][0] = 1; pm->stripes[0][1] = 2; pm->stripes[0][2] = 3; pm->stripes[0][3] = 4; pm->stripes[0][4] = 5; pm->stripes[0][5] = 6;
-    pm->stripes[1] = (double*)malloc(sizeof(double) * 6);
-    pm->stripes[1][0] = 7; pm->stripes[1][1] = 8; pm->stripes[1][2] = 9; pm->stripes[1][3] = 10; pm->stripes[1][4] = 11; pm->stripes[1][5] = 12;
-    pm->stripes[2] = (double*)malloc(sizeof(double) * 6);
-    pm->stripes[2][0] = 13; pm->stripes[2][1] = 14; pm->stripes[2][2] = 15; pm->stripes[2][3] = 16; pm->stripes[2][4] = 17; pm->stripes[2][5] = 18;
 
+    if (case==3) {
+      pm->stripe_start = 6;
+      pm->stripe_stop = 9;
+      pm->stripe_total = 9;
+      pm->is_upper_triangle = true;
+      pm->stripes = (double**)malloc(sizeof(double*) * 3);
+      pm->stripes[0] = (double*)malloc(sizeof(double) * 6);
+      pm->stripes[0][0] = 1; pm->stripes[0][1] = 2; pm->stripes[0][2] = 3; pm->stripes[0][3] = 4; pm->stripes[0][4] = 5; pm->stripes[0][5] = 6;
+      pm->stripes[1] = (double*)malloc(sizeof(double) * 6);
+      pm->stripes[1][0] = 7; pm->stripes[1][1] = 8; pm->stripes[1][2] = 9; pm->stripes[1][3] = 10; pm->stripes[1][4] = 11; pm->stripes[1][5] = 12;
+      pm->stripes[2] = (double*)malloc(sizeof(double) * 6);
+      pm->stripes[2][0] = 13; pm->stripes[2][1] = 14; pm->stripes[2][2] = 15; pm->stripes[2][3] = 16; pm->stripes[2][4] = 17; pm->stripes[2][5] = 18;
+    } else if (case==1) {
+      pm->stripe_start = 0;
+      pm->stripe_stop = 2;
+      pm->stripe_total = 3;
+      pm->is_upper_triangle = true;
+      pm->stripes = (double**)malloc(sizeof(double*) * 2);
+      pm->stripes[0] = (double*)malloc(sizeof(double) * 6);
+      pm->stripes[0][0] = 1; pm1->stripes[0][1] = 2; pm1->stripes[0][2] = 3; pm1->stripes[0][3] = 4; pm1->stripes[0][4] = 5; pm1->stripes[0][5] = 6;
+      pm->stripes[1] = (double*)malloc(sizeof(double) * 6);
+      pm->stripes[1][0] = 7; pm1->stripes[1][1] = 8; pm1->stripes[1][2] = 9; pm1->stripes[1][3] = 10; pm1->stripes[1][4] = 11; pm1->stripes[1][5] = 12;
+    } else { // assume 2
+      pm->stripe_start = 2;
+      pm->stripe_stop = 3;
+      pm->stripe_total = 3;
+      pm->is_upper_triangle = true;
+      pm->stripes = (double**)malloc(sizeof(double*) * 1);
+      pm->stripes[0] = (double*)malloc(sizeof(double) * 6);
+      pm->stripes[0][0] = 16; pm2->stripes[0][1] = 17; pm2->stripes[0][2] = 18; pm2->stripes[0][3] = 16; pm2->stripes[0][4] = 17; pm2->stripes[0][5] = 18;
+    }
     return pm;
 }
 
@@ -270,53 +294,8 @@ void test_merge_partial_mat() {
     SUITE_START("test merge partial_mat_t");
 
     // the easy test
-    partial_mat_t* pm1 = (partial_mat_t*)malloc(sizeof(partial_mat_t));
-    pm1->n_samples = 6;
-    pm1->sample_ids = (char**)malloc(sizeof(char*) * 6);
-    pm1->sample_ids[0] = (char*)malloc(sizeof(char) * 2);
-    pm1->sample_ids[0][0] = 'A'; pm1->sample_ids[0][1] = '\0';
-    pm1->sample_ids[1] = (char*)malloc(sizeof(char) * 2);
-    pm1->sample_ids[1][0] = 'B'; pm1->sample_ids[1][1] = '\0';
-    pm1->sample_ids[2] = (char*)malloc(sizeof(char) * 3);
-    pm1->sample_ids[2][0] = 'C'; pm1->sample_ids[2][1] = 'x'; pm1->sample_ids[2][2] = '\0';
-    pm1->sample_ids[3] = (char*)malloc(sizeof(char) * 2);
-    pm1->sample_ids[3][0] = 'D'; pm1->sample_ids[3][1] = '\0';
-    pm1->sample_ids[4] = (char*)malloc(sizeof(char) * 2);
-    pm1->sample_ids[4][0] = 'E'; pm1->sample_ids[4][1] = '\0';
-    pm1->sample_ids[5] = (char*)malloc(sizeof(char) * 2);
-    pm1->sample_ids[5][0] = 'F'; pm1->sample_ids[5][1] = '\0';
-    pm1->stripes = (double**)malloc(sizeof(double*) * 2);
-    pm1->stripes[0] = (double*)malloc(sizeof(double) * 6);
-    pm1->stripes[0][0] = 1; pm1->stripes[0][1] = 2; pm1->stripes[0][2] = 3; pm1->stripes[0][3] = 4; pm1->stripes[0][4] = 5; pm1->stripes[0][5] = 6;
-    pm1->stripes[1] = (double*)malloc(sizeof(double) * 6);
-    pm1->stripes[1][0] = 7; pm1->stripes[1][1] = 8; pm1->stripes[1][2] = 9; pm1->stripes[1][3] = 10; pm1->stripes[1][4] = 11; pm1->stripes[1][5] = 12;
-    pm1->stripe_start = 0;
-    pm1->stripe_stop = 2;
-    pm1->stripe_total = 3;
-    pm1->is_upper_triangle = true;
-    
-    partial_mat_t* pm2 = (partial_mat_t*)malloc(sizeof(partial_mat_t));
-    pm2->n_samples = 6;
-    pm2->sample_ids = (char**)malloc(sizeof(char*) * 6);
-    pm2->sample_ids[0] = (char*)malloc(sizeof(char) * 2);
-    pm2->sample_ids[0][0] = 'A'; pm2->sample_ids[0][1] = '\0';
-    pm2->sample_ids[1] = (char*)malloc(sizeof(char) * 2);
-    pm2->sample_ids[1][0] = 'B'; pm2->sample_ids[1][1] = '\0';
-    pm2->sample_ids[2] = (char*)malloc(sizeof(char) * 3);
-    pm2->sample_ids[2][0] = 'C'; pm2->sample_ids[2][1] = 'x'; pm2->sample_ids[2][2] = '\0';
-    pm2->sample_ids[3] = (char*)malloc(sizeof(char) * 2);
-    pm2->sample_ids[3][0] = 'D'; pm2->sample_ids[3][1] = '\0';
-    pm2->sample_ids[4] = (char*)malloc(sizeof(char) * 2);
-    pm2->sample_ids[4][0] = 'E'; pm2->sample_ids[4][1] = '\0';
-    pm2->sample_ids[5] = (char*)malloc(sizeof(char) * 2);
-    pm2->sample_ids[5][0] = 'F'; pm2->sample_ids[5][1] = '\0';
-    pm2->stripes = (double**)malloc(sizeof(double*) * 1);
-    pm2->stripes[0] = (double*)malloc(sizeof(double) * 6);
-    pm2->stripes[0][0] = 16; pm2->stripes[0][1] = 17; pm2->stripes[0][2] = 18; pm2->stripes[0][3] = 16; pm2->stripes[0][4] = 17; pm2->stripes[0][5] = 18;
-    pm2->stripe_start = 2;
-    pm2->stripe_stop = 3;
-    pm2->stripe_total = 3;
-    pm2->is_upper_triangle = true;
+    partial_mat_t* pm1 = make_test_pm(1);
+    partial_mat_t* pm2 = make_test_pm(2);
 
     mat_t* exp = mat_three_rep();
 
@@ -364,14 +343,7 @@ void test_merge_partial_mat() {
     pm2->stripe_total = 9;
     pm2->is_upper_triangle = true;
     
-    partial_mat_t* pm3 = (partial_mat_t*)malloc(sizeof(partial_mat_t));
-    pm3 = make_test_pm();
-    pm3->stripe_start = 6;
-    pm3->stripe_stop = 9;
-    pm3->stripe_total = 9;
-    pm3->is_upper_triangle = true;
-
-    exp = mat_three_rep();
+    partial_mat_t* pm3 = make_test_pm(3);;
 
     partial_mat_t* pms_err[3];
 

--- a/sucpp/test_api.cpp
+++ b/sucpp/test_api.cpp
@@ -613,6 +613,7 @@ void test_merge_partial_mmap() {
     merge_status err = merge_partial_to_mmap_matrix_fp32(pms, 2, "/tmp", &obs);
     ASSERT(err == merge_okay);
     ASSERT(obs->n_samples == exp->n_samples);
+    ASSERT(obs->flags != 0);
     for(unsigned int i = 0; i < (obs->n_samples*obs->n_samples); i++) {
         ASSERT(obs->matrix[i] == exp->matrix[i]);
     }
@@ -626,6 +627,24 @@ void test_merge_partial_mmap() {
     destroy_mat_full_fp32(&obs);
     destroy_partial_dyn_mat(&pm1);
     destroy_partial_dyn_mat(&pm2);
+
+    // test failure due to FS problems
+
+    ierr = read_partial_header("/tmp/ssu_io_1.dat", &pm1);
+    ASSERT(ierr == read_okay);
+
+    ierr = read_partial_header("/tmp/ssu_io_2.dat", &pm2);
+    ASSERT(ierr == read_okay);
+
+    pms[0] = pm1;
+    pms[1] = pm2;
+
+
+    err = merge_partial_to_mmap_matrix_fp32(pms, 2, "/santa/goes/skiing", &obs);
+    ASSERT(err != merge_okay);
+    destroy_partial_dyn_mat(&pm1);
+    destroy_partial_dyn_mat(&pm2);
+
     destroy_partial_mat(&s1);
     destroy_partial_mat(&s2);
 

--- a/sucpp/test_api.cpp
+++ b/sucpp/test_api.cpp
@@ -148,6 +148,7 @@ template<class TMat, class TReal>
 TMat* mat_full_three_rep() {
     TMat* res = (TMat*)malloc(sizeof(TMat));
     res->n_samples = 6;
+    res->flags=0;
     res->matrix = (TReal*)malloc(sizeof(TReal) * 36);
     TReal * m=res->matrix ;
     m[ 0] =  0; m[ 1] =  1; m[ 2] =  7; m[ 3] = 16; m[ 4] = 11; m[ 5] =  6;

--- a/sucpp/test_api.cpp
+++ b/sucpp/test_api.cpp
@@ -117,26 +117,93 @@ void test_read_write_partial_mat() {
     io_status err = write_partial("/tmp/ssu_io.dat", pm);
     ASSERT(err == write_okay);
 
-    partial_mat_t *obs = NULL;
-    err = read_partial("/tmp/ssu_io.dat", &obs);
+    {
+      partial_mat_t *obs = NULL;
+      err = read_partial("/tmp/ssu_io.dat", &obs);
     
-    ASSERT(err == read_okay);
-    ASSERT(obs->n_samples == 6);
-    ASSERT(obs->stripe_start == 0);
-    ASSERT(obs->stripe_stop == 3);
-    ASSERT(obs->stripe_total == 3);
-    ASSERT(strcmp(obs->sample_ids[0], "A") == 0);
-    ASSERT(strcmp(obs->sample_ids[1], "B") == 0);
-    ASSERT(strcmp(obs->sample_ids[2], "Cx") == 0);
-    ASSERT(strcmp(obs->sample_ids[3], "D") == 0);
-    ASSERT(strcmp(obs->sample_ids[4], "E") == 0);
-    ASSERT(strcmp(obs->sample_ids[5], "F") == 0);
+      ASSERT(err == read_okay);
+      ASSERT(obs->n_samples == 6);
+      ASSERT(obs->stripe_start == 0);
+      ASSERT(obs->stripe_stop == 3);
+      ASSERT(obs->stripe_total == 3);
+      ASSERT(strcmp(obs->sample_ids[0], "A") == 0);
+      ASSERT(strcmp(obs->sample_ids[1], "B") == 0);
+      ASSERT(strcmp(obs->sample_ids[2], "Cx") == 0);
+      ASSERT(strcmp(obs->sample_ids[3], "D") == 0);
+      ASSERT(strcmp(obs->sample_ids[4], "E") == 0);
+      ASSERT(strcmp(obs->sample_ids[5], "F") == 0);
 
-    for(int i = 0; i < 3; i++) {
+      for(int i = 0; i < 3; i++) {
         for(int j = 0; j < 6; j++) {
             ASSERT(obs->stripes[i][j] == ((i * 6) + j + 1));
         }
+      }
+
+      destroy_partial_mat(&obs);
     }
+
+    {
+      partial_dyn_mat_t *obs = NULL;
+      err = read_partial_header("/tmp/ssu_io.dat", &obs);
+   
+      ASSERT(err == read_okay);
+      ASSERT(obs->n_samples == 6);
+      ASSERT(obs->stripe_start == 0);
+      ASSERT(obs->stripe_stop == 3);
+      ASSERT(obs->stripe_total == 3);
+      ASSERT(strcmp(obs->sample_ids[0], "A") == 0);
+      ASSERT(strcmp(obs->sample_ids[1], "B") == 0);
+      ASSERT(strcmp(obs->sample_ids[2], "Cx") == 0);
+      ASSERT(strcmp(obs->sample_ids[3], "D") == 0);
+      ASSERT(strcmp(obs->sample_ids[4], "E") == 0);
+      ASSERT(strcmp(obs->sample_ids[5], "F") == 0);
+
+      for(int i = 0; i < 3; i++) {
+        ASSERT(obs->stripes[i]==NULL);
+      }
+
+      err = read_partial_one_stripe(obs,1);
+      ASSERT(err == read_okay);
+
+      ASSERT(obs->stripes[0]==NULL);
+      ASSERT(obs->stripes[1]!=NULL);
+      ASSERT(obs->stripes[2]==NULL);
+
+      {
+        const int i = 1;
+        for(int j = 0; j < 6; j++) {
+            ASSERT(obs->stripes[i][j] == ((i * 6) + j + 1));
+        }
+      }
+
+      err = read_partial_one_stripe(obs,0);
+      ASSERT(err == read_okay);
+
+      ASSERT(obs->stripes[0]!=NULL);
+      ASSERT(obs->stripes[1]!=NULL);
+      ASSERT(obs->stripes[2]==NULL);
+
+      {
+        const int i = 0;
+        for(int j = 0; j < 6; j++) {
+            ASSERT(obs->stripes[i][j] == ((i * 6) + j + 1));
+        }
+      }
+    
+      err = read_partial_one_stripe(obs,2);
+      ASSERT(err == read_okay);
+
+
+      for(int i = 0; i < 3; i++) {
+        ASSERT(obs->stripes[i]!=NULL);
+        for(int j = 0; j < 6; j++) {
+            ASSERT(obs->stripes[i][j] == ((i * 6) + j + 1));
+        }
+      }
+
+      destroy_partial_dyn_mat(&obs);
+    }
+
     SUITE_END();
 }
 

--- a/sucpp/test_api.cpp
+++ b/sucpp/test_api.cpp
@@ -48,8 +48,9 @@ void SUITE_END() {
 //    SUITE_END();
 //}
 //
-partial_mat_t* make_test_pm(int case) {
-    partial_mat_t* pm = (partial_mat_t*)malloc(sizeof(partial_mat_t));
+
+template<class TMat, class TReal>
+void fill_test_pm(TMat* pm, int case_id) {
     pm->n_samples = 6;
     pm->sample_ids = (char**)malloc(sizeof(char*) * 6);
     pm->sample_ids[0] = (char*)malloc(sizeof(char) * 2);
@@ -65,64 +66,48 @@ partial_mat_t* make_test_pm(int case) {
     pm->sample_ids[5] = (char*)malloc(sizeof(char) * 2);
     pm->sample_ids[5][0] = 'F'; pm->sample_ids[5][1] = '\0';
 
-    if (case==3) {
-      pm->stripe_start = 6;
-      pm->stripe_stop = 9;
-      pm->stripe_total = 9;
-      pm->is_upper_triangle = true;
-      pm->stripes = (double**)malloc(sizeof(double*) * 3);
-      pm->stripes[0] = (double*)malloc(sizeof(double) * 6);
+    if (case_id==0) {
+      pm->stripe_start = 0;
+      pm->stripe_stop = 3;
+      pm->stripe_total = 3;
+      pm->stripes = (TReal**)malloc(sizeof(TReal*) * 3);
+      pm->stripes[0] = (TReal*)malloc(sizeof(TReal) * 6);
       pm->stripes[0][0] = 1; pm->stripes[0][1] = 2; pm->stripes[0][2] = 3; pm->stripes[0][3] = 4; pm->stripes[0][4] = 5; pm->stripes[0][5] = 6;
-      pm->stripes[1] = (double*)malloc(sizeof(double) * 6);
+      pm->stripes[1] = (TReal*)malloc(sizeof(TReal) * 6);
       pm->stripes[1][0] = 7; pm->stripes[1][1] = 8; pm->stripes[1][2] = 9; pm->stripes[1][3] = 10; pm->stripes[1][4] = 11; pm->stripes[1][5] = 12;
-      pm->stripes[2] = (double*)malloc(sizeof(double) * 6);
+      pm->stripes[2] = (TReal*)malloc(sizeof(TReal) * 6);
       pm->stripes[2][0] = 13; pm->stripes[2][1] = 14; pm->stripes[2][2] = 15; pm->stripes[2][3] = 16; pm->stripes[2][4] = 17; pm->stripes[2][5] = 18;
-    } else if (case==1) {
+    } else if (case_id==1) {
       pm->stripe_start = 0;
       pm->stripe_stop = 2;
       pm->stripe_total = 3;
-      pm->is_upper_triangle = true;
-      pm->stripes = (double**)malloc(sizeof(double*) * 2);
-      pm->stripes[0] = (double*)malloc(sizeof(double) * 6);
-      pm->stripes[0][0] = 1; pm1->stripes[0][1] = 2; pm1->stripes[0][2] = 3; pm1->stripes[0][3] = 4; pm1->stripes[0][4] = 5; pm1->stripes[0][5] = 6;
-      pm->stripes[1] = (double*)malloc(sizeof(double) * 6);
-      pm->stripes[1][0] = 7; pm1->stripes[1][1] = 8; pm1->stripes[1][2] = 9; pm1->stripes[1][3] = 10; pm1->stripes[1][4] = 11; pm1->stripes[1][5] = 12;
+      pm->stripes = (TReal**)malloc(sizeof(TReal*) * 2);
+      pm->stripes[0] = (TReal*)malloc(sizeof(TReal) * 6);
+      pm->stripes[0][0] = 1; pm->stripes[0][1] = 2; pm->stripes[0][2] = 3; pm->stripes[0][3] = 4; pm->stripes[0][4] = 5; pm->stripes[0][5] = 6;
+      pm->stripes[1] = (TReal*)malloc(sizeof(TReal) * 6);
+      pm->stripes[1][0] = 7; pm->stripes[1][1] = 8; pm->stripes[1][2] = 9; pm->stripes[1][3] = 10; pm->stripes[1][4] = 11; pm->stripes[1][5] = 12;
     } else { // assume 2
       pm->stripe_start = 2;
       pm->stripe_stop = 3;
       pm->stripe_total = 3;
-      pm->is_upper_triangle = true;
-      pm->stripes = (double**)malloc(sizeof(double*) * 1);
-      pm->stripes[0] = (double*)malloc(sizeof(double) * 6);
-      pm->stripes[0][0] = 16; pm2->stripes[0][1] = 17; pm2->stripes[0][2] = 18; pm2->stripes[0][3] = 16; pm2->stripes[0][4] = 17; pm2->stripes[0][5] = 18;
+      pm->stripes = (TReal**)malloc(sizeof(TReal*) * 1);
+      pm->stripes[0] = (TReal*)malloc(sizeof(TReal) * 6);
+      pm->stripes[0][0] = 16; pm->stripes[0][1] = 17; pm->stripes[0][2] = 18; pm->stripes[0][3] = 16; pm->stripes[0][4] = 17; pm->stripes[0][5] = 18;
     }
+    pm->is_upper_triangle = true;
+}
+
+partial_mat_t* make_test_pm(int case_id) {
+    partial_mat_t* pm = (partial_mat_t*)malloc(sizeof(partial_mat_t));
+
+    fill_test_pm<partial_mat_t,double>(pm,case_id);
     return pm;
 }
 
-partial_dyn_mat_t* make_test_pdm() {
+partial_dyn_mat_t* make_test_pdm(int case_id) {
     partial_dyn_mat_t* pm = (partial_dyn_mat_t*)malloc(sizeof(partial_dyn_mat_t));
-    pm->n_samples = 6;
-    pm->sample_ids = (char**)malloc(sizeof(char*) * 6);
-    pm->sample_ids[0] = (char*)malloc(sizeof(char) * 2);
-    pm->sample_ids[0][0] = 'A'; pm->sample_ids[0][1] = '\0';
-    pm->sample_ids[1] = (char*)malloc(sizeof(char) * 2);
-    pm->sample_ids[1][0] = 'B'; pm->sample_ids[1][1] = '\0';
-    pm->sample_ids[2] = (char*)malloc(sizeof(char) * 3);
-    pm->sample_ids[2][0] = 'C'; pm->sample_ids[2][1] = 'x'; pm->sample_ids[2][2] = '\0';
-    pm->sample_ids[3] = (char*)malloc(sizeof(char) * 2);
-    pm->sample_ids[3][0] = 'D'; pm->sample_ids[3][1] = '\0';
-    pm->sample_ids[4] = (char*)malloc(sizeof(char) * 2);
-    pm->sample_ids[4][0] = 'E'; pm->sample_ids[4][1] = '\0';
-    pm->sample_ids[5] = (char*)malloc(sizeof(char) * 2);
-    pm->sample_ids[5][0] = 'F'; pm->sample_ids[5][1] = '\0';
-    pm->stripes = (double**)malloc(sizeof(double*) * 3);
-    pm->stripes[0] = (double*)malloc(sizeof(double) * 6);
-    pm->stripes[0][0] = 1; pm->stripes[0][1] = 2; pm->stripes[0][2] = 3; pm->stripes[0][3] = 4; pm->stripes[0][4] = 5; pm->stripes[0][5] = 6;
-    pm->stripes[1] = (double*)malloc(sizeof(double) * 6);
-    pm->stripes[1][0] = 7; pm->stripes[1][1] = 8; pm->stripes[1][2] = 9; pm->stripes[1][3] = 10; pm->stripes[1][4] = 11; pm->stripes[1][5] = 12;
-    pm->stripes[2] = (double*)malloc(sizeof(double) * 6);
-    pm->stripes[2][0] = 13; pm->stripes[2][1] = 14; pm->stripes[2][2] = 15; pm->stripes[2][3] = 16; pm->stripes[2][4] = 17; pm->stripes[2][5] = 18;
-    pm->offsets = (uint64_t*)calloc(4,sizeof(uint64_t));
+    fill_test_pm<partial_dyn_mat_t,double>(pm,case_id);
+    pm->offsets = (uint64_t*)calloc(pm->stripe_stop-pm->stripe_start,sizeof(uint64_t));
     pm->filename = strdup("dummy");
 
     return pm;
@@ -191,11 +176,7 @@ TMat* mat_full_three_rep() {
 void test_read_write_partial_mat() {
     SUITE_START("test read/write partial_mat_t");
 
-    partial_mat_t* pm = make_test_pm();
-    pm->stripe_start = 0;
-    pm->stripe_stop = 3;
-    pm->stripe_total = 3;
-    pm->is_upper_triangle = true;
+    partial_mat_t* pm = make_test_pm(0);
     
     io_status err = write_partial("/tmp/ssu_io.dat", pm);
     ASSERT(err == write_okay);
@@ -343,7 +324,10 @@ void test_merge_partial_mat() {
     pm2->stripe_total = 9;
     pm2->is_upper_triangle = true;
     
-    partial_mat_t* pm3 = make_test_pm(3);;
+    partial_mat_t* pm3 = make_test_pm(0);
+    pm3->stripe_start = 6;
+    pm3->stripe_stop = 9;
+    pm3->stripe_total = 9;
 
     partial_mat_t* pms_err[3];
 
@@ -386,57 +370,8 @@ void test_merge_partial_dyn_mat() {
     SUITE_START("test merge partial_dyn_mat_t");
 
     // the easy test
-    partial_dyn_mat_t* pm1 = (partial_dyn_mat_t*)malloc(sizeof(partial_dyn_mat_t));
-    pm1->n_samples = 6;
-    pm1->sample_ids = (char**)malloc(sizeof(char*) * 6);
-    pm1->sample_ids[0] = (char*)malloc(sizeof(char) * 2);
-    pm1->sample_ids[0][0] = 'A'; pm1->sample_ids[0][1] = '\0';
-    pm1->sample_ids[1] = (char*)malloc(sizeof(char) * 2);
-    pm1->sample_ids[1][0] = 'B'; pm1->sample_ids[1][1] = '\0';
-    pm1->sample_ids[2] = (char*)malloc(sizeof(char) * 3);
-    pm1->sample_ids[2][0] = 'C'; pm1->sample_ids[2][1] = 'x'; pm1->sample_ids[2][2] = '\0';
-    pm1->sample_ids[3] = (char*)malloc(sizeof(char) * 2);
-    pm1->sample_ids[3][0] = 'D'; pm1->sample_ids[3][1] = '\0';
-    pm1->sample_ids[4] = (char*)malloc(sizeof(char) * 2);
-    pm1->sample_ids[4][0] = 'E'; pm1->sample_ids[4][1] = '\0';
-    pm1->sample_ids[5] = (char*)malloc(sizeof(char) * 2);
-    pm1->sample_ids[5][0] = 'F'; pm1->sample_ids[5][1] = '\0';
-    pm1->stripes = (double**)malloc(sizeof(double*) * 2);
-    pm1->stripes[0] = (double*)malloc(sizeof(double) * 6);
-    pm1->stripes[0][0] = 1; pm1->stripes[0][1] = 2; pm1->stripes[0][2] = 3; pm1->stripes[0][3] = 4; pm1->stripes[0][4] = 5; pm1->stripes[0][5] = 6;
-    pm1->stripes[1] = (double*)malloc(sizeof(double) * 6);
-    pm1->stripes[1][0] = 7; pm1->stripes[1][1] = 8; pm1->stripes[1][2] = 9; pm1->stripes[1][3] = 10; pm1->stripes[1][4] = 11; pm1->stripes[1][5] = 12;
-    pm1->stripe_start = 0;
-    pm1->stripe_stop = 2;
-    pm1->stripe_total = 3;
-    pm1->is_upper_triangle = true;
-    pm1->offsets = (uint64_t*)calloc(2,sizeof(uint64_t));
-    pm1->filename=strdup("dummy1");    
-
-    partial_dyn_mat_t* pm2 = (partial_dyn_mat_t*)malloc(sizeof(partial_dyn_mat_t));
-    pm2->n_samples = 6;
-    pm2->sample_ids = (char**)malloc(sizeof(char*) * 6);
-    pm2->sample_ids[0] = (char*)malloc(sizeof(char) * 2);
-    pm2->sample_ids[0][0] = 'A'; pm2->sample_ids[0][1] = '\0';
-    pm2->sample_ids[1] = (char*)malloc(sizeof(char) * 2);
-    pm2->sample_ids[1][0] = 'B'; pm2->sample_ids[1][1] = '\0';
-    pm2->sample_ids[2] = (char*)malloc(sizeof(char) * 3);
-    pm2->sample_ids[2][0] = 'C'; pm2->sample_ids[2][1] = 'x'; pm2->sample_ids[2][2] = '\0';
-    pm2->sample_ids[3] = (char*)malloc(sizeof(char) * 2);
-    pm2->sample_ids[3][0] = 'D'; pm2->sample_ids[3][1] = '\0';
-    pm2->sample_ids[4] = (char*)malloc(sizeof(char) * 2);
-    pm2->sample_ids[4][0] = 'E'; pm2->sample_ids[4][1] = '\0';
-    pm2->sample_ids[5] = (char*)malloc(sizeof(char) * 2);
-    pm2->sample_ids[5][0] = 'F'; pm2->sample_ids[5][1] = '\0';
-    pm2->stripes = (double**)malloc(sizeof(double*) * 1);
-    pm2->stripes[0] = (double*)malloc(sizeof(double) * 6);
-    pm2->stripes[0][0] = 16; pm2->stripes[0][1] = 17; pm2->stripes[0][2] = 18; pm2->stripes[0][3] = 16; pm2->stripes[0][4] = 17; pm2->stripes[0][5] = 18;
-    pm2->stripe_start = 2;
-    pm2->stripe_stop = 3;
-    pm2->stripe_total = 3;
-    pm2->is_upper_triangle = true;
-    pm2->offsets = (uint64_t*)calloc(1,sizeof(uint64_t));
-    pm2->filename=strdup("dummy2");
+    partial_dyn_mat_t* pm1 = make_test_pdm(1);
+    partial_dyn_mat_t* pm2 = make_test_pdm(2);
 
     mat_full_fp64_t* exp = mat_full_three_rep<mat_full_fp64_t,double>();
 
@@ -459,15 +394,9 @@ void test_merge_partial_dyn_mat() {
     // recreate deallocated stripes
     ASSERT(pm1->stripes[0]==NULL);
     ASSERT(pm1->stripes[1]==NULL);
-    pm1->stripes[0] = (double*)malloc(sizeof(double) * 6);
-    pm1->stripes[0][0] = 1; pm1->stripes[0][1] = 2; pm1->stripes[0][2] = 3; pm1->stripes[0][3] = 4; pm1->stripes[0][4] = 5; pm1->stripes[0][5] = 6;
-    pm1->stripes[1] = (double*)malloc(sizeof(double) * 6);
-    pm1->stripes[1][0] = 7; pm1->stripes[1][1] = 8; pm1->stripes[1][2] = 9; pm1->stripes[1][3] = 10; pm1->stripes[1][4] = 11; pm1->stripes[1][5] = 12;
-
     ASSERT(pm2->stripes[0]==NULL);
-    pm2->stripes = (double**)malloc(sizeof(double*) * 1);
-    pm2->stripes[0] = (double*)malloc(sizeof(double) * 6);
-    pm2->stripes[0][0] = 16; pm2->stripes[0][1] = 17; pm2->stripes[0][2] = 18; pm2->stripes[0][3] = 16; pm2->stripes[0][4] = 17; pm2->stripes[0][5] = 18;
+    pm1 = make_test_pdm(1);
+    pm2 = make_test_pdm(2);
 
     pms[0] = pm2;
     pms[1] = pm1;
@@ -500,11 +429,10 @@ void test_merge_partial_dyn_mat() {
     pm2->stripe_total = 9;
     pm2->is_upper_triangle = true;
     
-    partial_dyn_mat_t* pm3 = make_test_pdm();
+    partial_dyn_mat_t* pm3 = make_test_pdm(0);
     pm3->stripe_start = 6;
     pm3->stripe_stop = 9;
     pm3->stripe_total = 9;
-    pm3->is_upper_triangle = true;
 
     partial_dyn_mat_t* pms_err[3];
 

--- a/sucpp/test_api.cpp
+++ b/sucpp/test_api.cpp
@@ -75,6 +75,35 @@ partial_mat_t* make_test_pm() {
     return pm;
 }
 
+partial_dyn_mat_t* make_test_pdm() {
+    partial_dyn_mat_t* pm = (partial_dyn_mat_t*)malloc(sizeof(partial_dyn_mat_t));
+    pm->n_samples = 6;
+    pm->sample_ids = (char**)malloc(sizeof(char*) * 6);
+    pm->sample_ids[0] = (char*)malloc(sizeof(char) * 2);
+    pm->sample_ids[0][0] = 'A'; pm->sample_ids[0][1] = '\0';
+    pm->sample_ids[1] = (char*)malloc(sizeof(char) * 2);
+    pm->sample_ids[1][0] = 'B'; pm->sample_ids[1][1] = '\0';
+    pm->sample_ids[2] = (char*)malloc(sizeof(char) * 3);
+    pm->sample_ids[2][0] = 'C'; pm->sample_ids[2][1] = 'x'; pm->sample_ids[2][2] = '\0';
+    pm->sample_ids[3] = (char*)malloc(sizeof(char) * 2);
+    pm->sample_ids[3][0] = 'D'; pm->sample_ids[3][1] = '\0';
+    pm->sample_ids[4] = (char*)malloc(sizeof(char) * 2);
+    pm->sample_ids[4][0] = 'E'; pm->sample_ids[4][1] = '\0';
+    pm->sample_ids[5] = (char*)malloc(sizeof(char) * 2);
+    pm->sample_ids[5][0] = 'F'; pm->sample_ids[5][1] = '\0';
+    pm->stripes = (double**)malloc(sizeof(double*) * 3);
+    pm->stripes[0] = (double*)malloc(sizeof(double) * 6);
+    pm->stripes[0][0] = 1; pm->stripes[0][1] = 2; pm->stripes[0][2] = 3; pm->stripes[0][3] = 4; pm->stripes[0][4] = 5; pm->stripes[0][5] = 6;
+    pm->stripes[1] = (double*)malloc(sizeof(double) * 6);
+    pm->stripes[1][0] = 7; pm->stripes[1][1] = 8; pm->stripes[1][2] = 9; pm->stripes[1][3] = 10; pm->stripes[1][4] = 11; pm->stripes[1][5] = 12;
+    pm->stripes[2] = (double*)malloc(sizeof(double) * 6);
+    pm->stripes[2][0] = 13; pm->stripes[2][1] = 14; pm->stripes[2][2] = 15; pm->stripes[2][3] = 16; pm->stripes[2][4] = 17; pm->stripes[2][5] = 18;
+    pm->offsets = (uint64_t*)calloc(4,sizeof(uint64_t));
+    pm->filename = strdup("dummy");
+
+    return pm;
+}
+
 mat_t* mat_three_rep() {
     mat_t* res = (mat_t*)malloc(sizeof(mat_t));
     res->n_samples = 6;
@@ -88,6 +117,36 @@ mat_t* mat_three_rep() {
                                                               res->condensed_form[9] = 3;  res->condensed_form[10] = 9; res->condensed_form[11] = 18; 
                                                                                            res->condensed_form[12] = 4; res->condensed_form[13] = 10;  
                                                                                                                         res->condensed_form[14] = 5;
+    res->sample_ids = (char**)malloc(sizeof(char*) * 6);
+    res->sample_ids[0] = (char*)malloc(sizeof(char) * 2);
+    res->sample_ids[0][0] = 'A'; res->sample_ids[0][1] = '\0';
+    res->sample_ids[1] = (char*)malloc(sizeof(char) * 2);
+    res->sample_ids[1][0] = 'B'; res->sample_ids[1][1] = '\0';
+    res->sample_ids[2] = (char*)malloc(sizeof(char) * 3);
+    res->sample_ids[2][0] = 'C'; res->sample_ids[2][1] = 'x'; res->sample_ids[2][2] = '\0';
+    res->sample_ids[3] = (char*)malloc(sizeof(char) * 2);
+    res->sample_ids[3][0] = 'D'; res->sample_ids[3][1] = '\0';
+    res->sample_ids[4] = (char*)malloc(sizeof(char) * 2);
+    res->sample_ids[4][0] = 'E'; res->sample_ids[4][1] = '\0';
+    res->sample_ids[5] = (char*)malloc(sizeof(char) * 2);
+    res->sample_ids[5][0] = 'F'; res->sample_ids[5][1] = '\0';
+
+    return res;
+}
+
+template<class TMat, class TReal>
+TMat* mat_full_three_rep() {
+    TMat* res = (TMat*)malloc(sizeof(TMat));
+    res->n_samples = 6;
+    res->matrix = (TReal*)malloc(sizeof(TReal) * 36);
+    TReal * m=res->matrix ;
+    m[ 0] =  0; m[ 1] =  1; m[ 2] =  7; m[ 3] = 16; m[ 4] = 11; m[ 5] =  6;
+    m[ 6] =  1; m[ 7] =  0; m[ 8] =  2; m[ 9] =  8; m[10] = 17; m[11] = 12;
+    m[12] =  7; m[13] =  2; m[14] =  0; m[15] =  3; m[16] =  9; m[17] = 18;
+    m[18] = 16; m[19] =  8; m[20] =  3; m[21] =  0; m[22] =  4; m[23] = 10;
+    m[24] = 11; m[25] = 17; m[26] =  9; m[27] =  4; m[28] =  0; m[29] =  5;
+    m[30] =  6; m[31] = 12; m[32] = 18; m[33] = 10; m[34] =  5; m[35] =  0;
+
     res->sample_ids = (char**)malloc(sizeof(char*) * 6);
     res->sample_ids[0] = (char*)malloc(sizeof(char) * 2);
     res->sample_ids[0][0] = 'A'; res->sample_ids[0][1] = '\0';
@@ -253,7 +312,7 @@ void test_merge_partial_mat() {
     pm2->sample_ids[5][0] = 'F'; pm2->sample_ids[5][1] = '\0';
     pm2->stripes = (double**)malloc(sizeof(double*) * 1);
     pm2->stripes[0] = (double*)malloc(sizeof(double) * 6);
-    pm2->stripes[0][0] = 13; pm2->stripes[0][1] = 14; pm2->stripes[0][2] = 15; pm2->stripes[0][3] = 16; pm2->stripes[0][4] = 17; pm2->stripes[0][5] = 18;
+    pm2->stripes[0][0] = 16; pm2->stripes[0][1] = 17; pm2->stripes[0][2] = 18; pm2->stripes[0][3] = 16; pm2->stripes[0][4] = 17; pm2->stripes[0][5] = 18;
     pm2->stripe_start = 2;
     pm2->stripe_stop = 3;
     pm2->stripe_total = 3;
@@ -351,6 +410,171 @@ void test_merge_partial_mat() {
     SUITE_END();
 }
 
+void test_merge_partial_dyn_mat() {
+    SUITE_START("test merge partial_dyn_mat_t");
+
+    // the easy test
+    partial_dyn_mat_t* pm1 = (partial_dyn_mat_t*)malloc(sizeof(partial_dyn_mat_t));
+    pm1->n_samples = 6;
+    pm1->sample_ids = (char**)malloc(sizeof(char*) * 6);
+    pm1->sample_ids[0] = (char*)malloc(sizeof(char) * 2);
+    pm1->sample_ids[0][0] = 'A'; pm1->sample_ids[0][1] = '\0';
+    pm1->sample_ids[1] = (char*)malloc(sizeof(char) * 2);
+    pm1->sample_ids[1][0] = 'B'; pm1->sample_ids[1][1] = '\0';
+    pm1->sample_ids[2] = (char*)malloc(sizeof(char) * 3);
+    pm1->sample_ids[2][0] = 'C'; pm1->sample_ids[2][1] = 'x'; pm1->sample_ids[2][2] = '\0';
+    pm1->sample_ids[3] = (char*)malloc(sizeof(char) * 2);
+    pm1->sample_ids[3][0] = 'D'; pm1->sample_ids[3][1] = '\0';
+    pm1->sample_ids[4] = (char*)malloc(sizeof(char) * 2);
+    pm1->sample_ids[4][0] = 'E'; pm1->sample_ids[4][1] = '\0';
+    pm1->sample_ids[5] = (char*)malloc(sizeof(char) * 2);
+    pm1->sample_ids[5][0] = 'F'; pm1->sample_ids[5][1] = '\0';
+    pm1->stripes = (double**)malloc(sizeof(double*) * 2);
+    pm1->stripes[0] = (double*)malloc(sizeof(double) * 6);
+    pm1->stripes[0][0] = 1; pm1->stripes[0][1] = 2; pm1->stripes[0][2] = 3; pm1->stripes[0][3] = 4; pm1->stripes[0][4] = 5; pm1->stripes[0][5] = 6;
+    pm1->stripes[1] = (double*)malloc(sizeof(double) * 6);
+    pm1->stripes[1][0] = 7; pm1->stripes[1][1] = 8; pm1->stripes[1][2] = 9; pm1->stripes[1][3] = 10; pm1->stripes[1][4] = 11; pm1->stripes[1][5] = 12;
+    pm1->stripe_start = 0;
+    pm1->stripe_stop = 2;
+    pm1->stripe_total = 3;
+    pm1->is_upper_triangle = true;
+    pm1->offsets = (uint64_t*)calloc(2,sizeof(uint64_t));
+    pm1->filename=strdup("dummy1");    
+
+    partial_dyn_mat_t* pm2 = (partial_dyn_mat_t*)malloc(sizeof(partial_dyn_mat_t));
+    pm2->n_samples = 6;
+    pm2->sample_ids = (char**)malloc(sizeof(char*) * 6);
+    pm2->sample_ids[0] = (char*)malloc(sizeof(char) * 2);
+    pm2->sample_ids[0][0] = 'A'; pm2->sample_ids[0][1] = '\0';
+    pm2->sample_ids[1] = (char*)malloc(sizeof(char) * 2);
+    pm2->sample_ids[1][0] = 'B'; pm2->sample_ids[1][1] = '\0';
+    pm2->sample_ids[2] = (char*)malloc(sizeof(char) * 3);
+    pm2->sample_ids[2][0] = 'C'; pm2->sample_ids[2][1] = 'x'; pm2->sample_ids[2][2] = '\0';
+    pm2->sample_ids[3] = (char*)malloc(sizeof(char) * 2);
+    pm2->sample_ids[3][0] = 'D'; pm2->sample_ids[3][1] = '\0';
+    pm2->sample_ids[4] = (char*)malloc(sizeof(char) * 2);
+    pm2->sample_ids[4][0] = 'E'; pm2->sample_ids[4][1] = '\0';
+    pm2->sample_ids[5] = (char*)malloc(sizeof(char) * 2);
+    pm2->sample_ids[5][0] = 'F'; pm2->sample_ids[5][1] = '\0';
+    pm2->stripes = (double**)malloc(sizeof(double*) * 1);
+    pm2->stripes[0] = (double*)malloc(sizeof(double) * 6);
+    pm2->stripes[0][0] = 16; pm2->stripes[0][1] = 17; pm2->stripes[0][2] = 18; pm2->stripes[0][3] = 16; pm2->stripes[0][4] = 17; pm2->stripes[0][5] = 18;
+    pm2->stripe_start = 2;
+    pm2->stripe_stop = 3;
+    pm2->stripe_total = 3;
+    pm2->is_upper_triangle = true;
+    pm2->offsets = (uint64_t*)calloc(1,sizeof(uint64_t));
+    pm2->filename=strdup("dummy2");
+
+    mat_full_fp64_t* exp = mat_full_three_rep<mat_full_fp64_t,double>();
+
+    partial_dyn_mat_t* pms[2];
+    pms[0] = pm1;
+    pms[1] = pm2;
+
+    mat_full_fp64_t* obs = NULL;
+    merge_status err = merge_partial_to_matrix(pms, 2, &obs);
+    ASSERT(err == merge_okay);
+    ASSERT(obs->n_samples == exp->n_samples);
+    for(int i = 0; i < (obs->n_samples*obs->n_samples); i++) {
+        ASSERT(obs->matrix[i] == exp->matrix[i]);
+    }
+    for(int i = 0; i < obs->n_samples; i++) {
+        ASSERT(strcmp(obs->sample_ids[i], exp->sample_ids[i]) == 0);
+    }
+    // out of order test
+
+    // recreate deallocated stripes
+    ASSERT(pm1->stripes[0]==NULL);
+    ASSERT(pm1->stripes[1]==NULL);
+    pm1->stripes[0] = (double*)malloc(sizeof(double) * 6);
+    pm1->stripes[0][0] = 1; pm1->stripes[0][1] = 2; pm1->stripes[0][2] = 3; pm1->stripes[0][3] = 4; pm1->stripes[0][4] = 5; pm1->stripes[0][5] = 6;
+    pm1->stripes[1] = (double*)malloc(sizeof(double) * 6);
+    pm1->stripes[1][0] = 7; pm1->stripes[1][1] = 8; pm1->stripes[1][2] = 9; pm1->stripes[1][3] = 10; pm1->stripes[1][4] = 11; pm1->stripes[1][5] = 12;
+
+    ASSERT(pm2->stripes[0]==NULL);
+    pm2->stripes = (double**)malloc(sizeof(double*) * 1);
+    pm2->stripes[0] = (double*)malloc(sizeof(double) * 6);
+    pm2->stripes[0][0] = 16; pm2->stripes[0][1] = 17; pm2->stripes[0][2] = 18; pm2->stripes[0][3] = 16; pm2->stripes[0][4] = 17; pm2->stripes[0][5] = 18;
+
+    pms[0] = pm2;
+    pms[1] = pm1;
+
+    mat_full_fp32_t* exp2 = mat_full_three_rep<mat_full_fp32_t,float>();
+    mat_full_fp32_t *obs2 = NULL;
+    err = merge_partial_to_matrix_fp32(pms, 2, &obs2);
+    ASSERT(err == merge_okay);
+    ASSERT(obs2->n_samples == exp2->n_samples);
+    for(int i = 0; i < (obs2->n_samples*obs2->n_samples); i++) {
+        ASSERT(obs2->matrix[i] == exp2->matrix[i]);
+    }
+    for(int i = 0; i < obs2->n_samples; i++)
+        ASSERT(strcmp(obs2->sample_ids[i], exp2->sample_ids[i]) == 0);
+
+ 
+    ASSERT(pm2->stripes[0]==NULL);
+    ASSERT(pm1->stripes[0]==NULL);
+    ASSERT(pm1->stripes[1]==NULL);
+
+
+    // error checking
+    pm1->stripe_start = 0;
+    pm1->stripe_stop = 3;
+    pm1->stripe_total = 9;
+    pm1->is_upper_triangle = true;
+
+    pm2->stripe_start = 3;
+    pm2->stripe_stop = 5;
+    pm2->stripe_total = 9;
+    pm2->is_upper_triangle = true;
+    
+    partial_dyn_mat_t* pm3 = make_test_pdm();
+    pm3->stripe_start = 6;
+    pm3->stripe_stop = 9;
+    pm3->stripe_total = 9;
+    pm3->is_upper_triangle = true;
+
+    partial_dyn_mat_t* pms_err[3];
+
+    pms_err[2] = pm1;
+    pms_err[0] = pm2;
+    pms_err[1] = pm3;
+
+    err = merge_partial_to_matrix(pms_err, 3, &obs);
+    ASSERT(err == incomplete_stripe_set);
+
+    pm2->stripe_start = 2;
+    pm2->stripe_stop = 6;
+    err = merge_partial_to_matrix(pms_err, 3, &obs);
+    ASSERT(err == stripes_overlap);
+
+    pm2->stripe_start = 3;
+    pm2->sample_ids[2][0] = 'X';
+    err = merge_partial_to_matrix(pms_err, 3, &obs);
+    ASSERT(err == sample_id_consistency);
+
+    pm2->sample_ids[2][0] = 'C';
+    pm3->n_samples = 2;
+    err = merge_partial_to_matrix(pms_err, 3, &obs);
+    ASSERT(err == partials_mismatch);
+
+    pm3->n_samples = 6;
+    pm3->stripe_total = 12;
+    err = merge_partial_to_matrix(pms_err, 3, &obs);
+    ASSERT(err == partials_mismatch);
+    
+    /*
+     * Disable for now... not dealing properly with is_upper_triangle == false
+
+    pm3->is_upper_triangle = false;
+    pm3->stripe_total = 9;
+    err = merge_partial_to_matrix(pms_err, 3, &obs);
+    ASSERT(err == square_mismatch);
+    */
+    
+    SUITE_END();
+}
+
 int main(int argc, char** argv) {
     /* one_off and partial are executed as integration tests */    
 
@@ -358,6 +582,7 @@ int main(int argc, char** argv) {
     //test_read_mat();
     test_read_write_partial_mat();
     test_merge_partial_mat();
+    test_merge_partial_dyn_mat();
 
     printf("\n");
     printf(" %i / %i suites failed\n", suites_failed, suites_run);

--- a/sucpp/test_su.cpp
+++ b/sucpp/test_su.cpp
@@ -386,7 +386,7 @@ void test_bptree_postorder() {
     uint32_t exp[] = {2, 4, 7, 6, 1, 11, 15, 17, 14, 13, 0};
     uint32_t obs[tree.nparens / 2];
 
-    for(int i = 0; i < (tree.nparens / 2); i++)
+    for(unsigned int i = 0; i < (tree.nparens / 2); i++)
         obs[i] = tree.postorderselect(i);
 
     std::vector<uint32_t> exp_v = _uint32_array_to_vector(exp, tree.nparens / 2);
@@ -404,7 +404,7 @@ void test_bptree_preorder() {
     uint32_t exp[] = {0, 1, 2, 4, 6, 7, 11, 13, 14, 15, 17};
     uint32_t obs[tree.nparens / 2];
 
-    for(int i = 0; i < (tree.nparens / 2); i++)
+    for(unsigned int i = 0; i < (tree.nparens / 2); i++)
         obs[i] = tree.preorderselect(i);
 
     std::vector<uint32_t> exp_v = _uint32_array_to_vector(exp, tree.nparens / 2);
@@ -424,7 +424,7 @@ void test_bptree_parent() {
     // all the -2 and +1 garbage is to avoid testing the root.
     uint32_t obs[tree.nparens - 2];
 
-    for(int i = 0; i < (tree.nparens) - 2; i++)
+    for(int i = 0; i < (int(tree.nparens) - 2); i++)
         obs[i] = tree.parent(i+1);
 
     std::vector<uint32_t> exp_v = _uint32_array_to_vector(exp, tree.nparens - 2);
@@ -516,7 +516,7 @@ void test_bptree_leftchild() {
     std::vector<bool> structure = tree.get_structure();
 
     uint32_t exp_pos = 0;
-    for(int i = 0; i < tree.nparens; i++) {
+    for(unsigned int i = 0; i < tree.nparens; i++) {
         if(structure[i])
             ASSERT(tree.leftchild(i) == exp[exp_pos++]);
     }
@@ -531,7 +531,7 @@ void test_bptree_rightchild() {
     std::vector<bool> structure = tree.get_structure();
 
     uint32_t exp_pos = 0;
-    for(int i = 0; i < tree.nparens; i++) {
+    for(unsigned int i = 0; i < tree.nparens; i++) {
         if(structure[i])
             ASSERT(tree.rightchild(i) == exp[exp_pos++]);
     }
@@ -546,7 +546,7 @@ void test_bptree_rightsibling() {
     std::vector<bool> structure = tree.get_structure();
 
     uint32_t exp_pos = 0;
-    for(int i = 0; i < tree.nparens; i++) {
+    for(unsigned int i = 0; i < tree.nparens; i++) {
         if(structure[i])
             ASSERT(tree.rightsibling(i) == exp[exp_pos++]);
     }

--- a/sucpp/test_su.cpp
+++ b/sucpp/test_su.cpp
@@ -734,6 +734,20 @@ void test_unifrac_stripes_to_buf_even() {
     for(unsigned int i = 0; i < 36; i++) {
         ASSERT(exp[i] == obs[i]);
     }
+
+    // test also intermediate, 2-step procedure
+    double *obsC = (double*)malloc(sizeof(double) * 15);
+    su::stripes_to_condensed_form(stripes, 6, obsC, 0, 3);
+
+    float *obs2 = (float*)malloc(sizeof(float) * 36);
+    su::condensed_form_to_buf_fp32(obsC, 6, obs2);
+
+    for(unsigned int i = 0; i < 36; i++) {
+        ASSERT(exp[i] == obs2[i]);
+    }
+
+    free(obs2);
+    free(obsC);
     free(obs);
     SUITE_END();
 }
@@ -768,6 +782,20 @@ void test_unifrac_stripes_to_buf_odd() {
     for(unsigned int i = 0; i < 49; i++) {
         ASSERT(exp[i] == obs[i]);
     }
+
+    // test also intermediate, 2-step procedure
+    double *obsC = (double*)malloc(sizeof(double) * 21);
+    su::stripes_to_condensed_form(stripes, 7, obsC, 0, 3);
+
+    double *obs2 = (double*)malloc(sizeof(double) * 49);
+    su::condensed_form_to_buf(obsC, 7, obs2);
+    
+    for(unsigned int i = 0; i < 49; i++) {
+        ASSERT(exp[i] == obs2[i]);
+    }
+
+    free(obs2);
+    free(obsC);
     free(obs);
     SUITE_END();
 }

--- a/sucpp/test_su.cpp
+++ b/sucpp/test_su.cpp
@@ -660,23 +660,31 @@ void test_unifrac_deconvolute_stripes() {
 void test_unifrac_stripes_to_condensed_form_even() {
     SUITE_START("test stripes_to_condensed_form even samples");
     std::vector<double*> stripes;
-    double s1[] = {0, 5, 9, 12, 14, 4};
-    double s2[] = {1, 6, 10, 13, 3, 8};
-    double s3[] = {2, 7, 11, 2, 7, 11};
-    // {0, 0, 1, 2, 3, 4},
-    // {x, 0, 5, 6, 7, 8},
-    // {x, x, 0, 9, 10, 11},
-    // {x, x, x, 0, 12, 13},
-    // {x, x, x, x, 0, 14},
-    // {x, x, x, x, x, 0}
+    double s1[] = {0,  9, 17, 24, 30, 35, 39, 42, 44,  8};
+    double s2[] = {1, 10, 18, 25, 31, 36, 40, 43,  7, 16};
+    double s3[] = {2, 11, 19, 26, 32, 37, 41,  6, 15, 23};
+    double s4[] = {3, 12, 20, 27, 33, 38,  5, 14, 22, 29};
+    double s5[] = {4, 13, 21, 28, 34,  4, 13, 21, 28, 34};
     stripes.push_back(s1);
     stripes.push_back(s2);
     stripes.push_back(s3);
+    stripes.push_back(s4);
+    stripes.push_back(s5);
 
-    double exp[15] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14};
-    double *obs = (double*)malloc(sizeof(double) * 15);
-    su::stripes_to_condensed_form(stripes, 6, obs, 0, 3);
-    for(unsigned int i = 0; i < 15; i++) {
+    double exp[45] = {/* 0, */  0,  1,  2,  3,  4,  5,  6,  7,  8,
+                      /* *,  0, */  9, 10, 11, 12, 13, 14, 15, 16,
+                      /* *,  *,  0, */ 17, 18, 19, 20, 21, 22, 23,
+                      /* *,  *,  *,  0, */ 24, 25, 26, 27, 28, 29,
+                      /* *,  *,  *,  *,  0, */ 30, 31, 32, 33, 34,
+                      /* *,  *,  *,  *,  *,  0, */ 35, 36, 37, 38,
+                      /* *,  *,  *,  *,  *,  *,  0, */ 39, 40, 41,
+                      /* *,  *,  *,  *,  *,  *,  *,  0, */ 42, 43,
+                      /* *,  *,  *,  *,  *,  *,  *,  *,  0, */ 44};
+                      /* *,  *,  *,  *,  *,  *,  *,  *,  *, *,  0 */
+
+    double *obs = (double*)malloc(sizeof(double) * 45);
+    su::stripes_to_condensed_form(stripes, 10, obs, 0, 5);
+    for(unsigned int i = 0; i < 45; i++) {
         ASSERT(exp[i] == obs[i]);
     }
     free(obs);
@@ -686,25 +694,31 @@ void test_unifrac_stripes_to_condensed_form_even() {
 void test_unifrac_stripes_to_condensed_form_odd() {
     SUITE_START("test stripes_to_condensed_form odd samples");
     std::vector<double*> stripes;
-    double s1[] = {1, 2, 3, 4, 5, 6, 0};
-    double s2[] = {12, 11, 10, 9, 8, 7, 1};
-    double s3[] = {13, 14, 15, 16, 17, 18, 2};
-
-    // {0, 1, 12, 13, 17,  7,  0},
-    // {x, 0,  2, 11, 14, 18,  1},
-    // {x, x,  0,  3, 10, 15,  2},
-    // {x, x,  x,  0,  4,  9, 16},
-    // {x, x,  x,  x,  0,  5,  8},
-    // {x, x,  x,  x,  x,  0,  6}
-    // {x, x,  x,  x,  x,  x,  0}
+    double s1[] = { 1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 0};
+    double s2[] = {20, 19, 18, 17, 16, 15, 14 ,13, 12, 11, 1};
+    double s3[] = {21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 2};
+    double s4[] = {40, 39, 38, 37, 36, 35, 34, 33, 32, 31, 3};
+    double s5[] = {41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 4};
     stripes.push_back(s1);
     stripes.push_back(s2);
     stripes.push_back(s3);
+    stripes.push_back(s4);
+    stripes.push_back(s5);
 
-    double exp[21] = {1, 12, 13, 17, 7, 0, 2, 11, 14, 18, 1, 3, 10, 15, 2, 4, 9, 16, 5, 8, 6};
-    double *obs = (double*)malloc(sizeof(double) * 21);
-    su::stripes_to_condensed_form(stripes, 7, obs, 0, 3);
-    for(unsigned int i = 0; i < 21; i++) {
+    double exp[55] = {/* 0, */ 1, 20, 21, 40, 41, 47, 33, 29, 11,  0,
+                      /* 1,  0, */ 2, 19, 22, 39, 42, 48, 32, 30,  1,
+                      /*20,  2,  0, */ 3, 18, 23, 38, 43, 49, 31,  2,
+                      /*21, 19,  3,  0, */ 4, 17, 24, 37, 44, 50,  3,
+                      /*40, 22, 18,  4,  0, */ 5, 16, 25 ,36, 45 , 4,
+                      /*41, 39, 23, 17,  5,  0, */ 6, 15, 26, 35, 46,
+                      /*47, 42, 38, 24, 16,  6,  0, */ 7, 14, 27, 34,
+                      /*33, 48, 43, 37, 25, 15,  7,  0,*/  8, 13, 28,
+                      /*29, 32, 49, 44, 36, 26, 14,  8,  0, */ 9, 12,
+                      /*11, 30, 31, 50, 45, 35, 27, 13,  9,  0,*/ 10};
+                      /* 0,  1,  2,  3,  4, 46, 34, 28, 12, 10,  0}; */
+    double *obs = (double*)malloc(sizeof(double) * 55);
+    su::stripes_to_condensed_form(stripes, 11, obs, 0, 5);
+    for(unsigned int i = 0; i < 55; i++) {
         ASSERT(exp[i] == obs[i]);
     }
     free(obs);
@@ -714,34 +728,42 @@ void test_unifrac_stripes_to_condensed_form_odd() {
 void test_unifrac_stripes_to_buf_even() {
     SUITE_START("test stripes_to_buf even samples");
     std::vector<double*> stripes;
-    double s1[] = {0, 5, 9, 12, 14, 4};
-    double s2[] = {1, 6, 10, 13, 3, 8};
-    double s3[] = {2, 7, 11, 2, 7, 11};
+    double s1[] = {0,  9, 17, 24, 30, 35, 39, 42, 44,  8};
+    double s2[] = {1, 10, 18, 25, 31, 36, 40, 43,  7, 16};
+    double s3[] = {2, 11, 19, 26, 32, 37, 41,  6, 15, 23};
+    double s4[] = {3, 12, 20, 27, 33, 38,  5, 14, 22, 29};
+    double s5[] = {4, 13, 21, 28, 34,  4, 13, 21, 28, 34};
     stripes.push_back(s1);
     stripes.push_back(s2);
     stripes.push_back(s3);
+    stripes.push_back(s4);
+    stripes.push_back(s5);
 
     // test also double to float conversion
-    float exp[36] = {0, 0,  1,  2,  3,  4, 
-                     0, 0,  5,  6,  7,  8, 
-                     1, 5,  0,  9, 10, 11, 
-                     2, 6,  9,  0, 12, 13, 
-                     3, 7, 10, 12,  0, 14,
-                     4, 8, 11, 13, 14,  0};
-    float *obs = (float*)malloc(sizeof(float) * 36);
-    su::stripes_to_buf_fp32(stripes, 6, obs, 0, 3);
-    for(unsigned int i = 0; i < 36; i++) {
+    float exp[100] = {0,  0,  1,  2,  3,  4,  5,  6,  7,  8, 
+                      0,  0,  9, 10, 11, 12, 13, 14, 15, 16,  
+                      1,  9,  0, 17, 18, 19, 20, 21, 22, 23,
+                      2, 10, 17,  0, 24, 25, 26, 27, 28, 29, 
+                      3, 11, 18, 24,  0, 30, 31, 32, 33, 34,
+                      4, 12, 19, 25, 30,  0, 35, 36, 37, 38,
+                      5, 13, 20, 26, 31, 35,  0, 39, 40, 41,
+                      6, 14, 21, 27, 32, 36, 39,  0, 42, 43,
+                      7, 15, 22, 28, 33, 37, 40, 42,  0, 44,
+                      8, 16, 23, 29, 34, 38, 41, 43, 44,  0};
+    float *obs = (float*)malloc(sizeof(float) * 100);
+    su::stripes_to_buf_fp32(stripes, 10, obs, 0, 5);
+    for(unsigned int i = 0; i < 100; i++) {
         ASSERT(exp[i] == obs[i]);
     }
 
     // test also intermediate, 2-step procedure
-    double *obsC = (double*)malloc(sizeof(double) * 15);
-    su::stripes_to_condensed_form(stripes, 6, obsC, 0, 3);
+    double *obsC = (double*)malloc(sizeof(double) * 45);
+    su::stripes_to_condensed_form(stripes, 10, obsC, 0, 5);
 
-    float *obs2 = (float*)malloc(sizeof(float) * 36);
-    su::condensed_form_to_buf_fp32(obsC, 6, obs2);
+    float *obs2 = (float*)malloc(sizeof(float) * 100);
+    su::condensed_form_to_buf_fp32(obsC, 10, obs2);
 
-    for(unsigned int i = 0; i < 36; i++) {
+    for(unsigned int i = 0; i < 100; i++) {
         ASSERT(exp[i] == obs2[i]);
     }
 
@@ -754,42 +776,42 @@ void test_unifrac_stripes_to_buf_even() {
 void test_unifrac_stripes_to_buf_odd() {
     SUITE_START("test stripes_to_buf odd samples");
     std::vector<double*> stripes;
-    double s1[] = {1, 2, 3, 4, 5, 6, 0};
-    double s2[] = {12, 11, 10, 9, 8, 7, 1};
-    double s3[] = {13, 14, 15, 16, 17, 18, 2};
-
-    // {0, 1, 12, 13, 17,  7,  0},
-    // {x, 0,  2, 11, 14, 18,  1},
-    // {x, x,  0,  3, 10, 15,  2},
-    // {x, x,  x,  0,  4,  9, 16},
-    // {x, x,  x,  x,  0,  5,  8},
-    // {x, x,  x,  x,  x,  0,  6}
-    // {x, x,  x,  x,  x,  x,  0}
+    double s1[] = { 1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 0};
+    double s2[] = {20, 19, 18, 17, 16, 15, 14 ,13, 12, 11, 1};
+    double s3[] = {21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 2};
+    double s4[] = {40, 39, 38, 37, 36, 35, 34, 33, 32, 31, 3};
+    double s5[] = {41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 4};
     stripes.push_back(s1);
     stripes.push_back(s2);
     stripes.push_back(s3);
+    stripes.push_back(s4);
+    stripes.push_back(s5);
 
-    double exp[49] = { 0,  1, 12, 13, 17,  7,  0, 
-                       1,  0,  2, 11, 14, 18,  1, 
-                      12,  2,  0,  3, 10, 15,  2, 
-                      13, 11,  3,  0,  4,  9, 16, 
-                      17, 14, 10,  4,  0,  5,  8, 
-                       7, 18, 15,  9,  5,  0,  6,
-                       0,  1,  2, 16,  8,  6,  0};
-    double *obs = (double*)malloc(sizeof(double) * 49);
-    su::stripes_to_buf(stripes, 7, obs, 0, 3);
-    for(unsigned int i = 0; i < 49; i++) {
+    double exp[121] = { 0,  1, 20, 21, 40, 41, 47, 33, 29, 11,  0, 
+                        1,  0,  2, 19, 22, 39, 42, 48, 32, 30,  1,
+                       20,  2,  0,  3, 18, 23, 38, 43, 49, 31,  2,
+                       21, 19,  3,  0,  4, 17, 24, 37, 44, 50,  3,
+                       40, 22, 18,  4,  0,  5, 16, 25 ,36, 45 , 4, 
+                       41, 39, 23, 17,  5,  0,  6, 15, 26, 35, 46,
+                       47, 42, 38, 24, 16,  6,  0,  7, 14, 27, 34,
+                       33, 48, 43, 37, 25, 15,  7,  0,  8, 13, 28, 
+                       29, 32, 49, 44, 36, 26, 14,  8,  0,  9, 12,
+                       11, 30, 31, 50, 45, 35, 27, 13,  9,  0, 10,
+                        0,  1,  2,  3,  4, 46, 34, 28, 12, 10,  0};
+    double *obs = (double*)malloc(sizeof(double) * 121);
+    su::stripes_to_buf(stripes, 11, obs, 0, 5);
+    for(unsigned int i = 0; i < 121; i++) {
         ASSERT(exp[i] == obs[i]);
     }
 
     // test also intermediate, 2-step procedure
-    double *obsC = (double*)malloc(sizeof(double) * 21);
-    su::stripes_to_condensed_form(stripes, 7, obsC, 0, 3);
+    double *obsC = (double*)malloc(sizeof(double) * 55);
+    su::stripes_to_condensed_form(stripes, 11, obsC, 0, 5);
 
-    double *obs2 = (double*)malloc(sizeof(double) * 49);
-    su::condensed_form_to_buf(obsC, 7, obs2);
+    double *obs2 = (double*)malloc(sizeof(double) * 121);
+    su::condensed_form_to_buf(obsC, 11, obs2);
     
-    for(unsigned int i = 0; i < 49; i++) {
+    for(unsigned int i = 0; i < 121; i++) {
         ASSERT(exp[i] == obs2[i]);
     }
 

--- a/sucpp/test_su.cpp
+++ b/sucpp/test_su.cpp
@@ -712,6 +712,66 @@ void test_unifrac_stripes_to_condensed_form_odd() {
     SUITE_END();
 }
 
+void test_unifrac_stripes_to_buf_even() {
+    SUITE_START("test stripes_to_buf even samples");
+    std::vector<double*> stripes;
+    double s1[] = {0, 5, 9, 12, 14, 4};
+    double s2[] = {1, 6, 10, 13, 3, 8};
+    double s3[] = {2, 7, 11, 2, 7, 11};
+    stripes.push_back(s1);
+    stripes.push_back(s2);
+    stripes.push_back(s3);
+
+    // test also double to float conversion
+    float exp[36] = {0, 0,  1,  2,  3,  4, 
+                     0, 0,  5,  6,  7,  8, 
+                     1, 5,  0,  9, 10, 11, 
+                     2, 6,  9,  0, 12, 13, 
+                     3, 7, 10, 12,  0, 14,
+                     4, 8, 11, 13, 14,  0};
+    float *obs = (float*)malloc(sizeof(float) * 36);
+    su::stripes_to_buf_fp32(stripes, 6, obs, 0, 3);
+    for(unsigned int i = 0; i < 36; i++) {
+        ASSERT(exp[i] == obs[i]);
+    }
+    free(obs);
+    SUITE_END();
+}
+
+void test_unifrac_stripes_to_buf_odd() {
+    SUITE_START("test stripes_to_buf odd samples");
+    std::vector<double*> stripes;
+    double s1[] = {1, 2, 3, 4, 5, 6, 0};
+    double s2[] = {12, 11, 10, 9, 8, 7, 1};
+    double s3[] = {13, 14, 15, 16, 17, 18, 2};
+
+    // {0, 1, 12, 13, 17,  7,  0},
+    // {x, 0,  2, 11, 14, 18,  1},
+    // {x, x,  0,  3, 10, 15,  2},
+    // {x, x,  x,  0,  4,  9, 16},
+    // {x, x,  x,  x,  0,  5,  8},
+    // {x, x,  x,  x,  x,  0,  6}
+    // {x, x,  x,  x,  x,  x,  0}
+    stripes.push_back(s1);
+    stripes.push_back(s2);
+    stripes.push_back(s3);
+
+    double exp[49] = { 0,  1, 12, 13, 17,  7,  0, 
+                       1,  0,  2, 11, 14, 18,  1, 
+                      12,  2,  0,  3, 10, 15,  2, 
+                      13, 11,  3,  0,  4,  9, 16, 
+                      17, 14, 10,  4,  0,  5,  8, 
+                       7, 18, 15,  9,  5,  0,  6,
+                       0,  1,  2, 16,  8,  6,  0};
+    double *obs = (double*)malloc(sizeof(double) * 49);
+    su::stripes_to_buf(stripes, 7, obs, 0, 3);
+    for(unsigned int i = 0; i < 49; i++) {
+        ASSERT(exp[i] == obs[i]);
+    }
+    free(obs);
+    SUITE_END();
+}
+
 void test_unnormalized_weighted_unifrac() {
     SUITE_START("test unnormalized weighted unifrac");
 
@@ -1368,6 +1428,8 @@ int main(int argc, char** argv) {
     test_unifrac_deconvolute_stripes();
     test_unifrac_stripes_to_condensed_form_even();
     test_unifrac_stripes_to_condensed_form_odd();
+    test_unifrac_stripes_to_buf_even();
+    test_unifrac_stripes_to_buf_odd();
     test_unweighted_unifrac();
     test_unweighted_unifrac_fast();
     test_unnormalized_weighted_unifrac();

--- a/sucpp/test_su.cpp
+++ b/sucpp/test_su.cpp
@@ -784,7 +784,7 @@ void test_unifrac_stripes_to_matrix_even() {
                       7, 15, 22, 28, 33, 37, 40, 42,  0, 44,
                       8, 16, 23, 29, 34, 38, 41, 43, 44,  0};
     float *obs = (float*)malloc(sizeof(float) * 100);
-    su::stripes_to_matrix_fp32(stripes, 10, obs, 0, 5);
+    su::stripes_to_matrix_fp32(stripes, 10, 5, obs);
     for(unsigned int i = 0; i < 100; i++) {
         ASSERT(exp[i] == obs[i]);
     }
@@ -832,7 +832,7 @@ void test_unifrac_stripes_to_matrix_odd() {
                        11, 30, 31, 50, 45, 35, 27, 13,  9,  0, 10,
                         0,  1,  2,  3,  4, 46, 34, 28, 12, 10,  0};
     double *obs = (double*)malloc(sizeof(double) * 121);
-    su::stripes_to_matrix(stripes, 11, obs, 0, 5);
+    su::stripes_to_matrix(stripes, 11, 5, obs);
     for(unsigned int i = 0; i < 121; i++) {
         ASSERT(exp[i] == obs[i]);
     }
@@ -879,7 +879,7 @@ void test_unifrac_stripes_to_matrix_odd2() {
                        9, 10, 27, 28, 32, 24, 12,  8,  0};
 
     double *obs = (double*)malloc(sizeof(double) * 81);
-    su::stripes_to_matrix(stripes, 9, obs, 0, 5);
+    su::stripes_to_matrix(stripes, 9, 5, obs);
     for(unsigned int i = 0; i < 81; i++) {
         ASSERT(exp[i] == obs[i]);
     }

--- a/sucpp/test_su.cpp
+++ b/sucpp/test_su.cpp
@@ -784,7 +784,7 @@ void test_unifrac_stripes_to_matrix_even() {
                       7, 15, 22, 28, 33, 37, 40, 42,  0, 44,
                       8, 16, 23, 29, 34, 38, 41, 43, 44,  0};
     float *obs = (float*)malloc(sizeof(float) * 100);
-    su::stripes_to_matrix_fp32(stripes, 10, 5, obs);
+    su::stripes_to_matrix_fp32(stripes.data(), 10, 5, obs);
     for(unsigned int i = 0; i < 100; i++) {
         ASSERT(exp[i] == obs[i]);
     }
@@ -832,7 +832,7 @@ void test_unifrac_stripes_to_matrix_odd() {
                        11, 30, 31, 50, 45, 35, 27, 13,  9,  0, 10,
                         0,  1,  2,  3,  4, 46, 34, 28, 12, 10,  0};
     double *obs = (double*)malloc(sizeof(double) * 121);
-    su::stripes_to_matrix(stripes, 11, 5, obs);
+    su::stripes_to_matrix(stripes.data(), 11, 5, obs);
     for(unsigned int i = 0; i < 121; i++) {
         ASSERT(exp[i] == obs[i]);
     }
@@ -879,7 +879,7 @@ void test_unifrac_stripes_to_matrix_odd2() {
                        9, 10, 27, 28, 32, 24, 12,  8,  0};
 
     double *obs = (double*)malloc(sizeof(double) * 81);
-    su::stripes_to_matrix(stripes, 9, 5, obs);
+    su::stripes_to_matrix(stripes.data(), 9, 5, obs);
     for(unsigned int i = 0; i < 81; i++) {
         ASSERT(exp[i] == obs[i]);
     }

--- a/sucpp/test_su.cpp
+++ b/sucpp/test_su.cpp
@@ -726,7 +726,7 @@ void test_unifrac_stripes_to_condensed_form_odd() {
 }
 
 void test_unifrac_stripes_to_condensed_form_odd2() {
-    SUITE_START("test stripes_to_condensed_form odd samples");
+    SUITE_START("test stripes_to_condensed_form odd(2) samples");
     std::vector<double*> stripes;
     double s1[] = { 1,  2,  3,  4,  5,  6,  7,  8,  9};
     double s2[] = {18, 17, 16, 15, 14, 13, 12 ,11, 10};
@@ -758,8 +758,8 @@ void test_unifrac_stripes_to_condensed_form_odd2() {
 }
 
 
-void test_unifrac_stripes_to_buf_even() {
-    SUITE_START("test stripes_to_buf even samples");
+void test_unifrac_stripes_to_matrix_even() {
+    SUITE_START("test stripes_to_matrix even samples");
     std::vector<double*> stripes;
     double s1[] = {0,  9, 17, 24, 30, 35, 39, 42, 44,  8};
     double s2[] = {1, 10, 18, 25, 31, 36, 40, 43,  7, 16};
@@ -784,7 +784,7 @@ void test_unifrac_stripes_to_buf_even() {
                       7, 15, 22, 28, 33, 37, 40, 42,  0, 44,
                       8, 16, 23, 29, 34, 38, 41, 43, 44,  0};
     float *obs = (float*)malloc(sizeof(float) * 100);
-    su::stripes_to_buf_fp32(stripes, 10, obs, 0, 5);
+    su::stripes_to_matrix_fp32(stripes, 10, obs, 0, 5);
     for(unsigned int i = 0; i < 100; i++) {
         ASSERT(exp[i] == obs[i]);
     }
@@ -794,7 +794,7 @@ void test_unifrac_stripes_to_buf_even() {
     su::stripes_to_condensed_form(stripes, 10, obsC, 0, 5);
 
     float *obs2 = (float*)malloc(sizeof(float) * 100);
-    su::condensed_form_to_buf_fp32(obsC, 10, obs2);
+    su::condensed_form_to_matrix_fp32(obsC, 10, obs2);
 
     for(unsigned int i = 0; i < 100; i++) {
         ASSERT(exp[i] == obs2[i]);
@@ -806,8 +806,8 @@ void test_unifrac_stripes_to_buf_even() {
     SUITE_END();
 }
 
-void test_unifrac_stripes_to_buf_odd() {
-    SUITE_START("test stripes_to_buf odd samples");
+void test_unifrac_stripes_to_matrix_odd() {
+    SUITE_START("test stripes_to_matrix odd samples");
     std::vector<double*> stripes;
     double s1[] = { 1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 0};
     double s2[] = {20, 19, 18, 17, 16, 15, 14 ,13, 12, 11, 1};
@@ -832,7 +832,7 @@ void test_unifrac_stripes_to_buf_odd() {
                        11, 30, 31, 50, 45, 35, 27, 13,  9,  0, 10,
                         0,  1,  2,  3,  4, 46, 34, 28, 12, 10,  0};
     double *obs = (double*)malloc(sizeof(double) * 121);
-    su::stripes_to_buf(stripes, 11, obs, 0, 5);
+    su::stripes_to_matrix(stripes, 11, obs, 0, 5);
     for(unsigned int i = 0; i < 121; i++) {
         ASSERT(exp[i] == obs[i]);
     }
@@ -842,7 +842,7 @@ void test_unifrac_stripes_to_buf_odd() {
     su::stripes_to_condensed_form(stripes, 11, obsC, 0, 5);
 
     double *obs2 = (double*)malloc(sizeof(double) * 121);
-    su::condensed_form_to_buf(obsC, 11, obs2);
+    su::condensed_form_to_matrix(obsC, 11, obs2);
     
     for(unsigned int i = 0; i < 121; i++) {
         ASSERT(exp[i] == obs2[i]);
@@ -854,8 +854,8 @@ void test_unifrac_stripes_to_buf_odd() {
     SUITE_END();
 }
 
-void test_unifrac_stripes_to_buf_odd2() {
-    SUITE_START("test stripes_to_buf odd samples");
+void test_unifrac_stripes_to_matrix_odd2() {
+    SUITE_START("test stripes_to_matrix odd(2) samples");
     std::vector<double*> stripes;
     double s1[] = { 1,  2,  3,  4,  5,  6,  7,  8,  9};
     double s2[] = {18, 17, 16, 15, 14, 13, 12 ,11, 10};
@@ -879,7 +879,7 @@ void test_unifrac_stripes_to_buf_odd2() {
                        9, 10, 27, 28, 32, 24, 12,  8,  0};
 
     double *obs = (double*)malloc(sizeof(double) * 81);
-    su::stripes_to_buf(stripes, 9, obs, 0, 5);
+    su::stripes_to_matrix(stripes, 9, obs, 0, 5);
     for(unsigned int i = 0; i < 81; i++) {
         ASSERT(exp[i] == obs[i]);
     }
@@ -889,7 +889,7 @@ void test_unifrac_stripes_to_buf_odd2() {
     su::stripes_to_condensed_form(stripes, 9, obsC, 0, 5);
 
     double *obs2 = (double*)malloc(sizeof(double) * 81);
-    su::condensed_form_to_buf(obsC, 9, obs2);
+    su::condensed_form_to_matrix(obsC, 9, obs2);
     
     for(unsigned int i = 0; i < 81; i++) {
         ASSERT(exp[i] == obs2[i]);
@@ -1556,9 +1556,9 @@ int main(int argc, char** argv) {
     test_unifrac_stripes_to_condensed_form_even();
     test_unifrac_stripes_to_condensed_form_odd();
     test_unifrac_stripes_to_condensed_form_odd2();
-    test_unifrac_stripes_to_buf_even();
-    test_unifrac_stripes_to_buf_odd();
-    test_unifrac_stripes_to_buf_odd2();
+    test_unifrac_stripes_to_matrix_even();
+    test_unifrac_stripes_to_matrix_odd();
+    test_unifrac_stripes_to_matrix_odd2();
     test_unweighted_unifrac();
     test_unweighted_unifrac_fast();
     test_unnormalized_weighted_unifrac();

--- a/sucpp/test_su.cpp
+++ b/sucpp/test_su.cpp
@@ -725,6 +725,39 @@ void test_unifrac_stripes_to_condensed_form_odd() {
     SUITE_END();
 }
 
+void test_unifrac_stripes_to_condensed_form_odd2() {
+    SUITE_START("test stripes_to_condensed_form odd samples");
+    std::vector<double*> stripes;
+    double s1[] = { 1,  2,  3,  4,  5,  6,  7,  8,  9};
+    double s2[] = {18, 17, 16, 15, 14, 13, 12 ,11, 10};
+    double s3[] = {19, 20, 21, 22, 23, 24, 25, 26, 27};
+    double s4[] = {36, 35, 34, 33, 32, 31, 30, 29, 28};
+    double s5[] = {31, 30, 29, 28, 36, 35, 34, 33, 32};
+    stripes.push_back(s1);
+    stripes.push_back(s2);
+    stripes.push_back(s3);
+    stripes.push_back(s4);
+    stripes.push_back(s5);
+
+    double exp[36] = {/* 0, */ 1, 18, 19, 36, 31, 25, 11,  9,
+                      /* 1,  0, */ 2, 17, 20, 35, 30, 26, 10,
+                      /*20,  2,  0, */ 3, 16, 21, 34, 29, 27,
+                      /*21, 19,  3,  0, */ 4, 15, 22, 33, 28,
+                      /*40, 22, 18,  4,  0, */ 5, 14, 23 ,32,
+                      /*41, 39, 23, 17,  5,  0, */ 6, 13, 24,
+                      /*47, 42, 38, 24, 16,  6,  0, */ 7, 12,
+                      /*47, 42, 38, 24, 16,  6,  7, 0, */  8};
+                      /* 0,  1,  2,  3,  4, 46, 34, 8,  8, 0}; */
+    double *obs = (double*)malloc(sizeof(double) * 36);
+    su::stripes_to_condensed_form(stripes, 9, obs, 0, 5);
+    for(unsigned int i = 0; i < 36; i++) {
+        ASSERT(exp[i] == obs[i]);
+    }
+    free(obs);
+    SUITE_END();
+}
+
+
 void test_unifrac_stripes_to_buf_even() {
     SUITE_START("test stripes_to_buf even samples");
     std::vector<double*> stripes;
@@ -820,6 +853,54 @@ void test_unifrac_stripes_to_buf_odd() {
     free(obs);
     SUITE_END();
 }
+
+void test_unifrac_stripes_to_buf_odd2() {
+    SUITE_START("test stripes_to_buf odd samples");
+    std::vector<double*> stripes;
+    double s1[] = { 1,  2,  3,  4,  5,  6,  7,  8,  9};
+    double s2[] = {18, 17, 16, 15, 14, 13, 12 ,11, 10};
+    double s3[] = {19, 20, 21, 22, 23, 24, 25, 26, 27};
+    double s4[] = {36, 35, 34, 33, 32, 31, 30, 29, 28};
+    double s5[] = {31, 30, 29, 28, 36, 35, 34, 33, 32};
+    stripes.push_back(s1);
+    stripes.push_back(s2);
+    stripes.push_back(s3);
+    stripes.push_back(s4);
+    stripes.push_back(s5);
+
+    double exp[81] = { 0,  1, 18, 19, 36, 31, 25, 11,  9,
+                       1,  0,  2, 17, 20, 35, 30, 26, 10,
+                      18,  2,  0,  3, 16, 21, 34, 29, 27,
+                      19, 17,  3,  0,  4, 15, 22, 33, 28,
+                      36, 20, 16,  4,  0,  5, 14, 23 ,32,
+                      31, 35, 21, 15,  5,  0,  6, 13, 24,
+                      25, 30, 34, 22, 14,  6,  0,  7, 12,
+                      11, 26, 29, 33, 23, 13,  7,  0,  8,
+                       9, 10, 27, 28, 32, 24, 12,  8,  0};
+
+    double *obs = (double*)malloc(sizeof(double) * 81);
+    su::stripes_to_buf(stripes, 9, obs, 0, 5);
+    for(unsigned int i = 0; i < 81; i++) {
+        ASSERT(exp[i] == obs[i]);
+    }
+
+    // test also intermediate, 2-step procedure
+    double *obsC = (double*)malloc(sizeof(double) * 36);
+    su::stripes_to_condensed_form(stripes, 9, obsC, 0, 5);
+
+    double *obs2 = (double*)malloc(sizeof(double) * 81);
+    su::condensed_form_to_buf(obsC, 9, obs2);
+    
+    for(unsigned int i = 0; i < 81; i++) {
+        ASSERT(exp[i] == obs2[i]);
+    }
+
+    free(obs2);
+    free(obsC);
+    free(obs);
+    SUITE_END();
+}
+
 
 void test_unnormalized_weighted_unifrac() {
     SUITE_START("test unnormalized weighted unifrac");
@@ -1474,8 +1555,10 @@ int main(int argc, char** argv) {
     test_unifrac_deconvolute_stripes();
     test_unifrac_stripes_to_condensed_form_even();
     test_unifrac_stripes_to_condensed_form_odd();
+    test_unifrac_stripes_to_condensed_form_odd2();
     test_unifrac_stripes_to_buf_even();
     test_unifrac_stripes_to_buf_odd();
+    test_unifrac_stripes_to_buf_odd2();
     test_unweighted_unifrac();
     test_unweighted_unifrac_fast();
     test_unnormalized_weighted_unifrac();

--- a/sucpp/test_su.cpp
+++ b/sucpp/test_su.cpp
@@ -784,7 +784,7 @@ void test_unifrac_stripes_to_matrix_even() {
                       7, 15, 22, 28, 33, 37, 40, 42,  0, 44,
                       8, 16, 23, 29, 34, 38, 41, 43, 44,  0};
     float *obs = (float*)malloc(sizeof(float) * 100);
-    su::stripes_to_matrix_fp32(stripes.data(), 10, 5, obs);
+    su::stripes_to_matrix_fp32(su::MemoryStripes(stripes), 10, 5, obs);
     for(unsigned int i = 0; i < 100; i++) {
         ASSERT(exp[i] == obs[i]);
     }
@@ -832,7 +832,7 @@ void test_unifrac_stripes_to_matrix_odd() {
                        11, 30, 31, 50, 45, 35, 27, 13,  9,  0, 10,
                         0,  1,  2,  3,  4, 46, 34, 28, 12, 10,  0};
     double *obs = (double*)malloc(sizeof(double) * 121);
-    su::stripes_to_matrix(stripes.data(), 11, 5, obs);
+    su::stripes_to_matrix(su::MemoryStripes(stripes), 11, 5, obs);
     for(unsigned int i = 0; i < 121; i++) {
         ASSERT(exp[i] == obs[i]);
     }
@@ -879,7 +879,7 @@ void test_unifrac_stripes_to_matrix_odd2() {
                        9, 10, 27, 28, 32, 24, 12,  8,  0};
 
     double *obs = (double*)malloc(sizeof(double) * 81);
-    su::stripes_to_matrix(stripes.data(), 9, 5, obs);
+    su::stripes_to_matrix(su::MemoryStripes(stripes), 9, 5, obs);
     for(unsigned int i = 0; i < 81; i++) {
         ASSERT(exp[i] == obs[i]);
     }

--- a/sucpp/test_su.cpp
+++ b/sucpp/test_su.cpp
@@ -611,7 +611,6 @@ void test_unifrac_set_proportions() {
     su::biom table = su::biom("test.biom");
     su::PropStack ps = su::PropStack(table.n_samples);
 
-    double sample_counts[] = {7, 3, 4, 6, 3, 4};
     double *obs = ps.pop(4); // GG_OTU_2
     double exp4[] = {0.714285714286, 0.333333333333, 0.0, 0.333333333333, 1.0, 0.25};
     set_proportions(obs, tree, 4, table, ps);
@@ -1066,7 +1065,6 @@ void test_faith_pd_shear(){
 
 void test_unweighted_unifrac() {
     SUITE_START("test unweighted unifrac");
-    double **obs;
     std::vector<std::thread> threads(1);
     su::BPTree tree = su::BPTree("(GG_OTU_1:1,(GG_OTU_2:1,GG_OTU_3:1):1,(GG_OTU_5:1,GG_OTU_4:1):1);");
     su::biom table = su::biom("test.biom");
@@ -1106,7 +1104,6 @@ void test_unweighted_unifrac() {
 
 void test_unweighted_unifrac_fast() {
     SUITE_START("test unweighted unifrac no tips");
-    double **obs;
     std::vector<std::thread> threads(1);
     su::BPTree tree = su::BPTree("(GG_OTU_1:1,(GG_OTU_2:1,GG_OTU_3:1):1,(GG_OTU_5:1,GG_OTU_4:1):1);");
     su::biom table = su::biom("test.biom");
@@ -1146,7 +1143,6 @@ void test_unweighted_unifrac_fast() {
 
 void test_normalized_weighted_unifrac() {
     SUITE_START("test normalized weighted unifrac");
-    double **obs;
     std::vector<std::thread> threads(1);
     su::BPTree tree = su::BPTree("(GG_OTU_1:1,(GG_OTU_2:1,GG_OTU_3:1):1,(GG_OTU_5:1,GG_OTU_4:1):1);");
     su::biom table = su::biom("test.biom");

--- a/sucpp/unifrac.cpp
+++ b/sucpp/unifrac.cpp
@@ -234,7 +234,7 @@ void su::condensed_form_to_matrix_fp32(const double*  __restrict__ cf, const uin
 // write in a 2D matrix 
 // also suitable for writing to disk
 template<class TReal>
-void su::stripes_to_matrix_T(const std::vector<double*> &stripes, const uint32_t n_samples, const uint32_t n_stripes, TReal*  __restrict__ buf2d) {
+void su::stripes_to_matrix_T(const double  * __restrict__ const * __restrict__ stripes, const uint32_t n_samples, const uint32_t n_stripes, TReal*  __restrict__ buf2d) {
     // n must be >= 2, but that should be enforced upstream as that would imply
     // computing unifrac on a single sample.
 
@@ -329,14 +329,14 @@ void su::stripes_to_matrix_T(const std::vector<double*> &stripes, const uint32_t
 }
 
 // Make sure it gets instantiated
-template void su::stripes_to_matrix_T<double>(const std::vector<double*> &stripes, const uint32_t n_samples, const uint32_t n_stripes, double*  __restrict__ buf2d);
-template void su::stripes_to_matrix_T<float>(const std::vector<double*> &stripes, const uint32_t n_samples, const uint32_t n_stripes, float*  __restrict__ buf2d);
+template void su::stripes_to_matrix_T<double>(const double  * __restrict__ const * __restrict__ stripes, const uint32_t n_samples, const uint32_t n_stripes, double*  __restrict__ buf2d);
+template void su::stripes_to_matrix_T<float>(const double  * __restrict__ const * __restrict__stripes, const uint32_t n_samples, const uint32_t n_stripes, float*  __restrict__ buf2d);
 
-void su::stripes_to_matrix(const std::vector<double*> &stripes, const uint32_t n_samples, const uint32_t n_stripes, double*  __restrict__ buf2d) {
+void su::stripes_to_matrix(const double  * __restrict__ const * __restrict__ stripes, const uint32_t n_samples, const uint32_t n_stripes, double*  __restrict__ buf2d) {
    return su::stripes_to_matrix_T<double>(stripes, n_samples, n_stripes, buf2d);
 }
 
-void su::stripes_to_matrix_fp32(const std::vector<double*> &stripes, const uint32_t n_samples, const uint32_t n_stripes, float*  __restrict__ buf2d) {
+void su::stripes_to_matrix_fp32(const double  * __restrict__ const * __restrict__ stripes, const uint32_t n_samples, const uint32_t n_stripes, float*  __restrict__ buf2d) {
   return su::stripes_to_matrix_T<float>(stripes, n_samples, n_stripes, buf2d);
 }
 

--- a/sucpp/unifrac.cpp
+++ b/sucpp/unifrac.cpp
@@ -180,9 +180,11 @@ void su::stripes_to_condensed_form(std::vector<double*> &stripes, uint32_t n, do
     }
 }
 
-// write in a format suitable for writing to disk
+
+// write in a 2D matrix 
+// also suitable for writing to disk
 template<class TReal>
-void su::condensed_form_to_buf_T(double* cf, uint32_t n, TReal* buf2d) {
+void su::condensed_form_to_matrix_T(double* cf, uint32_t n, TReal* buf2d) {
      const uint64_t comb_N = su::comb_2(n);
      for(uint64_t i = 0; i < n; i++) {
         for(uint64_t j = 0; j < n; j++) {
@@ -203,15 +205,15 @@ void su::condensed_form_to_buf_T(double* cf, uint32_t n, TReal* buf2d) {
 
 
 // make sure it is instantiated
-template void su::condensed_form_to_buf_T<double>(double* cf, uint32_t n, double* buf2d);
-template void su::condensed_form_to_buf_T<float>(double* cf, uint32_t n, float* buf2d);
+template void su::condensed_form_to_matrix_T<double>(double* cf, uint32_t n, double* buf2d);
+template void su::condensed_form_to_matrix_T<float>(double* cf, uint32_t n, float* buf2d);
 
-void su::condensed_form_to_buf(double* cf, uint32_t n, double* buf2d) {
-  su::condensed_form_to_buf_T<double>(cf,n,buf2d);
+void su::condensed_form_to_matrix(double* cf, uint32_t n, double* buf2d) {
+  su::condensed_form_to_mtrix_T<double>(cf,n,buf2d);
 }
 
-void su::condensed_form_to_buf_fp32(double* cf, uint32_t n, float* buf2d) {
-  su::condensed_form_to_buf_T<float>(cf,n,buf2d);
+void su::condensed_form_to_matrix_fp32(double* cf, uint32_t n, float* buf2d) {
+  su::condensed_form_to_matrix_T<float>(cf,n,buf2d);
 }
 
 /*
@@ -229,9 +231,10 @@ void su::condensed_form_to_buf_fp32(double* cf, uint32_t n, float* buf2d) {
  * [ A A A A A A ]
  */
 
-// write in a format suitable for writing to disk
+// write in a 2D matrix 
+// also suitable for writing to disk
 template<class TReal>
-void su::stripes_to_buf_T(std::vector<double*> &stripes, uint32_t n, TReal* buf2d, unsigned int start, unsigned int stop) {
+void su::stripes_to_matrix_T(std::vector<double*> &stripes, uint32_t n, TReal* buf2d, unsigned int start, unsigned int stop) {
     // n must be >= 2, but that should be enforced upstream as that would imply
     // computing unifrac on a single sample.
 
@@ -328,15 +331,15 @@ void su::stripes_to_buf_T(std::vector<double*> &stripes, uint32_t n, TReal* buf2
 }
 
 // Make sure it gets instantiated
-template void su::stripes_to_buf_T<double>(std::vector<double*> &stripes, uint32_t n, double* buf2d, unsigned int start, unsigned int stop);
-template void su::stripes_to_buf_T<float>(std::vector<double*> &stripes, uint32_t n, float* buf2d, unsigned int start, unsigned int stop);
+template void su::stripes_to_matrix_T<double>(std::vector<double*> &stripes, uint32_t n, double* buf2d, unsigned int start, unsigned int stop);
+template void su::stripes_to_matrix_T<float>(std::vector<double*> &stripes, uint32_t n, float* buf2d, unsigned int start, unsigned int stop);
 
-void su::stripes_to_buf(std::vector<double*> &stripes, uint32_t n, double* buf2d, unsigned int start, unsigned int stop) {
-   return su::stripes_to_buf_T<double>(stripes, n, buf2d, start, stop);
+void su::stripes_to_matrix(std::vector<double*> &stripes, uint32_t n, double* buf2d, unsigned int start, unsigned int stop) {
+   return su::stripes_to_matrix_T<double>(stripes, n, buf2d, start, stop);
 }
 
-void su::stripes_to_buf_fp32(std::vector<double*> &stripes, uint32_t n, float* buf2d, unsigned int start, unsigned int stop) {
-  return su::stripes_to_buf_T<float>(stripes, n, buf2d, start, stop);
+void su::stripes_to_matrix_fp32(std::vector<double*> &stripes, uint32_t n, float* buf2d, unsigned int start, unsigned int stop) {
+  return su::stripes_to_matrix_T<float>(stripes, n, buf2d, start, stop);
 }
 
 

--- a/sucpp/unifrac.cpp
+++ b/sucpp/unifrac.cpp
@@ -234,7 +234,7 @@ void su::condensed_form_to_matrix_fp32(const double*  __restrict__ cf, const uin
 // write in a 2D matrix 
 // also suitable for writing to disk
 template<class TReal>
-void su::stripes_to_matrix_T(const double  * __restrict__ const * __restrict__ stripes, const uint32_t n_samples, const uint32_t n_stripes, TReal*  __restrict__ buf2d) {
+void su::stripes_to_matrix_T(const ManagedStripes &stripes, const uint32_t n_samples, const uint32_t n_stripes, TReal*  __restrict__ buf2d) {
     // n must be >= 2, but that should be enforced upstream as that would imply
     // computing unifrac on a single sample.
 
@@ -262,7 +262,8 @@ void su::stripes_to_matrix_T(const double  * __restrict__ const * __restrict__ s
 
              uint64_t j = i+1;
              for(; (stripe<n_stripes) && (j<jMax); stripe++, j++) {
-               TReal val = stripes[stripe][i];
+               const double *mystripe = stripes.get_stripe(stripe);
+               TReal val = mystripe[i];
                buf2d[i*n_samples+j] = val;
              }
 
@@ -270,7 +271,8 @@ void su::stripes_to_matrix_T(const double  * __restrict__ const * __restrict__ s
                stripe=n_samples-n_stripes-1;
                for(; j < jMax; j++) {
                  --stripe;
-                 TReal val = stripes[stripe][j];
+                 const double *mystripe = stripes.get_stripe(stripe);
+                 TReal val = mystripe[j];
                  buf2d[i*n_samples+j] = val;
                }
              }
@@ -298,7 +300,8 @@ void su::stripes_to_matrix_T(const double  * __restrict__ const * __restrict__ s
                stripe=n_stripes;
              }
              for(; (stripe<n_stripes) && (j<jMax); stripe++, j++) {
-                TReal val = stripes[stripe][i];
+                const double *mystripe = stripes.get_stripe(stripe);
+                TReal val = mystripe[i];
                 buf2d[i*n_samples+j] = val;
              }
 
@@ -307,10 +310,11 @@ void su::stripes_to_matrix_T(const double  * __restrict__ const * __restrict__ s
                if (j<jOut) {
                  stripe -= (jOut-j); // note: should not be able to overshoot
                  j=jOut;
-               } 
+               }
                for(; j < jMax; j++) {
                  --stripe;
-                 TReal val = stripes[stripe][j];
+                 const double * mystripe = stripes.get_stripe(stripe);
+                 TReal val = mystripe[j];
                  buf2d[i*n_samples+j] = val;
                }
              }
@@ -329,14 +333,14 @@ void su::stripes_to_matrix_T(const double  * __restrict__ const * __restrict__ s
 }
 
 // Make sure it gets instantiated
-template void su::stripes_to_matrix_T<double>(const double  * __restrict__ const * __restrict__ stripes, const uint32_t n_samples, const uint32_t n_stripes, double*  __restrict__ buf2d);
-template void su::stripes_to_matrix_T<float>(const double  * __restrict__ const * __restrict__stripes, const uint32_t n_samples, const uint32_t n_stripes, float*  __restrict__ buf2d);
+template void su::stripes_to_matrix_T<double>(const ManagedStripes &stripes, const uint32_t n_samples, const uint32_t n_stripes, double*  __restrict__ buf2d);
+template void su::stripes_to_matrix_T<float>(const ManagedStripes &stripes, const uint32_t n_samples, const uint32_t n_stripes, float*  __restrict__ buf2d);
 
-void su::stripes_to_matrix(const double  * __restrict__ const * __restrict__ stripes, const uint32_t n_samples, const uint32_t n_stripes, double*  __restrict__ buf2d) {
+void su::stripes_to_matrix(const ManagedStripes &stripes, const uint32_t n_samples, const uint32_t n_stripes, double*  __restrict__ buf2d) {
    return su::stripes_to_matrix_T<double>(stripes, n_samples, n_stripes, buf2d);
 }
 
-void su::stripes_to_matrix_fp32(const double  * __restrict__ const * __restrict__ stripes, const uint32_t n_samples, const uint32_t n_stripes, float*  __restrict__ buf2d) {
+void su::stripes_to_matrix_fp32(const ManagedStripes &stripes, const uint32_t n_samples, const uint32_t n_stripes, float*  __restrict__ buf2d) {
   return su::stripes_to_matrix_T<float>(stripes, n_samples, n_stripes, buf2d);
 }
 

--- a/sucpp/unifrac.cpp
+++ b/sucpp/unifrac.cpp
@@ -209,7 +209,7 @@ template void su::condensed_form_to_matrix_T<double>(double* cf, uint32_t n, dou
 template void su::condensed_form_to_matrix_T<float>(double* cf, uint32_t n, float* buf2d);
 
 void su::condensed_form_to_matrix(double* cf, uint32_t n, double* buf2d) {
-  su::condensed_form_to_mtrix_T<double>(cf,n,buf2d);
+  su::condensed_form_to_matrix_T<double>(cf,n,buf2d);
 }
 
 void su::condensed_form_to_matrix_fp32(double* cf, uint32_t n, float* buf2d) {

--- a/sucpp/unifrac.cpp
+++ b/sucpp/unifrac.cpp
@@ -215,11 +215,17 @@ void su::condensed_form_to_buf_fp32(double* cf, uint32_t n, float* buf2d) {
 }
 
 // write in a format suitable for writing to disk
-// Note: Does not initialize the diagonal
 template<class TReal>
 void su::stripes_to_buf_T(std::vector<double*> &stripes, uint32_t n, TReal* buf2d, unsigned int start, unsigned int stop) {
     // n must be >= 2, but that should be enforced upstream as that would imply
     // computing unifrac on a single sample.
+   
+    // initialize diagonal
+    if (start==0) {
+     for (uint64_t k = 0; k < n; k++) {
+       buf2d[k*n+k] = 0.0;
+     }
+    }
 
     for(unsigned int stripe = start; stripe < stop; stripe++) {
         // compute the (i, j) position of each element in each stripe

--- a/sucpp/unifrac.cpp
+++ b/sucpp/unifrac.cpp
@@ -184,7 +184,7 @@ void su::stripes_to_condensed_form(std::vector<double*> &stripes, uint32_t n, do
 // write in a 2D matrix 
 // also suitable for writing to disk
 template<class TReal>
-void su::condensed_form_to_matrix_T(double* cf, uint32_t n, TReal* buf2d) {
+void su::condensed_form_to_matrix_T(const double*  __restrict__ cf, const uint32_t n, TReal*  __restrict__ buf2d) {
      const uint64_t comb_N = su::comb_2(n);
      for(uint64_t i = 0; i < n; i++) {
         for(uint64_t j = 0; j < n; j++) {
@@ -205,14 +205,14 @@ void su::condensed_form_to_matrix_T(double* cf, uint32_t n, TReal* buf2d) {
 
 
 // make sure it is instantiated
-template void su::condensed_form_to_matrix_T<double>(double* cf, uint32_t n, double* buf2d);
-template void su::condensed_form_to_matrix_T<float>(double* cf, uint32_t n, float* buf2d);
+template void su::condensed_form_to_matrix_T<double>(const double*  __restrict__ cf, const uint32_t n, double*  __restrict__ buf2d);
+template void su::condensed_form_to_matrix_T<float>(const double*  __restrict__ cf, const uint32_t n, float*  __restrict__ buf2d);
 
-void su::condensed_form_to_matrix(double* cf, uint32_t n, double* buf2d) {
+void su::condensed_form_to_matrix(const double*  __restrict__ cf, const uint32_t n, double*  __restrict__ buf2d) {
   su::condensed_form_to_matrix_T<double>(cf,n,buf2d);
 }
 
-void su::condensed_form_to_matrix_fp32(double* cf, uint32_t n, float* buf2d) {
+void su::condensed_form_to_matrix_fp32(const double*  __restrict__ cf, const uint32_t n, float*  __restrict__ buf2d) {
   su::condensed_form_to_matrix_T<float>(cf,n,buf2d);
 }
 
@@ -234,7 +234,7 @@ void su::condensed_form_to_matrix_fp32(double* cf, uint32_t n, float* buf2d) {
 // write in a 2D matrix 
 // also suitable for writing to disk
 template<class TReal>
-void su::stripes_to_matrix_T(std::vector<double*> &stripes, uint32_t n_samples, uint32_t n_stripes, TReal* buf2d) {
+void su::stripes_to_matrix_T(const std::vector<double*> &stripes, const uint32_t n_samples, const uint32_t n_stripes, TReal*  __restrict__ buf2d) {
     // n must be >= 2, but that should be enforced upstream as that would imply
     // computing unifrac on a single sample.
 
@@ -329,14 +329,14 @@ void su::stripes_to_matrix_T(std::vector<double*> &stripes, uint32_t n_samples, 
 }
 
 // Make sure it gets instantiated
-template void su::stripes_to_matrix_T<double>(std::vector<double*> &stripes, uint32_t n_samples, uint32_t n_stripes, double* buf2d);
-template void su::stripes_to_matrix_T<float>(std::vector<double*> &stripes, uint32_t n_samples, uint32_t n_stripes, float* buf2d);
+template void su::stripes_to_matrix_T<double>(const std::vector<double*> &stripes, const uint32_t n_samples, const uint32_t n_stripes, double*  __restrict__ buf2d);
+template void su::stripes_to_matrix_T<float>(const std::vector<double*> &stripes, const uint32_t n_samples, const uint32_t n_stripes, float*  __restrict__ buf2d);
 
-void su::stripes_to_matrix(std::vector<double*> &stripes, uint32_t n_samples, uint32_t n_stripes, double* buf2d) {
+void su::stripes_to_matrix(const std::vector<double*> &stripes, const uint32_t n_samples, const uint32_t n_stripes, double*  __restrict__ buf2d) {
    return su::stripes_to_matrix_T<double>(stripes, n_samples, n_stripes, buf2d);
 }
 
-void su::stripes_to_matrix_fp32(std::vector<double*> &stripes, uint32_t n_samples, uint32_t n_stripes, float* buf2d) {
+void su::stripes_to_matrix_fp32(const std::vector<double*> &stripes, const uint32_t n_samples, const uint32_t n_stripes, float*  __restrict__ buf2d) {
   return su::stripes_to_matrix_T<float>(stripes, n_samples, n_stripes, buf2d);
 }
 

--- a/sucpp/unifrac.cpp
+++ b/sucpp/unifrac.cpp
@@ -247,8 +247,12 @@ void su::stripes_to_matrix_T(const ManagedStripes &stripes, const uint32_t n_sam
     const uint32_t TILE = 128/sizeof(TReal);
 #endif
 
-    for(uint32_t iOut = 0; iOut < n_samples; iOut+=TILE) {
-      for(uint32_t jOut = 0; jOut < n_samples; jOut+=TILE) {
+    for(uint32_t o = 0; o < n_samples; o+=TILE) { // off diagonal
+      for(uint32_t d = 0; d < (n_samples-o); d+=TILE) { // diagonal
+
+         uint32_t iOut = d;
+         uint32_t jOut = d+o;
+
          uint32_t iMax = std::min(iOut+TILE,n_samples);
          uint32_t jMax = std::min(jOut+TILE,n_samples);
 

--- a/sucpp/unifrac.hpp
+++ b/sucpp/unifrac.hpp
@@ -41,11 +41,33 @@
         
         double** deconvolute_stripes(std::vector<double*> &stripes, uint32_t n);
 
+        class ManagedStripes {
+        public:
+           virtual ~ManagedStripes() {}
+           virtual const double *get_stripe(uint32_t stripe) const = 0;
+           virtual void release_stripe(uint32_t stripe) = 0;
+        };
+
+        class MemoryStripes : public ManagedStripes {
+        private:
+           const double  * const * stripes;  // just a pointer, not owned
+        public:
+           MemoryStripes(const double  * const * _stripes) : stripes(_stripes) {}
+           MemoryStripes(std::vector<double*> &_stripes) : stripes(_stripes.data()) {}
+           MemoryStripes(const std::vector<double*> &_stripes) : stripes(_stripes.data()) {}
+           MemoryStripes(const std::vector<const double*> &_stripes) : stripes(_stripes.data()) {}
+           MemoryStripes(std::vector<const double*> &_stripes) : stripes(_stripes.data()) {}
+
+           virtual const double *get_stripe(uint32_t stripe) const {return stripes[stripe];}
+           virtual void release_stripe(uint32_t stripe) {};
+        };
+
+
         void stripes_to_condensed_form(std::vector<double*> &stripes, uint32_t n, double* cf, unsigned int start, unsigned int stop);
 
-        template<class TReal> void stripes_to_matrix_T(const double  * __restrict__ const * __restrict__ stripes, const uint32_t n_samples, const uint32_t n_stripes, TReal*  __restrict__ buf2d);
-        void stripes_to_matrix(const double  * __restrict__ const * __restrict__ stripes, const uint32_t n_samples, const uint32_t n_stripes, double*  __restrict__ buf2d);
-        void stripes_to_matrix_fp32(const double  * __restrict__ const * __restrict__ stripes, const uint32_t n_samples, const uint32_t n_stripes, float*  __restrict__ buf2d);
+        template<class TReal> void stripes_to_matrix_T(const ManagedStripes &stripes, const uint32_t n_samples, const uint32_t n_stripes, TReal*  __restrict__ buf2d);
+        void stripes_to_matrix(const ManagedStripes &stripes, const uint32_t n_samples, const uint32_t n_stripes, double*  __restrict__ buf2d);
+        void stripes_to_matrix_fp32(const ManagedStripes &stripes, const uint32_t n_samples, const uint32_t n_stripes, float*  __restrict__ buf2d);
 
 
         template<class TReal> void condensed_form_to_matrix_T(const double*  __restrict__ cf, const uint32_t n, TReal*  __restrict__ buf2d);

--- a/sucpp/unifrac.hpp
+++ b/sucpp/unifrac.hpp
@@ -45,7 +45,7 @@
         public:
            virtual ~ManagedStripes() {}
            virtual const double *get_stripe(uint32_t stripe) const = 0;
-           virtual void release_stripe(uint32_t stripe) = 0;
+           virtual void release_stripe(uint32_t stripe) const = 0;
         };
 
         class MemoryStripes : public ManagedStripes {
@@ -59,15 +59,16 @@
            MemoryStripes(std::vector<const double*> &_stripes) : stripes(_stripes.data()) {}
 
            virtual const double *get_stripe(uint32_t stripe) const {return stripes[stripe];}
-           virtual void release_stripe(uint32_t stripe) {};
+           virtual void release_stripe(uint32_t stripe) const {};
         };
 
 
         void stripes_to_condensed_form(std::vector<double*> &stripes, uint32_t n, double* cf, unsigned int start, unsigned int stop);
 
-        template<class TReal> void stripes_to_matrix_T(const ManagedStripes &stripes, const uint32_t n_samples, const uint32_t n_stripes, TReal*  __restrict__ buf2d);
-        void stripes_to_matrix(const ManagedStripes &stripes, const uint32_t n_samples, const uint32_t n_stripes, double*  __restrict__ buf2d);
-        void stripes_to_matrix_fp32(const ManagedStripes &stripes, const uint32_t n_samples, const uint32_t n_stripes, float*  __restrict__ buf2d);
+        // tile_size==0 means memory optimized
+        template<class TReal> void stripes_to_matrix_T(const ManagedStripes &stripes, const uint32_t n_samples, const uint32_t n_stripes, TReal*  __restrict__ buf2d, uint32_t tile_size=0);
+        void stripes_to_matrix(const ManagedStripes &stripes, const uint32_t n_samples, const uint32_t n_stripes, double*  __restrict__ buf2d, uint32_t tile_size=0);
+        void stripes_to_matrix_fp32(const ManagedStripes &stripes, const uint32_t n_samples, const uint32_t n_stripes, float*  __restrict__ buf2d, uint32_t tile_size=0);
 
 
         template<class TReal> void condensed_form_to_matrix_T(const double*  __restrict__ cf, const uint32_t n, TReal*  __restrict__ buf2d);

--- a/sucpp/unifrac.hpp
+++ b/sucpp/unifrac.hpp
@@ -43,14 +43,14 @@
 
         void stripes_to_condensed_form(std::vector<double*> &stripes, uint32_t n, double* cf, unsigned int start, unsigned int stop);
 
-        template<class TReal> void stripes_to_buf_T(std::vector<double*> &stripes, uint32_t n, TReal* buf2d, unsigned int start, unsigned int stop);
-        void stripes_to_buf(std::vector<double*> &stripes, uint32_t n, double* buf2d, unsigned int start, unsigned int stop);
-        void stripes_to_buf_fp32(std::vector<double*> &stripes, uint32_t n, float* buf2d, unsigned int start, unsigned int stop);
+        template<class TReal> void stripes_to_matrix_T(std::vector<double*> &stripes, uint32_t n, TReal* buf2d, unsigned int start, unsigned int stop);
+        void stripes_to_matrix(std::vector<double*> &stripes, uint32_t n, double* buf2d, unsigned int start, unsigned int stop);
+        void stripes_to_matrix_fp32(std::vector<double*> &stripes, uint32_t n, float* buf2d, unsigned int start, unsigned int stop);
 
 
-        template<class TReal> void condensed_form_to_buf_T(double* cf, uint32_t n, TReal* buf2d);
-        void condensed_form_to_buf(double* cf, uint32_t n, double* buf2d);
-        void condensed_form_to_buf_fp32(double* cf, uint32_t n, float* buf2d);
+        template<class TReal> void condensed_form_to_matrix_T(double* cf, uint32_t n, TReal* buf2d);
+        void condensed_form_to_matrix(double* cf, uint32_t n, double* buf2d);
+        void condensed_form_to_matrix_fp32(double* cf, uint32_t n, float* buf2d);
 
         void set_proportions(double* props, 
                              BPTree &tree, uint32_t node, 

--- a/sucpp/unifrac.hpp
+++ b/sucpp/unifrac.hpp
@@ -40,9 +40,18 @@
                          const task_parameters* task_p);
         
         double** deconvolute_stripes(std::vector<double*> &stripes, uint32_t n);
-        void stripes_to_condensed_form(std::vector<double*> &stripes, uint32_t n, double* &cf, unsigned int start, unsigned int stop);
-        void stripes_to_buf(std::vector<double*> &stripes, uint32_t n, double* &buf2d, unsigned int start, unsigned int stop);
-        void stripes_to_buf(std::vector<double*> &stripes, uint32_t n, float* &buf2d, unsigned int start, unsigned int stop);
+
+        void stripes_to_condensed_form(std::vector<double*> &stripes, uint32_t n, double* cf, unsigned int start, unsigned int stop);
+
+        template<class TReal> void stripes_to_buf_T(std::vector<double*> &stripes, uint32_t n, TReal* buf2d, unsigned int start, unsigned int stop);
+        void stripes_to_buf(std::vector<double*> &stripes, uint32_t n, double* buf2d, unsigned int start, unsigned int stop);
+        void stripes_to_buf_fp32(std::vector<double*> &stripes, uint32_t n, float* buf2d, unsigned int start, unsigned int stop);
+
+
+        template<class TReal> void condensed_form_to_buf_T(double* cf, uint32_t n, TReal* buf2d);
+        void condensed_form_to_buf(double* cf, uint32_t n, double* buf2d);
+        void condensed_form_to_buf_fp32(double* cf, uint32_t n, float* buf2d);
+
         void set_proportions(double* props, 
                              BPTree &tree, uint32_t node, 
                              biom &table, 

--- a/sucpp/unifrac.hpp
+++ b/sucpp/unifrac.hpp
@@ -43,9 +43,9 @@
 
         void stripes_to_condensed_form(std::vector<double*> &stripes, uint32_t n, double* cf, unsigned int start, unsigned int stop);
 
-        template<class TReal> void stripes_to_matrix_T(std::vector<double*> &stripes, uint32_t n, TReal* buf2d, unsigned int start, unsigned int stop);
-        void stripes_to_matrix(std::vector<double*> &stripes, uint32_t n, double* buf2d, unsigned int start, unsigned int stop);
-        void stripes_to_matrix_fp32(std::vector<double*> &stripes, uint32_t n, float* buf2d, unsigned int start, unsigned int stop);
+        template<class TReal> void stripes_to_matrix_T(std::vector<double*> &stripes, uint32_t n_samples, uint32_t n_stripes, TReal* buf2d);
+        void stripes_to_matrix(std::vector<double*> &stripes, uint32_t n_samples, uint32_t n_stripes, double* buf2d);
+        void stripes_to_matrix_fp32(std::vector<double*> &stripes, uint32_t n_samples, uint32_t n_stripes, float* buf2d);
 
 
         template<class TReal> void condensed_form_to_matrix_T(double* cf, uint32_t n, TReal* buf2d);

--- a/sucpp/unifrac.hpp
+++ b/sucpp/unifrac.hpp
@@ -43,14 +43,14 @@
 
         void stripes_to_condensed_form(std::vector<double*> &stripes, uint32_t n, double* cf, unsigned int start, unsigned int stop);
 
-        template<class TReal> void stripes_to_matrix_T(std::vector<double*> &stripes, uint32_t n_samples, uint32_t n_stripes, TReal* buf2d);
-        void stripes_to_matrix(std::vector<double*> &stripes, uint32_t n_samples, uint32_t n_stripes, double* buf2d);
-        void stripes_to_matrix_fp32(std::vector<double*> &stripes, uint32_t n_samples, uint32_t n_stripes, float* buf2d);
+        template<class TReal> void stripes_to_matrix_T(const std::vector<double*> &stripes, const uint32_t n_samples, const uint32_t n_stripes, TReal*  __restrict__ buf2d);
+        void stripes_to_matrix(const std::vector<double*> &stripes, const uint32_t n_samples, const uint32_t n_stripes, double*  __restrict__ buf2d);
+        void stripes_to_matrix_fp32(const std::vector<double*> &stripes, const uint32_t n_samples, const uint32_t n_stripes, float*  __restrict__ buf2d);
 
 
-        template<class TReal> void condensed_form_to_matrix_T(double* cf, uint32_t n, TReal* buf2d);
-        void condensed_form_to_matrix(double* cf, uint32_t n, double* buf2d);
-        void condensed_form_to_matrix_fp32(double* cf, uint32_t n, float* buf2d);
+        template<class TReal> void condensed_form_to_matrix_T(const double*  __restrict__ cf, const uint32_t n, TReal*  __restrict__ buf2d);
+        void condensed_form_to_matrix(const double*  __restrict__ cf, const uint32_t n, double*  __restrict__ buf2d);
+        void condensed_form_to_matrix_fp32(const double*  __restrict__ cf, const uint32_t n, float*  __restrict__ buf2d);
 
         void set_proportions(double* props, 
                              BPTree &tree, uint32_t node, 

--- a/sucpp/unifrac.hpp
+++ b/sucpp/unifrac.hpp
@@ -43,9 +43,9 @@
 
         void stripes_to_condensed_form(std::vector<double*> &stripes, uint32_t n, double* cf, unsigned int start, unsigned int stop);
 
-        template<class TReal> void stripes_to_matrix_T(const std::vector<double*> &stripes, const uint32_t n_samples, const uint32_t n_stripes, TReal*  __restrict__ buf2d);
-        void stripes_to_matrix(const std::vector<double*> &stripes, const uint32_t n_samples, const uint32_t n_stripes, double*  __restrict__ buf2d);
-        void stripes_to_matrix_fp32(const std::vector<double*> &stripes, const uint32_t n_samples, const uint32_t n_stripes, float*  __restrict__ buf2d);
+        template<class TReal> void stripes_to_matrix_T(const double  * __restrict__ const * __restrict__ stripes, const uint32_t n_samples, const uint32_t n_stripes, TReal*  __restrict__ buf2d);
+        void stripes_to_matrix(const double  * __restrict__ const * __restrict__ stripes, const uint32_t n_samples, const uint32_t n_stripes, double*  __restrict__ buf2d);
+        void stripes_to_matrix_fp32(const double  * __restrict__ const * __restrict__ stripes, const uint32_t n_samples, const uint32_t n_stripes, float*  __restrict__ buf2d);
 
 
         template<class TReal> void condensed_form_to_matrix_T(const double*  __restrict__ cf, const uint32_t n, TReal*  __restrict__ buf2d);

--- a/sucpp/unifrac.hpp
+++ b/sucpp/unifrac.hpp
@@ -41,6 +41,8 @@
         
         double** deconvolute_stripes(std::vector<double*> &stripes, uint32_t n);
         void stripes_to_condensed_form(std::vector<double*> &stripes, uint32_t n, double* &cf, unsigned int start, unsigned int stop);
+        void stripes_to_buf(std::vector<double*> &stripes, uint32_t n, double* &buf2d, unsigned int start, unsigned int stop);
+        void stripes_to_buf(std::vector<double*> &stripes, uint32_t n, float* &buf2d, unsigned int start, unsigned int stop);
         void set_proportions(double* props, 
                              BPTree &tree, uint32_t node, 
                              biom &table, 


### PR DESCRIPTION
The original merge used a lot of memory and had a sub-optimal memory access pattern.
The refactoring minimizes the use of memory, improves memory access pattern and add support for using a disk buffer for holding the intermediate matrix.
All combined, it allows to either drastically reduce the runtime or the memory usage.