### PR TITLE
BUG: format string missing value

### DIFF
--- a/sucpp/api.cpp
+++ b/sucpp/api.cpp
@@ -258,7 +258,7 @@ compute_status partial(const char* biom_filename, const char* tree_filename,
     std::vector<double*> dm_stripes_total((table.n_samples + 1) / 2);
 
     if(nthreads > dm_stripes.size()) {
-        fprintf(stderr, "More threads were requested than stripes. Using %d threads.\n", dm_stripes);
+        fprintf(stderr, "More threads were requested than stripes. Using %d threads.\n", dm_stripes.size());
         nthreads = dm_stripes.size();
     }
 
@@ -310,7 +310,7 @@ compute_status one_off(const char* biom_filename, const char* tree_filename,
     std::vector<double*> dm_stripes_total((table.n_samples + 1) / 2);
 
     if(nthreads > dm_stripes.size()) {
-        fprintf(stderr, "More threads were requested than stripes. Using %d threads.\n", dm_stripes);
+        fprintf(stderr, "More threads were requested than stripes. Using %d threads.\n", dm_stripes.size());
         nthreads = dm_stripes.size();
     }
 
@@ -819,7 +819,7 @@ MergeStatus merge_partial(partial_mat_t** partial_mats, int n_partials, unsigned
     }
 
     if(nthreads > stripes.size()) {
-        fprintf(stderr, "More threads were requested than stripes. Using %d threads.\n", stripes);
+        fprintf(stderr, "More threads were requested than stripes. Using %d threads.\n", stripes.size());
         nthreads = stripes.size();
     }
 

--- a/sucpp/api.cpp
+++ b/sucpp/api.cpp
@@ -258,7 +258,7 @@ compute_status partial(const char* biom_filename, const char* tree_filename,
     std::vector<double*> dm_stripes_total((table.n_samples + 1) / 2);
 
     if(nthreads > dm_stripes.size()) {
-        fprintf(stderr, "More threads were requested than stripes. Using %d threads.\n", (table.n_samples +1) / 2);
+        fprintf(stderr, "More threads were requested than stripes. Using %d threads.\n", dm_stripes);
         nthreads = dm_stripes.size();
     }
 
@@ -310,7 +310,7 @@ compute_status one_off(const char* biom_filename, const char* tree_filename,
     std::vector<double*> dm_stripes_total((table.n_samples + 1) / 2);
 
     if(nthreads > dm_stripes.size()) {
-        fprintf(stderr, "More threads were requested than stripes. Using %d threads.\n");
+        fprintf(stderr, "More threads were requested than stripes. Using %d threads.\n", dm_stripes);
         nthreads = dm_stripes.size();
     }
 
@@ -819,7 +819,7 @@ MergeStatus merge_partial(partial_mat_t** partial_mats, int n_partials, unsigned
     }
 
     if(nthreads > stripes.size()) {
-        fprintf(stderr, "More threads were requested than stripes. Using %d threads.\n");
+        fprintf(stderr, "More threads were requested than stripes. Using %d threads.\n", stripes);
         nthreads = stripes.size();
     }
 


### PR DESCRIPTION
I found two more places in the code with the same issue I attempted to correct in #107. These were not discovered in actual use - I'm just assuming that failure to pass a value to `fprintf` will produce unwanted results for someone someday.

I've attempted to use existing variables in all three locations this time (rather than re-calculating the number of stripes), but I haven't used C++ before, and _have not tested_. One of these days, I promise I'll figure out how to build/test this thing, but in the meantime, tread with caution. :)