### PR TITLE
Improvements to cache locality and sparse vector handling

### DIFF
--- a/sucpp/biom.cpp
+++ b/sucpp/biom.cpp
@@ -159,7 +159,7 @@ void biom::create_id_index(std::vector<std::string> &ids,
     }
 }
 
-unsigned int biom::get_obs_data_direct(std::string id, uint32_t *& current_indices_out, double *& current_data_out) {
+unsigned int biom::get_obs_data_direct(const std::string &id, uint32_t *& current_indices_out, double *& current_data_out) {
     uint32_t idx = obs_id_index.at(id);
     uint32_t start = obs_indptr[idx];
     uint32_t end = obs_indptr[idx + 1];
@@ -198,11 +198,11 @@ unsigned int biom::get_obs_data_direct(std::string id, uint32_t *& current_indic
     return count[0];
 }
 
-void biom::get_obs_data(std::string id, double* out) {
+void biom::get_obs_data(const std::string &id, double* out) const {
     uint32_t idx = obs_id_index.at(id);
     unsigned int count = obs_counts_resident[idx];
-    uint32_t *indices = obs_indices_resident[idx];
-    double *data = obs_data_resident[idx];
+    const uint32_t * const indices = obs_indices_resident[idx];
+    const double * const data = obs_data_resident[idx];
 
     // reset our output buffer
     for(unsigned int i = 0; i < n_samples; i++)
@@ -213,7 +213,7 @@ void biom::get_obs_data(std::string id, double* out) {
     }
 }
 
-unsigned int biom::get_sample_data_direct(std::string id, uint32_t *& current_indices_out, double *& current_data_out) {
+unsigned int biom::get_sample_data_direct(const std::string &id, uint32_t *& current_indices_out, double *& current_data_out) {
     uint32_t idx = sample_id_index.at(id);
     uint32_t start = sample_indptr[idx];
     uint32_t end = sample_indptr[idx + 1];

--- a/sucpp/biom.cpp
+++ b/sucpp/biom.cpp
@@ -198,7 +198,8 @@ unsigned int biom::get_obs_data_direct(const std::string &id, uint32_t *& curren
     return count[0];
 }
 
-void biom::get_obs_data(const std::string &id, double* out) const {
+template<class TFloat>
+void biom::get_obs_data_TT(const std::string &id, TFloat* out) const {
     uint32_t idx = obs_id_index.at(id);
     unsigned int count = obs_counts_resident[idx];
     const uint32_t * const indices = obs_indices_resident[idx];
@@ -213,8 +214,18 @@ void biom::get_obs_data(const std::string &id, double* out) const {
     }
 }
 
+void biom::get_obs_data(const std::string &id, double* out) const {
+  biom::get_obs_data_TT(id,out);
+}
+
+void biom::get_obs_data(const std::string &id, float* out) const {
+  biom::get_obs_data_TT(id,out);
+}
+
+
 // note: out is supposed to be fully filled, i.e. out[start:end]
-void biom::get_obs_data_range(const std::string &id, unsigned int start, unsigned int end, double* out) const {
+template<class TFloat>
+void biom::get_obs_data_range_TT(const std::string &id, unsigned int start, unsigned int end, TFloat* out) const {
     uint32_t idx = obs_id_index.at(id);
     unsigned int count = obs_counts_resident[idx];
     const uint32_t * const indices = obs_indices_resident[idx];
@@ -232,7 +243,13 @@ void biom::get_obs_data_range(const std::string &id, unsigned int start, unsigne
     }
 }
 
+void biom::get_obs_data_range(const std::string &id, unsigned int start, unsigned int end, double* out) const {
+  biom::get_obs_data_range_TT(id,start,end,out);
+}
 
+void biom::get_obs_data_range(const std::string &id, unsigned int start, unsigned int end, float* out) const {
+  biom::get_obs_data_range_TT(id,start,end,out);
+}
 
 unsigned int biom::get_sample_data_direct(const std::string &id, uint32_t *& current_indices_out, double *& current_data_out) {
     uint32_t idx = sample_id_index.at(id);

--- a/sucpp/biom.cpp
+++ b/sucpp/biom.cpp
@@ -225,7 +225,7 @@ void biom::get_obs_data(const std::string &id, float* out) const {
 
 // note: out is supposed to be fully filled, i.e. out[start:end]
 template<class TFloat>
-void biom::get_obs_data_range_TT(const std::string &id, unsigned int start, unsigned int end, TFloat* out) const {
+void biom::get_obs_data_range_TT(const std::string &id, unsigned int start, unsigned int end, bool normalize, TFloat* out) const {
     uint32_t idx = obs_id_index.at(id);
     unsigned int count = obs_counts_resident[idx];
     const uint32_t * const indices = obs_indices_resident[idx];
@@ -235,20 +235,29 @@ void biom::get_obs_data_range_TT(const std::string &id, unsigned int start, unsi
     for(unsigned int i = start; i < end; i++)
         out[i-start] = 0.0;
 
-    for(unsigned int i = 0; i < count; i++) {
-        const uint32_t j = indices[i];
+    if (normalize) {
+      for(unsigned int i = 0; i < count; i++) {
+        const int32_t j = indices[i];
         if ((j>=start)&&(j<end)) { 
+          out[j-start] = data[i]/sample_counts[j];
+        }
+      }
+    } else {
+      for(unsigned int i = 0; i < count; i++) {
+        const uint32_t j = indices[i];
+        if ((j>=start)&&(j<end)) {
           out[j-start] = data[i];
         }
+      }
     }
 }
 
-void biom::get_obs_data_range(const std::string &id, unsigned int start, unsigned int end, double* out) const {
-  biom::get_obs_data_range_TT(id,start,end,out);
+void biom::get_obs_data_range(const std::string &id, unsigned int start, unsigned int end, bool normalize, double* out) const {
+  biom::get_obs_data_range_TT(id,start,end,normalize,out);
 }
 
-void biom::get_obs_data_range(const std::string &id, unsigned int start, unsigned int end, float* out) const {
-  biom::get_obs_data_range_TT(id,start,end,out);
+void biom::get_obs_data_range(const std::string &id, unsigned int start, unsigned int end, bool normalize, float* out) const {
+  biom::get_obs_data_range_TT(id,start,end,normalize,out);
 }
 
 unsigned int biom::get_sample_data_direct(const std::string &id, uint32_t *& current_indices_out, double *& current_data_out) {

--- a/sucpp/biom.cpp
+++ b/sucpp/biom.cpp
@@ -213,6 +213,27 @@ void biom::get_obs_data(const std::string &id, double* out) const {
     }
 }
 
+// note: out is supposed to be fully filled, i.e. out[start:end]
+void biom::get_obs_data_range(const std::string &id, unsigned int start, unsigned int end, double* out) const {
+    uint32_t idx = obs_id_index.at(id);
+    unsigned int count = obs_counts_resident[idx];
+    const uint32_t * const indices = obs_indices_resident[idx];
+    const double * const data = obs_data_resident[idx];
+
+    // reset our output buffer
+    for(unsigned int i = start; i < end; i++)
+        out[i-start] = 0.0;
+
+    for(unsigned int i = 0; i < count; i++) {
+        const uint32_t j = indices[i];
+        if ((j>=start)&&(j<end)) { 
+          out[j-start] = data[i];
+        }
+    }
+}
+
+
+
 unsigned int biom::get_sample_data_direct(const std::string &id, uint32_t *& current_indices_out, double *& current_data_out) {
     uint32_t idx = sample_id_index.at(id);
     uint32_t start = sample_indptr[idx];

--- a/sucpp/biom.hpp
+++ b/sucpp/biom.hpp
@@ -38,7 +38,7 @@ namespace su {
              *      Values of an index position [0, n_samples) which do not
              *      have data will be zero'd.
              */
-            void get_obs_data(std::string id, double* out);
+            void get_obs_data(const std::string &id, double* out) const; 
         private:
             /* retain DataSet handles within the HDF5 file */
             H5::DataSet obs_indices;
@@ -50,8 +50,8 @@ namespace su {
             double **obs_data_resident;
             unsigned int *obs_counts_resident;
 
-            unsigned int get_obs_data_direct(std::string id, uint32_t *& current_indices_out, double *& current_data_out);
-            unsigned int get_sample_data_direct(std::string id, uint32_t *& current_indices_out, double *& current_data_out);
+            unsigned int get_obs_data_direct(const std::string &id, uint32_t *& current_indices_out, double *& current_data_out);
+            unsigned int get_sample_data_direct(const std::string &id, uint32_t *& current_indices_out, double *& current_data_out);
             double* get_sample_counts();
 
             /* At construction, lookups mapping IDs -> index position within an

--- a/sucpp/biom.hpp
+++ b/sucpp/biom.hpp
@@ -39,6 +39,7 @@ namespace su {
              *      have data will be zero'd.
              */
             void get_obs_data(const std::string &id, double* out) const; 
+            void get_obs_data(const std::string &id, float* out) const;
 
             /* get a dense vector of a range of observation data
              *
@@ -50,6 +51,7 @@ namespace su {
              *      have data will be zero'd.
              */
             void get_obs_data_range(const std::string &id, unsigned int start, unsigned int end, double* out) const;
+            void get_obs_data_range(const std::string &id, unsigned int start, unsigned int end, float* out) const;
 
         private:
             /* retain DataSet handles within the HDF5 file */
@@ -97,5 +99,10 @@ namespace su {
              */
             void create_id_index(std::vector<std::string> &ids, 
                                  std::unordered_map<std::string, uint32_t> &map);
+
+
+            // templatized version
+            template<class TFloat> void get_obs_data_TT(const std::string &id, TFloat* out) const;
+            template<class TFloat> void get_obs_data_range_TT(const std::string &id, unsigned int start, unsigned int end, TFloat* out) const;
     };
 }

--- a/sucpp/biom.hpp
+++ b/sucpp/biom.hpp
@@ -46,12 +46,13 @@ namespace su {
              * @param id The observation ID to fetc
              * @param start Initial index
              * @param end   First index past the end
+             * @param normalize If set, divide by sample_counts
              * @param out An allocated array of at least size (end-start). First element will corrrectpoint to index start. 
              *      Values of an index position [0, (end-start)) which do not
              *      have data will be zero'd.
              */
-            void get_obs_data_range(const std::string &id, unsigned int start, unsigned int end, double* out) const;
-            void get_obs_data_range(const std::string &id, unsigned int start, unsigned int end, float* out) const;
+            void get_obs_data_range(const std::string &id, unsigned int start, unsigned int end, bool normalize, double* out) const;
+            void get_obs_data_range(const std::string &id, unsigned int start, unsigned int end, bool normalize, float* out) const;
 
         private:
             /* retain DataSet handles within the HDF5 file */
@@ -103,6 +104,6 @@ namespace su {
 
             // templatized version
             template<class TFloat> void get_obs_data_TT(const std::string &id, TFloat* out) const;
-            template<class TFloat> void get_obs_data_range_TT(const std::string &id, unsigned int start, unsigned int end, TFloat* out) const;
+            template<class TFloat> void get_obs_data_range_TT(const std::string &id, unsigned int start, unsigned int end, bool normalize, TFloat* out) const;
     };
 }

--- a/sucpp/biom.hpp
+++ b/sucpp/biom.hpp
@@ -39,6 +39,18 @@ namespace su {
              *      have data will be zero'd.
              */
             void get_obs_data(const std::string &id, double* out) const; 
+
+            /* get a dense vector of a range of observation data
+             *
+             * @param id The observation ID to fetc
+             * @param start Initial index
+             * @param end   First index past the end
+             * @param out An allocated array of at least size (end-start). First element will corrrectpoint to index start. 
+             *      Values of an index position [0, (end-start)) which do not
+             *      have data will be zero'd.
+             */
+            void get_obs_data_range(const std::string &id, unsigned int start, unsigned int end, double* out) const;
+
         private:
             /* retain DataSet handles within the HDF5 file */
             H5::DataSet obs_indices;

--- a/sucpp/test_su.cpp
+++ b/sucpp/test_su.cpp
@@ -555,14 +555,14 @@ void test_bptree_rightsibling() {
 
 void test_propstack_constructor() {
     SUITE_START("test propstack constructor");
-    su::PropStack ps = su::PropStack(10);
+    su::PropStack<double> ps(10);
     // nothing to test directly...
     SUITE_END();
 }
 
 void test_propstack_push_and_pop() {
     SUITE_START("test propstack push and pop");
-    su::PropStack ps = su::PropStack(10);
+    su::PropStack<double> ps(10);
 
     double *vec1 = ps.pop(1);
     double *vec2 = ps.pop(2);
@@ -587,7 +587,7 @@ void test_propstack_push_and_pop() {
 
 void test_propstack_get() {
     SUITE_START("test propstack get");
-    su::PropStack ps = su::PropStack(10);
+    su::PropStack<double> ps(10);
 
     double *vec1 = ps.pop(1);
     double *vec2 = ps.pop(2);
@@ -609,7 +609,7 @@ void test_unifrac_set_proportions() {
     //                           ( ( ) ( ( ) ( ) ) ( ( ) ( ) ) )
     su::BPTree tree = su::BPTree("(GG_OTU_1,(GG_OTU_2,GG_OTU_3),(GG_OTU_5,GG_OTU_4));");
     su::biom table = su::biom("test.biom");
-    su::PropStack ps = su::PropStack(table.n_samples);
+    su::PropStack<double> ps(table.n_samples);
 
     double *obs = ps.pop(4); // GG_OTU_2
     double exp4[] = {0.714285714286, 0.333333333333, 0.0, 0.333333333333, 1.0, 0.25};
@@ -645,7 +645,7 @@ void test_unifrac_set_proportions_range() {
 
     // first the whole table
     {
-      su::PropStack ps = su::PropStack(table.n_samples);
+      su::PropStack<double> ps(table.n_samples);
 
       double *obs = ps.pop(4); // GG_OTU_2
       set_proportions_range(obs, tree, 4, table, 0, table.n_samples, ps);
@@ -665,7 +665,7 @@ void test_unifrac_set_proportions_range() {
 
     // beginning
     {
-      su::PropStack ps = su::PropStack(3);
+      su::PropStack<double> ps(3);
 
       double *obs = ps.pop(4); // GG_OTU_2
       set_proportions_range(obs, tree, 4, table, 0, 3, ps);
@@ -686,7 +686,7 @@ void test_unifrac_set_proportions_range() {
     
     // end
     {
-      su::PropStack ps = su::PropStack(4);
+      su::PropStack<double> ps(4);
 
       double *obs = ps.pop(4); // GG_OTU_2
       set_proportions_range(obs, tree, 4, table, 2, table.n_samples, ps);
@@ -709,7 +709,7 @@ void test_unifrac_set_proportions_range() {
     {
       const unsigned int start = 1;
       const unsigned int end = 4;
-      su::PropStack ps = su::PropStack(end-start);
+      su::PropStack<double> ps(end-start);
 
       double *obs = ps.pop(4); // GG_OTU_2
       set_proportions_range(obs, tree, 4, table, start, end, ps);
@@ -727,8 +727,41 @@ void test_unifrac_set_proportions_range() {
         ASSERT(fabs(obs[i-start] - exp3[i]) < 0.000001);
     }
 
-    
+    SUITE_END();
+}
 
+void test_unifrac_set_proportions_range_float() {
+    SUITE_START("test unifrac set proportions range float");
+    //                           0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5
+    //                           ( ( ) ( ( ) ( ) ) ( ( ) ( ) ) )
+    su::BPTree tree = su::BPTree("(GG_OTU_1,(GG_OTU_2,GG_OTU_3),(GG_OTU_5,GG_OTU_4));");
+    su::biom table = su::biom("test.biom");
+
+    const float exp4[] = {0.714285714286, 0.333333333333, 0.0, 0.333333333333, 1.0, 0.25};
+    const float exp6[] = {0.0, 0.0, 0.25, 0.666666666667, 0.0, 0.5};
+    const float exp3[] = {0.71428571, 0.33333333, 0.25, 1.0, 1.0, 0.75};
+
+    // just midle
+    {
+      const unsigned int start = 1;
+      const unsigned int end = 4;
+      su::PropStack<float> ps(end-start);
+
+      float *obs = ps.pop(4); // GG_OTU_2
+      set_proportions_range(obs, tree, 4, table, start, end, ps);
+      for(unsigned int i =start; i < end; i++)
+        ASSERT(fabs(obs[i-start] - exp4[i]) < 0.000001);
+
+      obs = ps.pop(6); // GG_OTU_3
+      set_proportions_range(obs, tree, 6, table, start, end, ps);
+      for(unsigned int i = start; i < end; i++)
+        ASSERT(fabs(obs[i-start] - exp6[i]) < 0.000001);
+
+      obs = ps.pop(3); // node containing GG_OTU_2 and GG_OTU_3
+      set_proportions_range(obs, tree, 3, table, start, end, ps);
+      for(unsigned int i = start; i < end; i++)
+        ASSERT(fabs(obs[i-start] - exp3[i]) < 0.000001);
+    }
 
     SUITE_END();
 }
@@ -1808,6 +1841,7 @@ int main(int argc, char** argv) {
 
     test_unifrac_set_proportions();
     test_unifrac_set_proportions_range();
+    test_unifrac_set_proportions_range_float();
     test_unifrac_deconvolute_stripes();
     test_unifrac_stripes_to_condensed_form_even();
     test_unifrac_stripes_to_condensed_form_odd();

--- a/sucpp/tree.cpp
+++ b/sucpp/tree.cpp
@@ -197,27 +197,27 @@ void BPTree::index_and_cache() {
     }
 }
 
-uint32_t BPTree::postorderselect(uint32_t k) { 
+uint32_t BPTree::postorderselect(uint32_t k) const { 
     return open(select_0_index[k]);
 }
 
-uint32_t BPTree::preorderselect(uint32_t k) {
+uint32_t BPTree::preorderselect(uint32_t k) const {
     return select_1_index[k];
 }
 
-inline uint32_t BPTree::open(uint32_t i) {
+inline uint32_t BPTree::open(uint32_t i) const {
     return structure[i] ? i : openclose[i];
 }
 
-inline uint32_t BPTree::close(uint32_t i) {
+inline uint32_t BPTree::close(uint32_t i) const {
     return structure[i] ? openclose[i] : i;
 }
 
-bool BPTree::isleaf(unsigned int idx) {
+bool BPTree::isleaf(unsigned int idx) const {
     return (structure[idx] && !structure[idx + 1]);
 }
 
-uint32_t BPTree::leftchild(uint32_t i) {
+uint32_t BPTree::leftchild(uint32_t i) const {
     // aka fchild
     if(isleaf(i))
         return 0;  // this is awkward, using 0 which is root, but a root cannot be a child. edge case
@@ -225,7 +225,7 @@ uint32_t BPTree::leftchild(uint32_t i) {
         return i + 1;
 }
 
-uint32_t BPTree::rightchild(uint32_t i) {
+uint32_t BPTree::rightchild(uint32_t i) const {
     // aka lchild
     if(isleaf(i))
         return 0;  // this is awkward, using 0 which is root, but a root cannot be a child. edge case
@@ -233,7 +233,7 @@ uint32_t BPTree::rightchild(uint32_t i) {
         return open(close(i) - 1);
 }
 
-uint32_t BPTree::rightsibling(uint32_t i) {
+uint32_t BPTree::rightsibling(uint32_t i) const {
     // aka nsibling
     uint32_t position = close(i) + 1;
     if(position >= nparens)
@@ -244,18 +244,18 @@ uint32_t BPTree::rightsibling(uint32_t i) {
         return 0;
 }
 
-int32_t BPTree::parent(uint32_t i) {
+int32_t BPTree::parent(uint32_t i) const {
     return enclose(i);
 }
 
-int32_t BPTree::enclose(uint32_t i) {
+int32_t BPTree::enclose(uint32_t i) const {
     if(structure[i])
         return bwd(i, -2) + 1;
     else
         return bwd(i - 1, -2) + 1; 
 }
 
-int32_t BPTree::bwd(uint32_t i, int d) {
+int32_t BPTree::bwd(uint32_t i, int d) const {
     uint32_t target_excess = excess[i] + d;
     for(int current_idx = i - 1; current_idx >= 0; current_idx--) {
         if(excess[current_idx] == target_excess)
@@ -410,7 +410,7 @@ void BPTree::set_node_metadata(unsigned int open_idx, std::string &token) {
     lengths[open_idx] = length;
 }
 
-inline bool BPTree::is_structure_character(char c) {
+inline bool BPTree::is_structure_character(char c) const {
     return (c == '(' || c == ')' || c == ',' || c == ';');
 }
 

--- a/sucpp/tree.hpp
+++ b/sucpp/tree.hpp
@@ -36,7 +36,7 @@ namespace su {
              *
              * @param i The ith node in a postorder traversal
              */
-            uint32_t postorderselect(uint32_t i);
+            uint32_t postorderselect(uint32_t i)const ;
 
             /* preorder tree traversal
              *
@@ -45,37 +45,37 @@ namespace su {
              *
              * @param i The ith node in a preorder traversal
              */
-            uint32_t preorderselect(uint32_t i);
+            uint32_t preorderselect(uint32_t i) const;
 
             /* Test if the node at an index position is a leaf
              *
              * @param i The node to evaluate
              */
-            bool isleaf(uint32_t i);
+            bool isleaf(uint32_t i) const;
 
             /* Get the left child of a node
              *
              * @param i The node to obtain the left child from
              */
-            uint32_t leftchild(uint32_t i);
+            uint32_t leftchild(uint32_t i) const ;
 
             /* Get the right child of a node
              *
              * @param i The node to obtain the right child from
              */
-            uint32_t rightchild(uint32_t i);
+            uint32_t rightchild(uint32_t i) const;
 
             /* Get the right sibling of a node
              *
              * @param i The node to obtain the right sibling from
              */
-            uint32_t rightsibling(uint32_t i);
+            uint32_t rightsibling(uint32_t i) const;
             
             /* Get the parent of a node
              *
              * @param i The node to obtain the parent of
              */
-            int32_t parent(uint32_t i);
+            int32_t parent(uint32_t i) const;
 
             /* get the names at the tips of the tree */
             std::unordered_set<std::string> get_tip_names();
@@ -112,12 +112,12 @@ namespace su {
             void newick_to_metadata(std::string newick);  // convert newick to attributes
             void structure_to_openclose();  // set the cache mapping between parentheses pairs
             void set_node_metadata(unsigned int open_idx, std::string &token); // set attributes for a node
-            bool is_structure_character(char c);  // test if a character is a newick structure
-            inline uint32_t open(uint32_t i);  // obtain the index of the opening for a given parenthesis
-            inline uint32_t close(uint32_t i);  // obtain the index of the closing for a given parenthesis
+            bool is_structure_character(char c) const;  // test if a character is a newick structure
+            inline uint32_t open(uint32_t i) const;  // obtain the index of the opening for a given parenthesis
+            inline uint32_t close(uint32_t i) const;  // obtain the index of the closing for a given parenthesis
             std::string tokenize(std::string::iterator &start, const std::string::iterator &end);  // newick -> tokens
 
-            int32_t bwd(uint32_t i, int32_t d);
-            int32_t enclose(uint32_t i);
+            int32_t bwd(uint32_t i, int32_t d) const;
+            int32_t enclose(uint32_t i) const;
     };
 }

--- a/sucpp/unifrac.cpp
+++ b/sucpp/unifrac.cpp
@@ -908,7 +908,7 @@ void su::unifrac_vaw(biom &table,
 }
 
 template<class TFloat>
-void su::set_proportions(TFloat* props,
+void su::set_proportions(TFloat* __restrict__ props,
                          const BPTree &tree,
                          uint32_t node,
                          const biom &table,
@@ -926,14 +926,13 @@ void su::set_proportions(TFloat* props,
     } else {
         unsigned int current = tree.leftchild(node);
         unsigned int right = tree.rightchild(node);
-        TFloat *vec;
 
 #pragma omp parallel for schedule(static)
         for(unsigned int i = 0; i < table.n_samples; i++)
             props[i] = 0;
 
         while(current <= right && current != 0) {
-            vec = ps.get(current);  // pull from prop map
+            TFloat * __restrict__ vec = ps.get(current);  // pull from prop map
             ps.push(current);  // remove from prop map, place back on stack
 
 #pragma omp parallel for schedule(static)
@@ -946,13 +945,13 @@ void su::set_proportions(TFloat* props,
 }
 
 // make sure they get instantiated
-template void su::set_proportions(float* props,
+template void su::set_proportions(float* __restrict__ props,
                                   const BPTree &tree,
                                   uint32_t node,
                                   const biom &table,
                                   PropStack<float> &ps,
                                   bool normalize);
-template void su::set_proportions(double* props,
+template void su::set_proportions(double* __restrict__ props,
                                   const BPTree &tree,
                                   uint32_t node,
                                   const biom &table,
@@ -960,7 +959,7 @@ template void su::set_proportions(double* props,
                                   bool normalize);
 
 template<class TFloat>
-void su::set_proportions_range(TFloat* props,
+void su::set_proportions_range(TFloat* __restrict__ props,
                                const BPTree &tree,
                                uint32_t node,
                                const biom &table, 
@@ -984,7 +983,7 @@ void su::set_proportions_range(TFloat* props,
             props[i] = 0;
 
         while(current <= right && current != 0) {
-            const TFloat * vec = ps.get(current);  // pull from prop map
+            const TFloat * __restrict__ vec = ps.get(current);  // pull from prop map
             ps.push(current);  // remove from prop map, place back on stack
 
             for(unsigned int i = 0; i < els; i++)
@@ -996,14 +995,14 @@ void su::set_proportions_range(TFloat* props,
 }
 
 // make sure they get instantiated
-template void su::set_proportions_range(float* props,
+template void su::set_proportions_range(float* __restrict__ props,
                                         const BPTree &tree,
                                         uint32_t node,
                                         const biom &table,
                                         unsigned int start, unsigned int end,
                                         PropStack<float> &ps,
                                         bool normalize);
-template void su::set_proportions_range(double* props,
+template void su::set_proportions_range(double* __restrict__ props,
                                         const BPTree &tree,
                                         uint32_t node,
                                         const biom &table,

--- a/sucpp/unifrac.cpp
+++ b/sucpp/unifrac.cpp
@@ -968,13 +968,7 @@ void su::set_proportions_range(TFloat* __restrict__ props,
                                bool normalize) {
     const unsigned int els = end-start;
     if(tree.isleaf(node)) {
-       table.get_obs_data_range(tree.names[node], start, end, props);
-       if (normalize) {
-        for(unsigned int i = 0; i < els; i++) {
-           props[i] /= table.sample_counts[start+i];
-        }
-       }
-
+       table.get_obs_data_range(tree.names[node], start, end, normalize, props);
     } else {
         const unsigned int right = tree.rightchild(node);
         unsigned int current = tree.leftchild(node);

--- a/sucpp/unifrac.cpp
+++ b/sucpp/unifrac.cpp
@@ -832,9 +832,9 @@ void su::unifrac_vaw(biom &table,
 }
 
 void su::set_proportions(double* props,
-                         BPTree &tree,
+                         const BPTree &tree,
                          uint32_t node,
-                         biom &table,
+                         const biom &table,
                          PropStack &ps,
                          bool normalize) {
     if(tree.isleaf(node)) {

--- a/sucpp/unifrac.cpp
+++ b/sucpp/unifrac.cpp
@@ -626,6 +626,7 @@ void unifracTT(const biom &table,
           unsigned int filled_emb = 0;
 
           // chunk the progress to maximize cache reuse
+#pragma omp parallel for 
           for (unsigned int ck=0; ck<num_prop_chunks; ck++) {
             PropStack &propstack = propstack_multi.get_prop_stack(ck);
             const unsigned int tstart = propstack_multi.get_start(ck);
@@ -786,6 +787,7 @@ void unifrac_vawTT(const biom &table,
           unsigned int filled_emb = 0;
 
           // chunk the progress to maximize cache reuse
+#pragma omp parallel for 
           for (unsigned int ck=0; ck<num_prop_chunks; ck++) {
             PropStack &propstack = propstack_multi.get_prop_stack(ck);
             PropStack &countstack = countstack_multi.get_prop_stack(ck);

--- a/sucpp/unifrac.cpp
+++ b/sucpp/unifrac.cpp
@@ -134,7 +134,7 @@ template class su::PropStack<double>;
 template<class TFloat>
 class PropStackFixed : public PropStack<TFloat> {
   public:
-    static const uint32_t DEF_VEC_SIZE = 1024;
+    static const uint32_t DEF_VEC_SIZE = 1024*sizeof(double)/sizeof(TFloat);
 
     PropStackFixed() : PropStack<TFloat>(DEF_VEC_SIZE) {}
 };

--- a/sucpp/unifrac.cpp
+++ b/sucpp/unifrac.cpp
@@ -418,7 +418,7 @@ void progressbar(float progress) {
 }
 
 template<class TFloat>
-void initialize_sample_counts(TFloat*& _counts, const su::task_parameters* task_p, biom &table) {
+void initialize_sample_counts(TFloat*& _counts, const su::task_parameters* task_p, const biom &table) {
     const unsigned int n_samples = task_p->n_samples;
     const uint64_t  n_samples_r = ((n_samples + UNIFRAC_BLOCK-1)/UNIFRAC_BLOCK)*UNIFRAC_BLOCK; // round up
     TFloat * counts = NULL;
@@ -499,8 +499,8 @@ void su::faith_pd(biom &table,
 }
 
 template<class TaskT, class TFloat>
-void unifracTT(biom &table,
-               BPTree &tree,
+void unifracTT(const biom &table,
+               const BPTree &tree,
                const bool want_total,
                std::vector<double*> &dm_stripes,
                std::vector<double*> &dm_stripes_total,
@@ -687,8 +687,8 @@ void su::unifrac(biom &table,
 
 
 template<class TaskT, class TFloat>
-void unifrac_vawTT(biom &table,
-                          BPTree &tree,
+void unifrac_vawTT(const biom &table,
+                   const BPTree &tree,
                           const bool want_total,
                           std::vector<double*> &dm_stripes,
                           std::vector<double*> &dm_stripes_total,

--- a/sucpp/unifrac.hpp
+++ b/sucpp/unifrac.hpp
@@ -76,8 +76,8 @@
         void condensed_form_to_matrix_fp32(const double*  __restrict__ cf, const uint32_t n, float*  __restrict__ buf2d);
 
         void set_proportions(double* props, 
-                             BPTree &tree, uint32_t node, 
-                             biom &table, 
+                             const BPTree &tree, uint32_t node, 
+                             const biom &table, 
                              PropStack &ps,
                              bool normalize = true);
         std::vector<double*> make_strides(unsigned int n_samples);

--- a/sucpp/unifrac.hpp
+++ b/sucpp/unifrac.hpp
@@ -77,14 +77,14 @@
         void condensed_form_to_matrix_fp32(const double*  __restrict__ cf, const uint32_t n, float*  __restrict__ buf2d);
 
         template<class TFloat>
-        void set_proportions(TFloat* props, 
+        void set_proportions(TFloat* __restrict__ props, 
                              const BPTree &tree, uint32_t node, 
                              const biom &table, 
                              PropStack<TFloat> &ps,
                              bool normalize = true);
 
         template<class TFloat>
-        void set_proportions_range(TFloat* props,
+        void set_proportions_range(TFloat* __restrict__ props,
                                    const BPTree &tree, uint32_t node,
                                    const biom &table,unsigned int start, unsigned int end,
                                    PropStack<TFloat> &ps,

--- a/sucpp/unifrac.hpp
+++ b/sucpp/unifrac.hpp
@@ -8,18 +8,19 @@
 #ifndef __UNIFRAC
     namespace su {
         enum Method {unweighted, weighted_normalized, weighted_unnormalized, generalized, unweighted_fp32, weighted_normalized_fp32, weighted_unnormalized_fp32, generalized_fp32};
-        
+
+        template<class TFloat> 
         class PropStack {
             private:
-                std::stack<double*> prop_stack;
-                std::unordered_map<uint32_t, double*> prop_map;
+                std::stack<TFloat*> prop_stack;
+                std::unordered_map<uint32_t, TFloat*> prop_map;
                 uint32_t defaultsize;
             public:
                 PropStack(uint32_t vecsize);
                 ~PropStack();
-                double* pop(uint32_t i);
+                TFloat* pop(uint32_t i);
                 void push(uint32_t i);
-                double* get(uint32_t i);
+                TFloat* get(uint32_t i);
         };
 
         void faith_pd(biom &table, BPTree &tree, double* result);
@@ -75,16 +76,18 @@
         void condensed_form_to_matrix(const double*  __restrict__ cf, const uint32_t n, double*  __restrict__ buf2d);
         void condensed_form_to_matrix_fp32(const double*  __restrict__ cf, const uint32_t n, float*  __restrict__ buf2d);
 
-        void set_proportions(double* props, 
+        template<class TFloat>
+        void set_proportions(TFloat* props, 
                              const BPTree &tree, uint32_t node, 
                              const biom &table, 
-                             PropStack &ps,
+                             PropStack<TFloat> &ps,
                              bool normalize = true);
 
-        void set_proportions_range(double* props,
+        template<class TFloat>
+        void set_proportions_range(TFloat* props,
                                    const BPTree &tree, uint32_t node,
                                    const biom &table,unsigned int start, unsigned int end,
-                                   PropStack &ps,
+                                   PropStack<TFloat> &ps,
                                    bool normalize = true);
 
         std::vector<double*> make_strides(unsigned int n_samples);

--- a/sucpp/unifrac.hpp
+++ b/sucpp/unifrac.hpp
@@ -80,6 +80,13 @@
                              const biom &table, 
                              PropStack &ps,
                              bool normalize = true);
+
+        void set_proportions_range(double* props,
+                                   const BPTree &tree, uint32_t node,
+                                   const biom &table,unsigned int start, unsigned int end,
+                                   PropStack &ps,
+                                   bool normalize = true);
+
         std::vector<double*> make_strides(unsigned int n_samples);
 
         inline uint64_t comb_2(uint64_t N) {

--- a/sucpp/unifrac_task.cpp
+++ b/sucpp/unifrac_task.cpp
@@ -547,7 +547,7 @@ void su::UnifracUnweightedTask<TFloat>::_run(unsigned int filled_embs, const TFl
                                    psum[0x300+((o1 >> 24) & 0xff)] +
                                    psum[0x400+((o1 >> 32) & 0xff)] +
                                    psum[0x500+((o1 >> 40) & 0xff)] +
-                                   psum[0x600+((o1 >> 42) & 0xff)] +
+                                   psum[0x600+((o1 >> 48) & 0xff)] +
                                    psum[0x700+((o1 >> 56)       )];
                 }
             }

--- a/sucpp/unifrac_task.cpp
+++ b/sucpp/unifrac_task.cpp
@@ -447,9 +447,9 @@ void su::UnifracUnweightedTask<TFloat>::_run(unsigned int filled_embs, const TFl
 #endif
     for (unsigned int emb_el=0; emb_el<filled_embs_els; emb_el++) {
        for (unsigned int sub8=0; sub8<8; sub8++) {
-          const unsigned int emb4 = emb_el*8+sub8;
-          TFloat * __restrict__ psum = &(sums[emb4<<8]);
-          const TFloat * __restrict__ pl   = &(lengths[emb4*8]);
+          const unsigned int emb8 = emb_el*8+sub8;
+          TFloat * __restrict__ psum = &(sums[emb8<<8]);
+          const TFloat * __restrict__ pl   = &(lengths[emb8*8]);
 
 #pragma acc loop vector
           // compute all the combinations for this block (8-bits total)
@@ -475,16 +475,16 @@ void su::UnifracUnweightedTask<TFloat>::_run(unsigned int filled_embs, const TFl
 #endif
        for (unsigned int sub8=0; sub8<8; sub8++) {
           // we are summing we have enough buffer in sums
-          const unsigned int emb4 = emb_el*8+sub8;
-          TFloat * __restrict__ psum = &(sums[emb4<<8]);
+          const unsigned int emb8 = emb_el*8+sub8;
+          TFloat * __restrict__ psum = &(sums[emb8<<8]);
 
 #pragma acc loop vector
           // compute all the combinations for this block, set to 0 any past the limit
           // as above
           for (unsigned int b8_i=0; b8_i<0x100; b8_i++) {
              TFloat val= 0;
-             for (unsigned int li=(emb4*8); li<filled_embs; li++) {
-               val += ((b8_i >>  (li-(emb4*8))) & 1) * lengths[li];
+             for (unsigned int li=(emb8*8); li<filled_embs; li++) {
+               val += ((b8_i >>  (li-(emb8*8))) & 1) * lengths[li];
              }
              psum[b8_i] = val;
           }

--- a/sucpp/unifrac_task.hpp
+++ b/sucpp/unifrac_task.hpp
@@ -196,7 +196,7 @@ namespace su {
           if (end==n_samples) {
             // avoid NaNs
             for(unsigned int i = n_samples; i < n_samples_r; i++) {
-              out[offset + i] = 1.0;
+              out[offset + i] = 0.0;
             }
           }
         }

--- a/sucpp/unifrac_task.hpp
+++ b/sucpp/unifrac_task.hpp
@@ -171,8 +171,8 @@ namespace su {
           return buf;
         }
 
-        void embed_proportions_range(const double* __restrict__ in, unsigned int start, unsigned int end, unsigned int emb);
-        void embed_proportions(const double* __restrict__ in, unsigned int emb) {embed_proportions_range(in,0,dm_stripes.n_samples,emb);}
+        void embed_proportions_range(const TFloat* __restrict__ in, unsigned int start, unsigned int end, unsigned int emb);
+        void embed_proportions(const TFloat* __restrict__ in, unsigned int emb) {embed_proportions_range(in,0,dm_stripes.n_samples,emb);}
 
         
 
@@ -183,7 +183,7 @@ namespace su {
 
         // Just copy from one buffer to another
         // May convert between fp formats in the process (if TOut!=double)
-        template<class TOut> void embed_proportions_range_straight(TOut* __restrict__ out, const double* __restrict__ in, unsigned int start, unsigned int end, unsigned int emb) const
+        template<class TOut> void embed_proportions_range_straight(TOut* __restrict__ out, const TFloat* __restrict__ in, unsigned int start, unsigned int end, unsigned int emb) const
         {
           const unsigned int n_samples  = dm_stripes.n_samples;
           const uint64_t n_samples_r  = dm_stripes.n_samples_r;
@@ -207,7 +207,7 @@ namespace su {
         //    so it will likely take multiple passes to store all the values
         //
         // Note: assumes we are processing emb in increasing order, starting from 0
-        template<class TOut> void embed_proportions_range_bool(TOut* __restrict__ out, const double* __restrict__ in, unsigned int start, unsigned int end, unsigned int emb) const
+        template<class TOut> void embed_proportions_range_bool(TOut* __restrict__ out, const TFloat* __restrict__ in, unsigned int start, unsigned int end, unsigned int emb) const
         {
           const unsigned int n_packed = sizeof(TOut)*8;// e.g. 32 for unit32_t
           const unsigned int n_samples  = dm_stripes.n_samples;
@@ -245,14 +245,14 @@ namespace su {
     // straight embeded_proportions
     template<> inline void UnifracTaskBase<double,double>::embed_proportions_range(const double* __restrict__ in, unsigned int start, unsigned int end, unsigned int emb) {embed_proportions_range_straight(embedded_proportions,in,start,end,emb);}
     template<> inline void UnifracTaskBase<double,float>::embed_proportions_range(const double* __restrict__ in, unsigned int start, unsigned int end, unsigned int emb) {embed_proportions_range_straight(embedded_proportions,in,start,end,emb);}
-    template<> inline void UnifracTaskBase<float,float>::embed_proportions_range(const double* __restrict__ in, unsigned int start, unsigned int end, unsigned int emb) {embed_proportions_range_straight(embedded_proportions,in,start,end,emb);}
+    template<> inline void UnifracTaskBase<float,float>::embed_proportions_range(const float* __restrict__ in, unsigned int start, unsigned int end, unsigned int emb) {embed_proportions_range_straight(embedded_proportions,in,start,end,emb);}
     template<> inline  unsigned int UnifracTaskBase<double,double>::get_emb_els(unsigned int max_embs) {return max_embs;}
     template<> inline  unsigned int UnifracTaskBase<double,float>::get_emb_els(unsigned int max_embs) {return max_embs;}
     template<> inline  unsigned int UnifracTaskBase<float,float>::get_emb_els(unsigned int max_embs) {return max_embs;}
 
     //packed bool embeded_proportions
     template<> inline void UnifracTaskBase<double,uint32_t>::embed_proportions_range(const double* __restrict__ in, unsigned int start, unsigned int end, unsigned int emb) {embed_proportions_range_bool(embedded_proportions,in,start,end,emb);}
-    template<> inline void UnifracTaskBase<float,uint32_t>::embed_proportions_range(const double* __restrict__ in, unsigned int start, unsigned int end, unsigned int emb) {embed_proportions_range_bool(embedded_proportions,in,start,end,emb);}
+    template<> inline void UnifracTaskBase<float,uint32_t>::embed_proportions_range(const float* __restrict__ in, unsigned int start, unsigned int end, unsigned int emb) {embed_proportions_range_bool(embedded_proportions,in,start,end,emb);}
     template<> inline  unsigned int UnifracTaskBase<double,uint32_t>::get_emb_els(unsigned int max_embs) {return (max_embs+31)/32;}
     template<> inline  unsigned int UnifracTaskBase<float,uint32_t>::get_emb_els(unsigned int max_embs) {return (max_embs+31)/32;}
 
@@ -464,11 +464,11 @@ namespace su {
 
        void sync_embedded(unsigned int filled_embs) { this->sync_embedded_proportions(filled_embs); this->sync_embedded_counts(filled_embs);}
 
-        void embed_range(const double* __restrict__ in_proportions, const double* __restrict__ in_counts, unsigned int start, unsigned int end, unsigned int emb) {
+        void embed_range(const TFloat* __restrict__ in_proportions, const TFloat* __restrict__ in_counts, unsigned int start, unsigned int end, unsigned int emb) {
           this->embed_proportions_range(in_proportions,start,end,emb);
           this->embed_proportions_range_straight(this->embedded_counts,in_counts,start,end,emb);
         }
-        void embed(const double* __restrict__ in_proportions, const double* __restrict__ in_counts, unsigned int emb) { embed_range(in_proportions,in_counts,0,this->dm_stripes.n_samples,emb);}
+        void embed(const TFloat* __restrict__ in_proportions, const double* __restrict__ in_counts, unsigned int emb) { embed_range(in_proportions,in_counts,0,this->dm_stripes.n_samples,emb);}
 
        virtual void run(unsigned int filled_embs, const TFloat * __restrict__ length) = 0;
     };

--- a/sucpp/unifrac_task.hpp
+++ b/sucpp/unifrac_task.hpp
@@ -234,7 +234,7 @@ namespace su {
           } else {
             // just update my bit
             for(unsigned int i = start; i < end; i++) {
-              out[offset + i] |= ((in[i-start] > 0) << emb_bit);
+              out[offset + i] |= (TOut(in[i-start] > 0) << emb_bit);
             }
 
             // the rest of the els are already OK

--- a/sucpp/unifrac_task.hpp
+++ b/sucpp/unifrac_task.hpp
@@ -171,7 +171,8 @@ namespace su {
           return buf;
         }
 
-        void embed_proportions(const double* __restrict__ in, unsigned int emb);
+        void embed_proportions_range(const double* __restrict__ in, unsigned int start, unsigned int end, unsigned int emb);
+        void embed_proportions(const double* __restrict__ in, unsigned int emb) {embed_proportions_range(in,0,dm_stripes.n_samples,emb);}
 
         
 
@@ -182,20 +183,21 @@ namespace su {
 
         // Just copy from one buffer to another
         // May convert between fp formats in the process (if TOut!=double)
-        template<class TOut> void embed_proportions_straight(TOut* __restrict__ out, const double* __restrict__ in, unsigned int emb)
+        template<class TOut> void embed_proportions_range_straight(TOut* __restrict__ out, const double* __restrict__ in, unsigned int start, unsigned int end, unsigned int emb) const
         {
           const unsigned int n_samples  = dm_stripes.n_samples;
           const uint64_t n_samples_r  = dm_stripes.n_samples_r;
           const uint64_t offset = emb * n_samples_r;
 
-#pragma omp parallel for schedule(static)
-          for(unsigned int i = 0; i < n_samples; i++) {
-            out[offset + i] = in[i];
+          for(unsigned int i = start; i < end; i++) {
+            out[offset + i] = in[i-start];
           }
 
-          // avoid NaNs
-          for(unsigned int i = n_samples; i < n_samples_r; i++) {
-            out[offset + i] = 1.0;
+          if (end==n_samples) {
+            // avoid NaNs
+            for(unsigned int i = n_samples; i < n_samples_r; i++) {
+              out[offset + i] = 1.0;
+            }
           }
         }
 
@@ -205,7 +207,7 @@ namespace su {
         //    so it will likely take multiple passes to store all the values
         //
         // Note: assumes we are processing emb in increasing order, starting from 0
-        template<class TOut> void embed_proportions_bool(TOut* __restrict__ out, const double* __restrict__ in, unsigned int emb)
+        template<class TOut> void embed_proportions_range_bool(TOut* __restrict__ out, const double* __restrict__ in, unsigned int start, unsigned int end, unsigned int emb) const
         {
           const unsigned int n_packed = sizeof(TOut)*8;// e.g. 32 for unit32_t
           const unsigned int n_samples  = dm_stripes.n_samples;
@@ -219,20 +221,20 @@ namespace su {
           if  (emb_bit==0) {
             // assign for emb_bit==0, so it clears the other bits
             // assumes we processing emb in increasing order, starting from 0
-#pragma omp parallel for schedule(static)
-            for(unsigned int i = 0; i < n_samples; i++) {            
-              out[offset + i] = (in[i] > 0);
+            for(unsigned int i = start; i < end; i++) {            
+              out[offset + i] = (in[i-start] > 0);
             }
 
-            // avoid NaNs
-            for(unsigned int i = n_samples; i < n_samples_r; i++) {
-              out[offset + i] = 0;
+            if (end==n_samples) {
+              // avoid NaNs
+              for(unsigned int i = n_samples; i < n_samples_r; i++) {
+                out[offset + i] = 0;
+              }
             }
           } else {
             // just update my bit
-#pragma omp parallel for schedule(static)
-            for(unsigned int i = 0; i < n_samples; i++) {
-              out[offset + i] |= ((in[i] > 0) << emb_bit);
+            for(unsigned int i = start; i < end; i++) {
+              out[offset + i] |= ((in[i-start] > 0) << emb_bit);
             }
 
             // the rest of the els are already OK
@@ -241,16 +243,16 @@ namespace su {
     };
 
     // straight embeded_proportions
-    template<> inline void UnifracTaskBase<double,double>::embed_proportions(const double* __restrict__ in, unsigned int emb) {embed_proportions_straight(embedded_proportions,in,emb);}
-    template<> inline void UnifracTaskBase<double,float>::embed_proportions(const double* __restrict__ in, unsigned int emb) {embed_proportions_straight(embedded_proportions,in,emb);}
-    template<> inline void UnifracTaskBase<float,float>::embed_proportions(const double* __restrict__ in, unsigned int emb) {embed_proportions_straight(embedded_proportions,in,emb);}
+    template<> inline void UnifracTaskBase<double,double>::embed_proportions_range(const double* __restrict__ in, unsigned int start, unsigned int end, unsigned int emb) {embed_proportions_range_straight(embedded_proportions,in,start,end,emb);}
+    template<> inline void UnifracTaskBase<double,float>::embed_proportions_range(const double* __restrict__ in, unsigned int start, unsigned int end, unsigned int emb) {embed_proportions_range_straight(embedded_proportions,in,start,end,emb);}
+    template<> inline void UnifracTaskBase<float,float>::embed_proportions_range(const double* __restrict__ in, unsigned int start, unsigned int end, unsigned int emb) {embed_proportions_range_straight(embedded_proportions,in,start,end,emb);}
     template<> inline  unsigned int UnifracTaskBase<double,double>::get_emb_els(unsigned int max_embs) {return max_embs;}
     template<> inline  unsigned int UnifracTaskBase<double,float>::get_emb_els(unsigned int max_embs) {return max_embs;}
     template<> inline  unsigned int UnifracTaskBase<float,float>::get_emb_els(unsigned int max_embs) {return max_embs;}
 
     //packed bool embeded_proportions
-    template<> inline void UnifracTaskBase<double,uint32_t>::embed_proportions(const double* __restrict__ in, unsigned int emb) {embed_proportions_bool(embedded_proportions,in,emb);}
-    template<> inline void UnifracTaskBase<float,uint32_t>::embed_proportions(const double* __restrict__ in, unsigned int emb) {embed_proportions_bool(embedded_proportions,in,emb);}
+    template<> inline void UnifracTaskBase<double,uint32_t>::embed_proportions_range(const double* __restrict__ in, unsigned int start, unsigned int end, unsigned int emb) {embed_proportions_range_bool(embedded_proportions,in,start,end,emb);}
+    template<> inline void UnifracTaskBase<float,uint32_t>::embed_proportions_range(const double* __restrict__ in, unsigned int start, unsigned int end, unsigned int emb) {embed_proportions_range_bool(embedded_proportions,in,start,end,emb);}
     template<> inline  unsigned int UnifracTaskBase<double,uint32_t>::get_emb_els(unsigned int max_embs) {return (max_embs+31)/32;}
     template<> inline  unsigned int UnifracTaskBase<float,uint32_t>::get_emb_els(unsigned int max_embs) {return (max_embs+31)/32;}
 
@@ -462,10 +464,11 @@ namespace su {
 
        void sync_embedded(unsigned int filled_embs) { this->sync_embedded_proportions(filled_embs); this->sync_embedded_counts(filled_embs);}
 
-        void embed(const double* __restrict__ in_proportions, const double* __restrict__ in_counts, unsigned int emb) {
-          this->embed_proportions(in_proportions,emb);
-          this->embed_proportions_straight(this->embedded_counts,in_counts,emb);
+        void embed_range(const double* __restrict__ in_proportions, const double* __restrict__ in_counts, unsigned int start, unsigned int end, unsigned int emb) {
+          this->embed_proportions_range(in_proportions,start,end,emb);
+          this->embed_proportions_range_straight(this->embedded_counts,in_counts,start,end,emb);
         }
+        void embed(const double* __restrict__ in_proportions, const double* __restrict__ in_counts, unsigned int emb) { embed_range(in_proportions,in_counts,0,this->dm_stripes.n_samples,emb);}
 
        virtual void run(unsigned int filled_embs, const TFloat * __restrict__ length) = 0;
     };

--- a/sucpp/unifrac_task.hpp
+++ b/sucpp/unifrac_task.hpp
@@ -327,7 +327,7 @@ namespace su {
           sums = NULL;
           posix_memalign((void **)&zcheck, 4096, sizeof(bool) * n_samples);
           posix_memalign((void **)&sums  , 4096, sizeof(TFloat) * n_samples);
-#pragma acc enter data create(zcheck[:n_samples],sums[:_max_embs])
+#pragma acc enter data create(zcheck[:n_samples],sums[:n_samples])
         }
 
         virtual ~UnifracUnnormalizedWeightedTask()


### PR DESCRIPTION
Contains the following improvements:
* Chunk the compute of emb_buffers, to fit large problems in CPU cache
* Add explicit check for zero elements in Unweighted, to optimize for the sparse nature of the emb_buffer
* Move unweighted to 64-bit packed format, to maximize sparse checking efficiency
* Add zero checks and use distributed properties in UnnormalizedWeighted and NormalizedWeighted

It also contains some additional const guarantees, that allow for better algorithmic reasoning.
