### PR TITLE
Change GPU compile to co-exist with CPU code path

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -115,13 +115,14 @@ jobs:
         make api
         if [[ "$(uname -s)" == "Linux" ]];
         then
-          # the ACC_CXX not needed anymore
+          # capi_test needs standard gcc
+          ACCPATH=$PATH
           export PATH=$ORGPATH
-          unset ACC_CXX
         fi
         make capi_test
         if [[ "$(uname -s)" == "Linux" ]]; 
         then
+          export PATH=$ACCPATH
           make rapi_test
         fi
         popd

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,6 +75,39 @@ jobs:
           clang -v
         fi
         which h5c++
+        if [[ "$(uname -s)" == "Linux" ]];
+        then
+          # Enable OpenACC build
+          curl -s -S -o nvhpc_2020.tar.gz  https://developer.download.nvidia.com/hpc-sdk/20.9/nvhpc_2020_209_Linux_x86_64_cuda_11.0.tar.gz
+          tar xpzf nvhpc_2020.tar.gz
+          rm -f nvhpc_2020.0.tar.gz
+
+          mkdir conda_nv_bins
+          (cd conda_nv_bins && for f in \
+              ar as c++ cc cpp g++ gcc ld nm ranlib strip; \
+           do \
+             ln -s `which x86_64-conda-linux-gnu-${f}` ${f}; \
+           done )
+
+          PATH=${PWD}/conda_nv_bins:$PATH
+
+          sed -i -e "s#PATH=/#PATH=$PWD/conda_nv_bins:/#g" \
+            nvhpc_*/install_components/install 
+          sed -i -e "s#PATH=/#PATH=$PWD/conda_nv_bins:/#g" \
+            nvhpc_*/install_components/*/*/compilers/bin/makelocalrc
+          sed -i -e "s#PATH=/#PATH=$PWD/conda_nv_bins:/#g" \
+            nvhpc_*/install_components/*/*/compilers/bin/addlocalrc
+          sed -i -e "s#PATH=/#PATH=$PWD/conda_nv_bins:/#g" \
+            nvhpc_*/install_components/install_cuda
+
+          export NVHPC_INSTALL_DIR=$PWD/hpc_sdk
+          export NVHPC_SILENT=true
+
+          (cd nvhpc_*; ./install)
+
+          export PATH=\$PATH:`ls -d $PWD/hpc_sdk/*/202*/compilers/bin`
+          export ACC_CXX=pgc++
+        fi
         pushd sucpp
         make test
         make main
@@ -92,6 +125,7 @@ jobs:
       run: |
         conda activate unifrac
         pushd sucpp
+        export UNIFRAC_GPU_INFO=Y
         ./test_su
         ./test_api
         ./test_ska

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,7 +80,7 @@ jobs:
           # Enable OpenACC build
           curl -s -S -o nvhpc_2020.tar.gz  https://developer.download.nvidia.com/hpc-sdk/20.9/nvhpc_2020_209_Linux_x86_64_cuda_11.0.tar.gz
           tar xpzf nvhpc_2020.tar.gz
-          rm -f nvhpc_2020.0.tar.gz
+          rm -f nvhpc_2020.tar.gz
 
           mkdir conda_nv_bins
           (cd conda_nv_bins && for f in \
@@ -103,7 +103,7 @@ jobs:
           export NVHPC_INSTALL_DIR=$PWD/hpc_sdk
           export NVHPC_SILENT=true
 
-          (cd nvhpc_*; ./install)
+          (cd nvhpc_*_x86_64_*; ./install)
 
           export PATH=\$PATH:`ls -d $PWD/hpc_sdk/*/202*/compilers/bin`
           export ACC_CXX=pgc++

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -105,7 +105,7 @@ jobs:
 
           (cd nvhpc_*_x86_64_*; ./install)
 
-          export PATH=\$PATH:`ls -d $PWD/hpc_sdk/*/202*/compilers/bin`
+          export PATH=$PATH:`ls -d $PWD/hpc_sdk/*/202*/compilers/bin`
           export ACC_CXX=pgc++
         fi
         pushd sucpp

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,6 +77,7 @@ jobs:
         which h5c++
         if [[ "$(uname -s)" == "Linux" ]];
         then
+          ORGPATH=$PATH
           # Enable OpenACC build
           curl -s -S -o nvhpc_2020.tar.gz  https://developer.download.nvidia.com/hpc-sdk/20.9/nvhpc_2020_209_Linux_x86_64_cuda_11.0.tar.gz
           tar xpzf nvhpc_2020.tar.gz
@@ -112,6 +113,12 @@ jobs:
         make test
         make main
         make api
+        if [[ "$(uname -s)" == "Linux" ]];
+        then
+          # the ACC_CXX not needed anymore
+          export PATH=$ORGPATH
+          unset ACC_CXX
+        fi
         make capi_test
         if [[ "$(uname -s)" == "Linux" ]]; 
         then

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2016-2017, UniFrac development team.
+Copyright (c) 2016-2021, UniFrac development team.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/docs/compile_cpu.README.md
+++ b/docs/compile_cpu.README.md
@@ -75,12 +75,15 @@ Assuming you are in the environment above, fetch the UniFrac source code and per
 The binaries will be automatically put in the conda path.
 
 ```
-git clone https://github.com/biocore/unifrac.git
+# save original version of binaries
+mkdir $CONDA_PREFIX/bin/org
+mkdir $CONDA_PREFIX/lib/org
 
-# save CPU version of binaries
-mv $CONDA_PREFIX/bin/ssu $CONDA_PREFIX/bin/ssu.cpu
-mv $CONDA_PREFIX/bin/faithpd $CONDA_PREFIX/bin/faithpd.cpu
-mv $CONDA_PREFIX/lib/libssu.so $CONDA_PREFIX/bin/libssu.so.cpu
+mv $CONDA_PREFIX/bin/ssu $CONDA_PREFIX/bin/org/
+mv $CONDA_PREFIX/bin/faithpd $CONDA_PREFIX/bin/org/
+mv $CONDA_PREFIX/lib/libssu*.so $CONDA_PREFIX/lib/org/
+
+git clone https://github.com/biocore/unifrac.git
 
 (cd unifrac/sucpp/ && make && make main && make api)
 ```

--- a/sucpp/Makefile
+++ b/sucpp/Makefile
@@ -90,9 +90,11 @@ endif
 
 CPPFLAGS += -Wall  -std=c++11 -pedantic -I. $(OPT) -fPIC -L$(CONDA_PREFIX)/lib
 
-UFCMP=unifrac_cmp_cpu.o
+UFCMP_LIBS=libssu_cpu.so
+UFCMP_LINK=-lssu_cpu
 ifdef ACC_CXX
-	UFCMP+= unifrac_cmp_acc.o
+	UFCMP+= libssu_acc.so
+	UFCMP_LINK+= -lssu_acc
 endif
 
 test: test_su.cpp test_ska.cpp test_api.cpp libssu.so
@@ -120,9 +122,14 @@ rapi_test: main
 	echo LDFLAGS=-llz4 $(BLASLIB) >> ~/.R/Makevars
 	Rscript R_interface/rapi_test.R
 	
-libssu.so: tree.o biom.o $(UFCMP) unifrac.o cmd.o skbio_alt.o api.o
-	$(H5CXX) $(LDDFLAGS) -o libssu.so tree.o biom.o $(UFCMP) unifrac.o cmd.o skbio_alt.o api.o -lc -lhdf5_cpp -llz4 $(BLASLIB) -L$(PREFIX)/lib
+libssu.so: tree.o biom.o unifrac.o cmd.o skbio_alt.o api.o $(UFCMP_LIBS)
+	$(H5CXX) $(LDDFLAGS) -o libssu.so tree.o biom.o unifrac.o cmd.o skbio_alt.o api.o $(UFCMP_LINK) -lc -lhdf5_cpp -llz4 $(BLASLIB) -L$(PREFIX)/lib
 	cp libssu.so ${PREFIX}/lib/
+
+libssu_cpu.so: unifrac_cmp_cpu.o
+	$(H5CXX) $(LDDFLAGS) -o libssu_cpu.so unifrac_cmp_cpu.o -L$(PREFIX)/lib
+	cp libssu_cpu.so ${PREFIX}/lib/
+
 
 api: libssu.so
 

--- a/sucpp/Makefile
+++ b/sucpp/Makefile
@@ -20,8 +20,7 @@ endif
 
 ifeq ($(PLATFORM),Darwin)
 	AVX2 := $(shell sysctl -a | grep -c AVX2)
-	LDDFLAGS = -dynamiclib 
-        #-install_name @rpath/libssu.so
+	LDDFLAGS = -dynamiclib -install_name @rpath/libssu.so
 else
 	AVX2 := $(shell grep "^flags" /proc/cpuinfo | head -n 1 | grep -c avx2)
 	LDDFLAGS = -shared

--- a/sucpp/Makefile
+++ b/sucpp/Makefile
@@ -20,7 +20,8 @@ endif
 
 ifeq ($(PLATFORM),Darwin)
 	AVX2 := $(shell sysctl -a | grep -c AVX2)
-	LDDFLAGS = -dynamiclib -install_name @rpath/libssu.so
+	LDDFLAGS = -dynamiclib 
+        #-install_name @rpath/libssu.so
 else
 	AVX2 := $(shell grep "^flags" /proc/cpuinfo | head -n 1 | grep -c avx2)
 	LDDFLAGS = -shared
@@ -51,7 +52,13 @@ endif
 LDDFLAGS += -L$(CONDA_PREFIX)/lib
 CPPFLAGS += -Wall  -std=c++11 -pedantic -I. $(OPT) -fPIC -L$(CONDA_PREFIX)/lib
 
-BASE_LDDFLAGS = $(LDDFLAGS) -Wl,-rpath-link,$(PREFIX)/lib
+ifeq ($(PLATFORM),Darwin)
+  LDDFLAGS += -Wl,-rpath,$(PREFIX)/lib
+else
+  LDDFLAGS += -Wl,-rpath-link,$(PREFIX)/lib
+endif
+BASE_LDDFLAGS = $(LDDFLAGS) 
+
 
 UFCMP_LIBS=libssu_cpu.so
 UFCMP_LINK=-lssu_cpu
@@ -117,22 +124,26 @@ ifeq ($(PLATFORM),Darwin)
 
 # We never use ACC under MacOS, so keep it simple
 
-libssu.so: tree.o biom.o unifrac.o unifrac_cmp_cpu.o cmd.o skbio_alt.o api.o 
-	$(H5CXX) $(LDDFLAGS) -o libssu.so tree.o biom.o unifrac.o unifrac_cmp_cpu.o cmd.o skbio_alt.o api.o -lc -lhdf5_cpp -llz4 $(BLASLIB)
+libssu.so: tree.o biom.o unifrac.o unifrac_internal.o unifrac_cmp_cpu.o cmd.o skbio_alt.o api.o 
+	$(H5CXX) $(LDDFLAGS) -o libssu.so tree.o biom.o unifrac.o unifrac_internal.o unifrac_cmp_cpu.o cmd.o skbio_alt.o api.o -lc -lhdf5_cpp -llz4 $(BLASLIB)
 	cp libssu.so ${PREFIX}/lib/
 
 else
 
-libssu.so: tree.o biom.o unifrac.o cmd.o skbio_alt.o api.o $(UFCMP_LIBS)
-	$(H5CXX) $(LDDFLAGS) -o libssu.so tree.o biom.o unifrac.o cmd.o skbio_alt.o api.o $(UFCMP_LINK) -lc -lhdf5_cpp -llz4 $(BLASLIB)
+libssu.so: unifrac.o cmd.o api.o $(UFCMP_LIBS) libssu_internal.so
+	$(H5CXX) $(LDDFLAGS) -o libssu.so unifrac.o cmd.o api.o $(UFCMP_LINK) -lssu_internal -lc -llz4 
 	cp libssu.so ${PREFIX}/lib/
 
-libssu_cpu.so: unifrac_cmp_cpu.o
-	$(CXX) $(BASE_LDDFLAGS) -o libssu_cpu.so unifrac_cmp_cpu.o -lc
+libssu_internal.so: tree.o biom.o skbio_alt.o unifrac_internal.o
+	$(H5CXX) $(LDDFLAGS) -o libssu_internal.so tree.o biom.o skbio_alt.o unifrac_internal.o -lc -lhdf5_cpp $(BLASLIB)
+	cp libssu_internal.so ${PREFIX}/lib/
+
+libssu_cpu.so: unifrac_cmp_cpu.o libssu_internal.so
+	$(CXX) $(BASE_LDDFLAGS) -o libssu_cpu.so unifrac_cmp_cpu.o -lssu_internal -lc
 	cp libssu_cpu.so ${PREFIX}/lib/
 
-libssu_acc.so: unifrac_cmp_acc.o
-	$(ACC_CXX) $(ACC_LDDFLAGS) -o libssu_acc.so unifrac_cmp_acc.o -lc
+libssu_acc.so: unifrac_cmp_acc.o libssu_internal.so
+	$(ACC_CXX) $(ACC_LDDFLAGS) -o libssu_acc.so unifrac_cmp_acc.o -lssu_internal -lc
 	cp libssu_acc.so ${PREFIX}/lib/
 
 endif

--- a/sucpp/Makefile
+++ b/sucpp/Makefile
@@ -90,14 +90,14 @@ endif
 
 CPPFLAGS += -Wall  -std=c++11 -pedantic -I. $(OPT) -fPIC -L$(CONDA_PREFIX)/lib
 
-test: tree.o test_su.cpp biom.o unifrac.o skbio_alt.o api.o
-	$(H5CXX) $(CPPFLAGS) $(EXEFLAGS) test_su.cpp -o test_su tree.o biom.o unifrac.o skbio_alt.o api.o -llz4 $(BLASLIB) -lpthread
-	$(H5CXX) $(CPPFLAGS) $(EXEFLAGS) test_ska.cpp -o test_ska skbio_alt.o tree.o biom.o unifrac.o api.o -llz4 $(BLASLIB) -lpthread
-	$(H5CXX) $(CPPFLAGS) $(EXEFLAGS) test_api.cpp -o test_api tree.o biom.o unifrac.o skbio_alt.o api.o -llz4 $(BLASLIB) -lpthread
+test: tree.o test_su.cpp biom.o unifrac_cmp.o unifrac.o skbio_alt.o api.o
+	$(H5CXX) $(CPPFLAGS) $(EXEFLAGS) test_su.cpp -o test_su tree.o biom.o unifrac_cmp.o unifrac.o skbio_alt.o api.o -llz4 $(BLASLIB) -lpthread
+	$(H5CXX) $(CPPFLAGS) $(EXEFLAGS) test_ska.cpp -o test_ska skbio_alt.o tree.o biom.o unifrac_cmp.o unifrac.o api.o -llz4 $(BLASLIB) -lpthread
+	$(H5CXX) $(CPPFLAGS) $(EXEFLAGS) test_api.cpp -o test_api tree.o biom.o unifrac_cmp.o unifrac.o skbio_alt.o api.o -llz4 $(BLASLIB) -lpthread
 
-main: tree.o biom.o unifrac.o cmd.o skbio_alt.o api.o
-	$(H5CXX) $(CPPFLAGS) $(EXEFLAGS) su.cpp -o ssu tree.o biom.o unifrac.o cmd.o skbio_alt.o api.o -lhdf5_cpp -llz4 $(BLASLIB) -lpthread
-	$(H5CXX) $(CPPFLAGS) $(EXEFLAGS) faithpd.cpp -o faithpd tree.o biom.o unifrac.o cmd.o skbio_alt.o api.o -lhdf5_cpp -llz4 $(BLASLIB) -lpthread
+main: tree.o biom.o unifrac_cmp.o unifrac.o cmd.o skbio_alt.o api.o
+	$(H5CXX) $(CPPFLAGS) $(EXEFLAGS) su.cpp -o ssu tree.o biom.o unifrac_cmp.o unifrac.o cmd.o skbio_alt.o api.o -lhdf5_cpp -llz4 $(BLASLIB) -lpthread
+	$(H5CXX) $(CPPFLAGS) $(EXEFLAGS) faithpd.cpp -o faithpd tree.o biom.o unifrac_cmp.o unifrac.o cmd.o skbio_alt.o api.o -lhdf5_cpp -llz4 $(BLASLIB) -lpthread
 	cp ssu ${PREFIX}/bin/
 	cp faithpd ${PREFIX}/bin/
 
@@ -115,8 +115,8 @@ rapi_test: main
 	echo LDFLAGS=-llz4 $(BLASLIB) >> ~/.R/Makevars
 	Rscript R_interface/rapi_test.R
 	
-api: tree.o biom.o unifrac.o cmd.o skbio_alt.o api.o
-	$(H5CXX) $(LDDFLAGS) -o libssu.so tree.o biom.o unifrac.o cmd.o skbio_alt.o api.o -lc -lhdf5_cpp -llz4 $(BLASLIB) -L$(PREFIX)/lib
+api: tree.o biom.o unifrac_cmp.o unifrac.o cmd.o skbio_alt.o api.o
+	$(H5CXX) $(LDDFLAGS) -o libssu.so tree.o biom.o unifrac_cmp.o unifrac.o cmd.o skbio_alt.o api.o -lc -lhdf5_cpp -llz4 $(BLASLIB) -L$(PREFIX)/lib
 	cp libssu.so ${PREFIX}/lib/
 
 capi_test: api
@@ -126,8 +126,12 @@ capi_test: api
 api.o: api.cpp api.hpp unifrac.hpp skbio_alt.hpp biom.hpp tree.hpp
 	$(H5CXX) $(CPPFLAGS) api.cpp -c -o api.o -fPIC
 
-unifrac.o: unifrac.cpp unifrac.hpp unifrac_task.cpp unifrac_task.hpp biom_interface.hpp tree.hpp
+unifrac.o: unifrac.cpp unifrac.hpp unifrac_internal.hpp unifrac_cmp.hpp biom_interface.hpp tree.hpp
 	$(CXX) $(CPPFLAGS) -c $< -o $@
+
+unifrac_cmp.o: unifrac_cmp.cpp unifrac_cmp.hpp unifrac_internal.hpp unifrac.hpp unifrac_task.cpp unifrac_task.hpp biom_interface.hpp tree.hpp
+	$(CXX) $(CPPFLAGS) -c $< -o $@
+
 
 %.o: %.cpp %.hpp
 	$(H5CXX) $(CPPFLAGS) -c $< -o $@

--- a/sucpp/Makefile
+++ b/sucpp/Makefile
@@ -118,7 +118,7 @@ libssu_cpu.so: unifrac_cmp_cpu.o
 	cp libssu_cpu.so ${PREFIX}/lib/
 
 libssu_acc.so: unifrac_cmp_acc.o
-	$(ACC_CXX) $(ACC_LDDFLAGS) -o libssu_acc.so unifrac_cmp_acc.o -L$(PREFIX)/lib -lc -fPIC
+	$(ACC_CXX) $(ACC_LDDFLAGS) -o libssu_acc.so unifrac_cmp_acc.o -Wl,-rpath-link,$(PREFIX)/lib -L$(PREFIX)/lib -lgomp -lc -fPIC
 	cp libssu_acc.so ${PREFIX}/lib/
 
 api: libssu.so

--- a/sucpp/Makefile
+++ b/sucpp/Makefile
@@ -141,7 +141,7 @@ api: libssu.so
 	# api == libssu.so
 
 capi_test: api
-	$(CPP) -std=c99 capi_test.c -lssu -L${PREFIX}/lib -Wl,-rpath,${PREFIX}/lib -o capi_test
+	gcc -std=c99 capi_test.c -lssu -L${PREFIX}/lib -Wl,-rpath,${PREFIX}/lib -o capi_test
 	export LD_LIBRARY_PATH="${PREFIX}/lib":"./capi_test"
 
 api.o: api.cpp api.hpp unifrac.hpp skbio_alt.hpp biom.hpp tree.hpp

--- a/sucpp/Makefile
+++ b/sucpp/Makefile
@@ -90,6 +90,11 @@ endif
 
 CPPFLAGS += -Wall  -std=c++11 -pedantic -I. $(OPT) -fPIC -L$(CONDA_PREFIX)/lib
 
+UFCMP=unifrac_cmp_cpu.o
+ifdef ACC_CXX
+	UFCMP+= unifrac_cmp_acc.o
+endif
+
 test: test_su.cpp test_ska.cpp test_api.cpp libssu.so
 	$(H5CXX) $(CPPFLAGS) $(EXEFLAGS) test_su.cpp -o test_su -lssu -lpthread
 	$(H5CXX) $(CPPFLAGS) $(EXEFLAGS) test_ska.cpp -o test_ska -lssu -lpthread
@@ -115,8 +120,8 @@ rapi_test: main
 	echo LDFLAGS=-llz4 $(BLASLIB) >> ~/.R/Makevars
 	Rscript R_interface/rapi_test.R
 	
-libssu.so: tree.o biom.o unifrac_cmp.o unifrac.o cmd.o skbio_alt.o api.o
-	$(H5CXX) $(LDDFLAGS) -o libssu.so tree.o biom.o unifrac_cmp.o unifrac.o cmd.o skbio_alt.o api.o -lc -lhdf5_cpp -llz4 $(BLASLIB) -L$(PREFIX)/lib
+libssu.so: tree.o biom.o $(UFCMP) unifrac.o cmd.o skbio_alt.o api.o
+	$(H5CXX) $(LDDFLAGS) -o libssu.so tree.o biom.o $(UFCMP) unifrac.o cmd.o skbio_alt.o api.o -lc -lhdf5_cpp -llz4 $(BLASLIB) -L$(PREFIX)/lib
 	cp libssu.so ${PREFIX}/lib/
 
 api: libssu.so
@@ -131,8 +136,11 @@ api.o: api.cpp api.hpp unifrac.hpp skbio_alt.hpp biom.hpp tree.hpp
 unifrac.o: unifrac.cpp unifrac.hpp unifrac_internal.hpp unifrac_cmp.hpp biom_interface.hpp tree.hpp
 	$(CXX) $(CPPFLAGS) -c $< -o $@
 
-unifrac_cmp.o: unifrac_cmp.cpp unifrac_cmp.hpp unifrac_internal.hpp unifrac.hpp unifrac_task.cpp unifrac_task.hpp biom_interface.hpp tree.hpp
-	$(CXX) $(CPPFLAGS) -c $< -o $@
+unifrac_cmp_cpu.o: unifrac_cmp.cpp unifrac_cmp.hpp unifrac_internal.hpp unifrac.hpp unifrac_task.cpp unifrac_task.hpp biom_interface.hpp tree.hpp
+	$(CXX) $(CPPFLAGS) -Wno-unknown-pragmas -c $< -o $@
+
+unifrac_cmp_acc.o: unifrac_cmp.cpp unifrac_cmp.hpp unifrac_internal.hpp unifrac.hpp unifrac_task.cpp unifrac_task.hpp biom_interface.hpp tree.hpp
+	$(ACC_CXX) $(ACC_CPPFLAGS) -c $< -o $@
 
 
 %.o: %.cpp %.hpp

--- a/sucpp/Makefile
+++ b/sucpp/Makefile
@@ -56,8 +56,9 @@ ifeq ($(PLATFORM),Darwin)
 else
   LDDFLAGS += -Wl,-rpath-link,$(PREFIX)/lib
 endif
-BASE_LDDFLAGS = $(LDDFLAGS) 
-
+BASE_LDDFLAGS = $(LDDFLAGS)
+ 
+R_LDFLAGS = -llz4 $(BLASLIB)
 
 UFCMP_LIBS=libssu_cpu.so
 UFCMP_LINK=-lssu_cpu
@@ -67,6 +68,8 @@ ifdef ACC_CXX
 
 	UFCMP_LIBS+= libssu_acc.so
 	UFCMP_LINK+= -lssu_acc
+
+        R_LDFLAGS += -lssu_acc
 
 	ACC_CPPFLAGS += -mp -acc
 	ACC_CPPFLAGS += -Wall  -std=c++11 -pedantic -I. -fPIC -L$(CONDA_PREFIX)/lib
@@ -125,7 +128,7 @@ main: ssu faithpd
 
 rapi_test: main
 	mkdir -p ~/.R
-	if [ -a ~/.R/Makevars ] ; \
+	if [ -e ~/.R/Makevars ] ; \
 	then \
 		echo "WARNING: OVERWRITING ~/.R/Makevars" ; \
 		echo "The original Makevars file has been copied to ~/.R/Makevars" ;\
@@ -134,7 +137,7 @@ rapi_test: main
 	echo CXX1X=h5c++ > ~/.R/Makevars
 	echo CXX=h5c++ >> ~/.R/Makevars 
 	echo CC=h5c++ >> ~/.R/Makevars
-	echo LDFLAGS=-llz4 $(BLASLIB) >> ~/.R/Makevars
+	echo LDFLAGS=$(R_LDFLAGS) >> ~/.R/Makevars
 	Rscript R_interface/rapi_test.R
 	
 ifeq ($(PLATFORM),Darwin)

--- a/sucpp/Makefile
+++ b/sucpp/Makefile
@@ -48,7 +48,10 @@ else
 endif
 
 
+LDDFLAGS += -L$(CONDA_PREFIX)/lib
 CPPFLAGS += -Wall  -std=c++11 -pedantic -I. $(OPT) -fPIC -L$(CONDA_PREFIX)/lib
+
+BASE_LDDFLAGS = $(LDDFLAGS) -Wl,-rpath-link,$(PREFIX)/lib
 
 UFCMP_LIBS=libssu_cpu.so
 UFCMP_LINK=-lssu_cpu
@@ -77,7 +80,8 @@ ifdef ACC_CXX
         # optional info
         ACC_CPPFLAGS += -Minfo=accel
 
-        ACC_LDDFLAGS = -shared -mp -acc -Bstatic_pgi
+        # use the GNU OMP library to avoid conflicts
+        ACC_LDDFLAGS = -shared -mp -acc -Wl,-rpath-link,$(PREFIX)/lib -L$(CONDA_PREFIX)/lib -lgomp -Bstatic_pgi
 
         ifeq ($(PERFORMING_CONDA_BUILD),True)
                 ACC_CPPFLAGS += -tp=px
@@ -110,15 +114,15 @@ rapi_test: main
 	Rscript R_interface/rapi_test.R
 	
 libssu.so: tree.o biom.o unifrac.o cmd.o skbio_alt.o api.o $(UFCMP_LIBS)
-	$(H5CXX) $(LDDFLAGS) -o libssu.so tree.o biom.o unifrac.o cmd.o skbio_alt.o api.o $(UFCMP_LINK) -lc -lhdf5_cpp -llz4 $(BLASLIB) -L$(PREFIX)/lib
+	$(H5CXX) $(LDDFLAGS) -o libssu.so tree.o biom.o unifrac.o cmd.o skbio_alt.o api.o $(UFCMP_LINK) -lc -lhdf5_cpp -llz4 $(BLASLIB)
 	cp libssu.so ${PREFIX}/lib/
 
 libssu_cpu.so: unifrac_cmp_cpu.o
-	$(CXX) $(LDDFLAGS) -o libssu_cpu.so unifrac_cmp_cpu.o -L$(PREFIX)/lib -lc -fPIC
+	$(CXX) $(BASE_LDDFLAGS) -o libssu_cpu.so unifrac_cmp_cpu.o -lc
 	cp libssu_cpu.so ${PREFIX}/lib/
 
 libssu_acc.so: unifrac_cmp_acc.o
-	$(ACC_CXX) $(ACC_LDDFLAGS) -o libssu_acc.so unifrac_cmp_acc.o -Wl,-rpath-link,$(PREFIX)/lib -L$(PREFIX)/lib -lgomp -lc -fPIC
+	$(ACC_CXX) $(ACC_LDDFLAGS) -o libssu_acc.so unifrac_cmp_acc.o -lc
 	cp libssu_acc.so ${PREFIX}/lib/
 
 api: libssu.so
@@ -144,5 +148,5 @@ unifrac_cmp_acc.o: unifrac_cmp.cpp unifrac_cmp.hpp unifrac_internal.hpp unifrac.
 	$(H5CXX) $(CPPFLAGS) -c $< -o $@
 
 clean:
-	-rm -f *.o ssu
+	-rm -f *.o *.so ssu faithpd test_su test_api test_ska
 

--- a/sucpp/Makefile
+++ b/sucpp/Makefile
@@ -148,12 +148,12 @@ libssu.so: tree.o biom.o unifrac.o unifrac_internal.o unifrac_cmp_cpu.o cmd.o sk
 
 else
 
-libssu.so: unifrac.o cmd.o api.o $(UFCMP_LIBS) libssu_internal.so
-	$(H5CXX) $(LDDFLAGS) -o libssu.so unifrac.o cmd.o api.o $(UFCMP_LINK) -lssu_internal -lc -llz4 
+libssu.so: biom.o unifrac.o cmd.o api.o $(UFCMP_LIBS) libssu_internal.so
+	$(H5CXX) $(LDDFLAGS) -o libssu.so biom.o unifrac.o cmd.o api.o $(UFCMP_LINK) -lssu_internal -lc -llz4 
 	cp libssu.so ${PREFIX}/lib/
 
-libssu_internal.so: tree.o biom.o skbio_alt.o unifrac_internal.o
-	$(H5CXX) $(LDDFLAGS) -o libssu_internal.so tree.o biom.o skbio_alt.o unifrac_internal.o -lc -lhdf5_cpp $(BLASLIB)
+libssu_internal.so: tree.o skbio_alt.o unifrac_internal.o
+	$(H5CXX) $(LDDFLAGS) -o libssu_internal.so tree.o skbio_alt.o unifrac_internal.o -lc -lhdf5_cpp $(BLASLIB)
 	cp libssu_internal.so ${PREFIX}/lib/
 
 libssu_cpu.so: unifrac_cmp_cpu.o libssu_internal.so

--- a/sucpp/Makefile
+++ b/sucpp/Makefile
@@ -95,16 +95,28 @@ ifdef ACC_CXX
         endif
 endif
 
-test: test_su.cpp test_ska.cpp test_api.cpp libssu.so
+test_su: test_su.cpp libssu.so
 	$(H5CXX) $(CPPFLAGS) $(EXEFLAGS) test_su.cpp -o test_su -lssu -lpthread
+
+test_ska: test_ska.cpp libssu.so
 	$(H5CXX) $(CPPFLAGS) $(EXEFLAGS) test_ska.cpp -o test_ska -lssu -lpthread
+
+test_api: test_api.cpp libssu.so
 	$(H5CXX) $(CPPFLAGS) $(EXEFLAGS) test_api.cpp -o test_api -lssu -lpthread
 
-main: su.cpp faithpd.cpp libssu.so
+test: test_su test_ska test_api
+	# test = (su,ska,api)
+
+ssu: su.cpp libssu.so
 	$(H5CXX) $(CPPFLAGS) $(EXEFLAGS) su.cpp -o ssu -lssu -lpthread
-	$(H5CXX) $(CPPFLAGS) $(EXEFLAGS) faithpd.cpp -o faithpd -lssu -lpthread
 	cp ssu ${PREFIX}/bin/
+
+faithpd: faithpd.cpp libssu.so
+	$(H5CXX) $(CPPFLAGS) $(EXEFLAGS) faithpd.cpp -o faithpd -lssu -lpthread
 	cp faithpd ${PREFIX}/bin/
+
+main: ssu faithpd
+	# main == (ssu,faithpd)
 
 rapi_test: main
 	mkdir -p ~/.R

--- a/sucpp/Makefile
+++ b/sucpp/Makefile
@@ -90,14 +90,14 @@ endif
 
 CPPFLAGS += -Wall  -std=c++11 -pedantic -I. $(OPT) -fPIC -L$(CONDA_PREFIX)/lib
 
-test: tree.o test_su.cpp biom.o unifrac_cmp.o unifrac.o skbio_alt.o api.o
-	$(H5CXX) $(CPPFLAGS) $(EXEFLAGS) test_su.cpp -o test_su tree.o biom.o unifrac_cmp.o unifrac.o skbio_alt.o api.o -llz4 $(BLASLIB) -lpthread
-	$(H5CXX) $(CPPFLAGS) $(EXEFLAGS) test_ska.cpp -o test_ska skbio_alt.o tree.o biom.o unifrac_cmp.o unifrac.o api.o -llz4 $(BLASLIB) -lpthread
-	$(H5CXX) $(CPPFLAGS) $(EXEFLAGS) test_api.cpp -o test_api tree.o biom.o unifrac_cmp.o unifrac.o skbio_alt.o api.o -llz4 $(BLASLIB) -lpthread
+test: test_su.cpp test_ska.cpp test_api.cpp libssu.so
+	$(H5CXX) $(CPPFLAGS) $(EXEFLAGS) test_su.cpp -o test_su -lssu -lpthread
+	$(H5CXX) $(CPPFLAGS) $(EXEFLAGS) test_ska.cpp -o test_ska -lssu -lpthread
+	$(H5CXX) $(CPPFLAGS) $(EXEFLAGS) test_api.cpp -o test_api -lssu -lpthread
 
-main: tree.o biom.o unifrac_cmp.o unifrac.o cmd.o skbio_alt.o api.o
-	$(H5CXX) $(CPPFLAGS) $(EXEFLAGS) su.cpp -o ssu tree.o biom.o unifrac_cmp.o unifrac.o cmd.o skbio_alt.o api.o -lhdf5_cpp -llz4 $(BLASLIB) -lpthread
-	$(H5CXX) $(CPPFLAGS) $(EXEFLAGS) faithpd.cpp -o faithpd tree.o biom.o unifrac_cmp.o unifrac.o cmd.o skbio_alt.o api.o -lhdf5_cpp -llz4 $(BLASLIB) -lpthread
+main: su.cpp faithpd.cpp libssu.so
+	$(H5CXX) $(CPPFLAGS) $(EXEFLAGS) su.cpp -o ssu -lssu -lpthread
+	$(H5CXX) $(CPPFLAGS) $(EXEFLAGS) faithpd.cpp -o faithpd -lssu -lpthread
 	cp ssu ${PREFIX}/bin/
 	cp faithpd ${PREFIX}/bin/
 
@@ -115,9 +115,11 @@ rapi_test: main
 	echo LDFLAGS=-llz4 $(BLASLIB) >> ~/.R/Makevars
 	Rscript R_interface/rapi_test.R
 	
-api: tree.o biom.o unifrac_cmp.o unifrac.o cmd.o skbio_alt.o api.o
+libssu.so: tree.o biom.o unifrac_cmp.o unifrac.o cmd.o skbio_alt.o api.o
 	$(H5CXX) $(LDDFLAGS) -o libssu.so tree.o biom.o unifrac_cmp.o unifrac.o cmd.o skbio_alt.o api.o -lc -lhdf5_cpp -llz4 $(BLASLIB) -L$(PREFIX)/lib
 	cp libssu.so ${PREFIX}/lib/
+
+api: libssu.so
 
 capi_test: api
 	gcc -std=c99 capi_test.c -lssu -L${PREFIX}/lib -Wl,-rpath,${PREFIX}/lib -o capi_test

--- a/sucpp/Makefile
+++ b/sucpp/Makefile
@@ -4,22 +4,14 @@ PLATFORM := $(shell uname -s)
 COMPILER := $(shell ($(H5CXX) -v 2>&1) | tr A-Z a-z )
 
 ifdef DEBUG
-	ifneq (,$(findstring pgi,$(COMPILER)))
-		OPT = -g
-	else
-		OPT = -O0 -DDEBUG=1 --debug -g -ggdb
-	endif
+	OPT = -O0 -DDEBUG=1 --debug -g -ggdb
 else
-	ifneq (,$(findstring pgi,$(COMPILER)))
-		OPT = -fast
-	else
-	  ifneq (,$(findstring gcc,$(COMPILER)))
-		OPT = -O4
-		TGTFLAGS = -fwhole-program
-	  else
-		OPT = -O3
-	  endif
-	endif
+  ifneq (,$(findstring gcc,$(COMPILER)))
+	OPT = -O4
+	TGTFLAGS = -fwhole-program
+  else
+	OPT = -O3
+  endif
 endif
 
 ifeq ($(PREFIX),)
@@ -36,50 +28,18 @@ endif
 
 EXEFLAGS =
 
-ifneq (,$(findstring pgi,$(COMPILER)))
-	MPFLAG =  -mp
-else
-	MPFLAG = -fopenmp
-endif
+MPFLAG = -fopenmp
 
 LDDFLAGS += $(MPFLAG)
 CPPFLAGS += $(MPFLAG)
 
-ifndef NOGPU
-	ifneq (,$(findstring pgi,$(COMPILER)))
-		CPPFLAGS += -acc
-	        ifeq ($(PERFORMING_CONDA_BUILD),True)
-	            CPPFLAGS += -ta=tesla:ccall
-		else
-	            CPPFLAGS += -ta=tesla
-                endif
-		# optional info
-		CPPFLAGS += -Minfo=accel
-	        LDDFLAGS += -shlib -acc -Bstatic_pgi
-	        EXEFLAGS += -Bstatic_pgi
-	endif	
-	ifdef SMALLGPU
-		CPPFLAGS += -DSMALLGPU
-	endif
-
-endif
-
-ifneq (,$(findstring pgi,$(COMPILER)))
-	ifeq ($(PERFORMING_CONDA_BUILD),True)
-		CPPFLAGS += -tp=px
-	endif
+ifeq ($(PERFORMING_CONDA_BUILD),True)
+	CPPFLAGS += -mtune=generic
 else
-	ifeq ($(PERFORMING_CONDA_BUILD),True)
-		CPPFLAGS += -mtune=generic
-	else
-         	CPPFLAGS += -mfma -march=native
-	endif
+       	CPPFLAGS += -mfma -march=native
 endif
 
-ifeq (,$(findstring pgi,$(COMPILER)))
-	# basically, not gcc
-	CPPFLAGS += -Wextra -Wno-unused-parameter
-endif
+CPPFLAGS += -Wextra -Wno-unused-parameter
 
 ifeq ($(PLATFORM),Darwin)
         BLASLIB=-llapacke -lcblas
@@ -93,8 +53,35 @@ CPPFLAGS += -Wall  -std=c++11 -pedantic -I. $(OPT) -fPIC -L$(CONDA_PREFIX)/lib
 UFCMP_LIBS=libssu_cpu.so
 UFCMP_LINK=-lssu_cpu
 ifdef ACC_CXX
-	UFCMP+= libssu_acc.so
+	# Tell the generic code we will be building the ACC code, too
+	CPPFLAGS += -DUNIFRAC_ENABLE_ACC=1
+
+	UFCMP_LIBS+= libssu_acc.so
 	UFCMP_LINK+= -lssu_acc
+
+	ACC_CPPFLAGS += -mp -acc
+	ACC_CPPFLAGS += -Wall  -std=c++11 -pedantic -I. -fPIC -L$(CONDA_PREFIX)/lib
+
+	ifdef DEBUG
+                ACC_OPT = -g
+	else
+                ACC_OPT = -fast
+	endif
+        ACC_CPPFLAGS += $(ACC_OPT)
+
+        ifeq ($(PERFORMING_CONDA_BUILD),True)
+          ACC_CPPFLAGS += -ta=tesla:ccall
+        else
+          ACC_CPPFLAGS += -ta=tesla
+        endif
+        # optional info
+        ACC_CPPFLAGS += -Minfo=accel
+
+        ACC_LDDFLAGS = -shared -mp -acc -Bstatic_pgi
+
+        ifeq ($(PERFORMING_CONDA_BUILD),True)
+                ACC_CPPFLAGS += -tp=px
+        endif
 endif
 
 test: test_su.cpp test_ska.cpp test_api.cpp libssu.so
@@ -127,9 +114,12 @@ libssu.so: tree.o biom.o unifrac.o cmd.o skbio_alt.o api.o $(UFCMP_LIBS)
 	cp libssu.so ${PREFIX}/lib/
 
 libssu_cpu.so: unifrac_cmp_cpu.o
-	$(CXX) $(LDDFLAGS) -o libssu_cpu.so unifrac_cmp_cpu.o -L$(PREFIX)/lib
+	$(CXX) $(LDDFLAGS) -o libssu_cpu.so unifrac_cmp_cpu.o -L$(PREFIX)/lib -lc -fPIC
 	cp libssu_cpu.so ${PREFIX}/lib/
 
+libssu_acc.so: unifrac_cmp_acc.o
+	$(ACC_CXX) $(ACC_LDDFLAGS) -o libssu_acc.so unifrac_cmp_acc.o -L$(PREFIX)/lib -lc -fPIC
+	cp libssu_acc.so ${PREFIX}/lib/
 
 api: libssu.so
 

--- a/sucpp/Makefile
+++ b/sucpp/Makefile
@@ -141,7 +141,7 @@ api: libssu.so
 	# api == libssu.so
 
 capi_test: api
-	gcc -std=c99 capi_test.c -lssu -L${PREFIX}/lib -Wl,-rpath,${PREFIX}/lib -o capi_test
+	$(CPP) -std=c99 capi_test.c -lssu -L${PREFIX}/lib -Wl,-rpath,${PREFIX}/lib -o capi_test
 	export LD_LIBRARY_PATH="${PREFIX}/lib":"./capi_test"
 
 api.o: api.cpp api.hpp unifrac.hpp skbio_alt.hpp biom.hpp tree.hpp

--- a/sucpp/Makefile
+++ b/sucpp/Makefile
@@ -1,7 +1,7 @@
-CXX := h5c++
+H5CXX := h5c++
 
 PLATFORM := $(shell uname -s)
-COMPILER := $(shell ($(CXX) -v 2>&1) | tr A-Z a-z )
+COMPILER := $(shell ($(H5CXX) -v 2>&1) | tr A-Z a-z )
 
 ifdef DEBUG
 	ifneq (,$(findstring pgi,$(COMPILER)))
@@ -91,13 +91,13 @@ endif
 CPPFLAGS += -Wall  -std=c++11 -pedantic -I. $(OPT) -fPIC -L$(CONDA_PREFIX)/lib
 
 test: tree.o test_su.cpp biom.o unifrac.o skbio_alt.o api.o
-	$(CXX) $(CPPFLAGS) $(EXEFLAGS) test_su.cpp -o test_su tree.o biom.o unifrac.o skbio_alt.o api.o -llz4 $(BLASLIB) -lpthread
-	$(CXX) $(CPPFLAGS) $(EXEFLAGS) test_ska.cpp -o test_ska skbio_alt.o tree.o biom.o unifrac.o api.o -llz4 $(BLASLIB) -lpthread
-	$(CXX) $(CPPFLAGS) $(EXEFLAGS) test_api.cpp -o test_api tree.o biom.o unifrac.o skbio_alt.o api.o -llz4 $(BLASLIB) -lpthread
+	$(H5CXX) $(CPPFLAGS) $(EXEFLAGS) test_su.cpp -o test_su tree.o biom.o unifrac.o skbio_alt.o api.o -llz4 $(BLASLIB) -lpthread
+	$(H5CXX) $(CPPFLAGS) $(EXEFLAGS) test_ska.cpp -o test_ska skbio_alt.o tree.o biom.o unifrac.o api.o -llz4 $(BLASLIB) -lpthread
+	$(H5CXX) $(CPPFLAGS) $(EXEFLAGS) test_api.cpp -o test_api tree.o biom.o unifrac.o skbio_alt.o api.o -llz4 $(BLASLIB) -lpthread
 
 main: tree.o biom.o unifrac.o cmd.o skbio_alt.o api.o
-	$(CXX) $(CPPFLAGS) $(EXEFLAGS) su.cpp -o ssu tree.o biom.o unifrac.o cmd.o skbio_alt.o api.o -lhdf5_cpp -llz4 $(BLASLIB) -lpthread
-	$(CXX) $(CPPFLAGS) $(EXEFLAGS) faithpd.cpp -o faithpd tree.o biom.o unifrac.o cmd.o skbio_alt.o api.o -lhdf5_cpp -llz4 $(BLASLIB) -lpthread
+	$(H5CXX) $(CPPFLAGS) $(EXEFLAGS) su.cpp -o ssu tree.o biom.o unifrac.o cmd.o skbio_alt.o api.o -lhdf5_cpp -llz4 $(BLASLIB) -lpthread
+	$(H5CXX) $(CPPFLAGS) $(EXEFLAGS) faithpd.cpp -o faithpd tree.o biom.o unifrac.o cmd.o skbio_alt.o api.o -lhdf5_cpp -llz4 $(BLASLIB) -lpthread
 	cp ssu ${PREFIX}/bin/
 	cp faithpd ${PREFIX}/bin/
 
@@ -116,7 +116,7 @@ rapi_test: main
 	Rscript R_interface/rapi_test.R
 	
 api: tree.o biom.o unifrac.o cmd.o skbio_alt.o api.o
-	$(CXX) $(LDDFLAGS) -o libssu.so tree.o biom.o unifrac.o cmd.o skbio_alt.o api.o -lc -lhdf5_cpp -llz4 $(BLASLIB) -L$(PREFIX)/lib
+	$(H5CXX) $(LDDFLAGS) -o libssu.so tree.o biom.o unifrac.o cmd.o skbio_alt.o api.o -lc -lhdf5_cpp -llz4 $(BLASLIB) -L$(PREFIX)/lib
 	cp libssu.so ${PREFIX}/lib/
 
 capi_test: api
@@ -124,10 +124,13 @@ capi_test: api
 	export LD_LIBRARY_PATH="${PREFIX}/lib":"./capi_test"
 
 api.o: api.cpp api.hpp unifrac.hpp skbio_alt.hpp biom.hpp tree.hpp
-	$(CXX) $(CPPFLAGS) api.cpp -c -o api.o -fPIC
+	$(H5CXX) $(CPPFLAGS) api.cpp -c -o api.o -fPIC
+
+unifrac.o: unifrac.cpp unifrac.hpp unifrac_task.cpp unifrac_task.hpp biom_interface.hpp tree.hpp
+	$(CXX) $(CPPFLAGS) -c $< -o $@
 
 %.o: %.cpp %.hpp
-	$(CXX) $(CPPFLAGS) -c $< -o $@
+	$(H5CXX) $(CPPFLAGS) -c $< -o $@
 
 clean:
 	-rm -f *.o ssu

--- a/sucpp/Makefile
+++ b/sucpp/Makefile
@@ -127,7 +127,7 @@ libssu.so: tree.o biom.o unifrac.o cmd.o skbio_alt.o api.o $(UFCMP_LIBS)
 	cp libssu.so ${PREFIX}/lib/
 
 libssu_cpu.so: unifrac_cmp_cpu.o
-	$(H5CXX) $(LDDFLAGS) -o libssu_cpu.so unifrac_cmp_cpu.o -L$(PREFIX)/lib
+	$(CXX) $(LDDFLAGS) -o libssu_cpu.so unifrac_cmp_cpu.o -L$(PREFIX)/lib
 	cp libssu_cpu.so ${PREFIX}/lib/
 
 

--- a/sucpp/Makefile
+++ b/sucpp/Makefile
@@ -95,14 +95,20 @@ ifdef ACC_CXX
         endif
 endif
 
+ifeq ($(PLATFORM),Darwin)
+  TEST_DEPS = -lssu
+else
+  TEST_DEPS = -lssu -lssu_internal
+endif
+
 test_su: test_su.cpp libssu.so
-	$(H5CXX) $(CPPFLAGS) $(EXEFLAGS) test_su.cpp -o test_su -lssu -lpthread
+	$(H5CXX) $(CPPFLAGS) $(EXEFLAGS) test_su.cpp -o test_su $(TEST_DEPS) -lpthread
 
 test_ska: test_ska.cpp libssu.so
-	$(H5CXX) $(CPPFLAGS) $(EXEFLAGS) test_ska.cpp -o test_ska -lssu -lpthread
+	$(H5CXX) $(CPPFLAGS) $(EXEFLAGS) test_ska.cpp -o test_ska $(TEST_DEPS) -lpthread
 
 test_api: test_api.cpp libssu.so
-	$(H5CXX) $(CPPFLAGS) $(EXEFLAGS) test_api.cpp -o test_api -lssu -lpthread
+	$(H5CXX) $(CPPFLAGS) $(EXEFLAGS) test_api.cpp -o test_api $(TEST_DEPS) -lpthread
 
 test: test_su test_ska test_api
 	# test = (su,ska,api)

--- a/sucpp/Makefile
+++ b/sucpp/Makefile
@@ -138,6 +138,7 @@ libssu_acc.so: unifrac_cmp_acc.o
 endif
 
 api: libssu.so
+	# api == libssu.so
 
 capi_test: api
 	gcc -std=c99 capi_test.c -lssu -L${PREFIX}/lib -Wl,-rpath,${PREFIX}/lib -o capi_test

--- a/sucpp/Makefile
+++ b/sucpp/Makefile
@@ -113,6 +113,16 @@ rapi_test: main
 	echo LDFLAGS=-llz4 $(BLASLIB) >> ~/.R/Makevars
 	Rscript R_interface/rapi_test.R
 	
+ifeq ($(PLATFORM),Darwin)
+
+# We never use ACC under MacOS, so keep it simple
+
+libssu.so: tree.o biom.o unifrac.o unifrac_cmp_cpu.o cmd.o skbio_alt.o api.o 
+	$(H5CXX) $(LDDFLAGS) -o libssu.so tree.o biom.o unifrac.o unifrac_cmp_cpu.o cmd.o skbio_alt.o api.o -lc -lhdf5_cpp -llz4 $(BLASLIB)
+	cp libssu.so ${PREFIX}/lib/
+
+else
+
 libssu.so: tree.o biom.o unifrac.o cmd.o skbio_alt.o api.o $(UFCMP_LIBS)
 	$(H5CXX) $(LDDFLAGS) -o libssu.so tree.o biom.o unifrac.o cmd.o skbio_alt.o api.o $(UFCMP_LINK) -lc -lhdf5_cpp -llz4 $(BLASLIB)
 	cp libssu.so ${PREFIX}/lib/
@@ -124,6 +134,8 @@ libssu_cpu.so: unifrac_cmp_cpu.o
 libssu_acc.so: unifrac_cmp_acc.o
 	$(ACC_CXX) $(ACC_LDDFLAGS) -o libssu_acc.so unifrac_cmp_acc.o -lc
 	cp libssu_acc.so ${PREFIX}/lib/
+
+endif
 
 api: libssu.so
 

--- a/sucpp/affinity.hpp
+++ b/sucpp/affinity.hpp
@@ -42,7 +42,7 @@ CPU_COUNT(cpu_set_t *cs) { return __builtin_popcount(cs->count); }
 
 #define CPU_SETSIZE 32
 
-int sched_getaffinity(pid_t pid, size_t cpu_size, cpu_set_t *cpu_set)
+static int sched_getaffinity(pid_t pid, size_t cpu_size, cpu_set_t *cpu_set)
 {
   int32_t core_count = 0;
   size_t  len = sizeof(core_count);
@@ -58,7 +58,7 @@ int sched_getaffinity(pid_t pid, size_t cpu_size, cpu_set_t *cpu_set)
   return 0;
 }
 
-int pthread_setaffinity_np(pthread_t thread, size_t cpu_size,
+static int pthread_setaffinity_np(pthread_t thread, size_t cpu_size,
                            cpu_set_t *cpu_set)
 {
   thread_port_t mach_thread;
@@ -79,7 +79,7 @@ int pthread_setaffinity_np(pthread_t thread, size_t cpu_size,
 #define handle_error_en(en, msg) \
        do { errno = en; perror(msg); exit(EXIT_FAILURE); } while (0)
 
-int bind_to_core(int core) {
+static int bind_to_core(int core) {
     /* bind the calling thread to the requested core
      *
      * The use of this method is for better NUMA utilization. The 

--- a/sucpp/biom.cpp
+++ b/sucpp/biom.cpp
@@ -1,3 +1,12 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2016-2021, UniFrac development team.
+ * All rights reserved.
+ *
+ * See LICENSE file for more details
+ */
+
 #include <cstdlib>
 #include <iostream>
 #include <stdio.h>

--- a/sucpp/biom.hpp
+++ b/sucpp/biom.hpp
@@ -1,24 +1,26 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2016-2021, UniFrac development team.
+ * All rights reserved.
+ *
+ * See LICENSE file for more details
+ */
+
+
+#ifndef _UNIFRAC_BIOM_H
+#define _UNIFRAC_BIOM_H
+
 #include <H5Cpp.h>
 #include <H5Dpublic.h>
 #include <vector>
 #include <unordered_map>
 
+#include "biom_interface.hpp"
+
 namespace su {
-    class biom {
+    class biom : public biom_interface {
         public:
-            // cache the IDs contained within the table
-            std::vector<std::string> sample_ids;
-            std::vector<std::string> obs_ids;
-
-            // cache both index pointers into both CSC and CSR representations
-            std::vector<uint32_t> sample_indptr;
-            std::vector<uint32_t> obs_indptr;
-
-            uint32_t n_samples;  // the number of samples
-            uint32_t n_obs;      // the number of observations
-            uint32_t nnz;        // the total number of nonzero entries
-            double *sample_counts;
-
             /* default constructor
              *
              * @param filename The path to the BIOM table to read
@@ -29,7 +31,7 @@ namespace su {
              *
              * Temporary arrays are freed
              */
-            ~biom();
+            virtual ~biom();
 
             /* get a dense vector of observation data
              *
@@ -107,3 +109,6 @@ namespace su {
             template<class TFloat> void get_obs_data_range_TT(const std::string &id, unsigned int start, unsigned int end, bool normalize, TFloat* out) const;
     };
 }
+
+#endif /* _UNIFRAC_BIOM_H */
+

--- a/sucpp/biom_interface.hpp
+++ b/sucpp/biom_interface.hpp
@@ -1,0 +1,72 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2021-2021, UniFrac development team.
+ * All rights reserved.
+ *
+ * See LICENSE file for more details
+ */
+
+
+#ifndef _UNIFRAC_BIOM_INTERFACE_H
+#define _UNIFRAC_BIOM_INTERFACE_H
+
+#include <vector>
+#include <string>
+
+namespace su {
+    class biom_interface {
+        public:
+            // cache the IDs contained within the table
+            std::vector<std::string> sample_ids;
+            std::vector<std::string> obs_ids;
+
+            // cache both index pointers into both CSC and CSR representations
+            std::vector<uint32_t> sample_indptr;
+            std::vector<uint32_t> obs_indptr;
+
+            uint32_t n_samples;  // the number of samples
+            uint32_t n_obs;      // the number of observations
+            uint32_t nnz;        // the total number of nonzero entries
+            double *sample_counts;
+
+            /* default constructor
+             *
+             * Automatically create the needed objects.
+             * All other initialization happens in children constructors.
+             */
+            biom_interface() {}
+
+            /* default destructor
+             *
+             * Automatically destroy the objects.
+             * All other cleanup must have been performed by the children constructors.
+             */
+            virtual ~biom_interface() {}
+
+            /* get a dense vector of observation data
+             *
+             * @param id The observation ID to fetch
+             * @param out An allocated array of at least size n_samples. 
+             *      Values of an index position [0, n_samples) which do not
+             *      have data will be zero'd.
+             */
+            virtual void get_obs_data(const std::string &id, double* out) const = 0; 
+            virtual void get_obs_data(const std::string &id, float* out) const = 0;
+
+            /* get a dense vector of a range of observation data
+             *
+             * @param id The observation ID to fetc
+             * @param start Initial index
+             * @param end   First index past the end
+             * @param normalize If set, divide by sample_counts
+             * @param out An allocated array of at least size (end-start). First element will corrrectpoint to index start. 
+             *      Values of an index position [0, (end-start)) which do not
+             *      have data will be zero'd.
+             */
+            virtual void get_obs_data_range(const std::string &id, unsigned int start, unsigned int end, bool normalize, double* out) const = 0;
+            virtual void get_obs_data_range(const std::string &id, unsigned int start, unsigned int end, bool normalize, float* out) const = 0;
+    };
+}
+
+#endif /* _UNIFRAC_BIOOM_INTERFACE_H */

--- a/sucpp/su.cpp
+++ b/sucpp/su.cpp
@@ -395,8 +395,6 @@ int main(int argc, char **argv){
         return EXIT_SUCCESS;
     }
 
-#pragma acc init
-
     unsigned int nthreads;
     std::string table_filename = input.getCmdOption("-i");
     std::string tree_filename = input.getCmdOption("-t");

--- a/sucpp/test_su.cpp
+++ b/sucpp/test_su.cpp
@@ -1808,8 +1808,6 @@ void test_bptree_constructor_newline_bug() {
 }
 
 int main(int argc, char** argv) {
-#pragma acc init
-
     test_bptree_constructor_simple();
     test_bptree_constructor_newline_bug();
     test_bptree_constructor_from_existing();

--- a/sucpp/test_su.cpp
+++ b/sucpp/test_su.cpp
@@ -3,6 +3,7 @@
 #include "tree.hpp"
 #include "biom.hpp"
 #include "unifrac.hpp"
+#include "unifrac_internal.hpp"
 #include <cmath>
 #include <unordered_set>
 #include <string.h>

--- a/sucpp/tree.hpp
+++ b/sucpp/tree.hpp
@@ -1,3 +1,15 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2016-2021, UniFrac development team.
+ * All rights reserved.
+ *
+ * See LICENSE file for more details
+ */
+
+#ifndef __UNIFRAC_TREE_H
+#define __UNIFRAC_TREE_H 1
+
 #include <string>
 #include <sstream>
 #include <iostream>
@@ -121,3 +133,6 @@ namespace su {
             int32_t enclose(uint32_t i) const;
     };
 }
+
+#endif /* UNIFRAC_TREE_H */
+

--- a/sucpp/unifrac.cpp
+++ b/sucpp/unifrac.cpp
@@ -20,6 +20,9 @@
 #include <pthread.h>
 
 #include "unifrac_internal.hpp"
+
+// We will always have the CPU version
+#define SUCMP_NM  su_cpu
 #include "unifrac_cmp.hpp"
 
 
@@ -531,26 +534,24 @@ void su::faith_pd(biom_interface &table,
     }
 }
 
-/*
- * Defined in unifrac_cmd.cpp
 void su::unifrac(biom_interface &table,
                  BPTree &tree,
                  Method unifrac_method,
                  std::vector<double*> &dm_stripes,
                  std::vector<double*> &dm_stripes_total,
-                 const su::task_parameters* task_p)
+                 const su::task_parameters* task_p) {
+  su_cpu::unifrac(table, tree, unifrac_method, dm_stripes, dm_stripes_total, task_p);
+}
 
-*/
 
-/*
- *  Defined in unifrac_cmd.cpp
 void su::unifrac_vaw(biom_interface &table,
                      BPTree &tree,
                      Method unifrac_method,
                      std::vector<double*> &dm_stripes,
                      std::vector<double*> &dm_stripes_total,
-                     const su::task_parameters* task_p)
- */
+                     const su::task_parameters* task_p) {
+  su_cpu::unifrac_vaw(table, tree, unifrac_method, dm_stripes, dm_stripes_total, task_p);
+}
 
 template<class TFloat>
 void su::set_proportions(TFloat* __restrict__ props,

--- a/sucpp/unifrac.cpp
+++ b/sucpp/unifrac.cpp
@@ -520,8 +520,20 @@ inline bool use_acc() {
  if (proc_use_acc!=-1) return (proc_use_acc!=0);
  int has_nvidia_gpu_rc = access("/proc/driver/nvidia/gpus", F_OK);
 
+ bool print_info = false;
+
+ if (const char* env_p = std::getenv("UNIFRAC_GPU_INFO")) {
+   print_info = true;
+   std::string env_s(env_p);
+   if ((env_s=="NO") || (env_s=="N") || (env_s=="no") || (env_s=="n") ||
+       (env_s=="NEVER") || (env_s=="never")) {
+     print_info = false;
+   }
+ }
+
+
  if (has_nvidia_gpu_rc != 0) {
-   printf("INFO (unifrac): GPU not found, using CPU\n");
+   if (print_info) printf("INFO (unifrac): GPU not found, using CPU\n");
    proc_use_acc=0;
    return false;
  }
@@ -530,13 +542,13 @@ inline bool use_acc() {
    std::string env_s(env_p);
    if ((env_s=="NO") || (env_s=="N") || (env_s=="no") || (env_s=="n") ||
        (env_s=="NEVER") || (env_s=="never")) {
-     printf("INFO (unifrac): Use of GPU explicitly disabled, using CPU\n");
+     if (print_info) printf("INFO (unifrac): Use of GPU explicitly disabled, using CPU\n");
      proc_use_acc=0;
      return false;
    }
  }
 
- printf("INFO (unifrac): Using GPU\n");
+ if (print_info) printf("INFO (unifrac): Using GPU\n");
  proc_use_acc=1;
  return true;
 }

--- a/sucpp/unifrac.cpp
+++ b/sucpp/unifrac.cpp
@@ -33,9 +33,7 @@
 #undef SUCMP_NM
 #endif
 
-
-static pthread_mutex_t printf_mutex;
-static bool* report_status;
+using namespace su;
 
 std::string su::test_table_ids_are_subset_of_tree(su::biom_interface &table, su::BPTree &tree) {
     std::unordered_set<std::string> tip_names = tree.get_tip_names();
@@ -52,109 +50,6 @@ std::string su::test_table_ids_are_subset_of_tree(su::biom_interface &table, su:
 
     return a_missing_name;
 }
-
-int sync_printf(const char *format, ...) {
-    // https://stackoverflow.com/a/23587285/19741
-    va_list args;
-    va_start(args, format);
-
-    pthread_mutex_lock(&printf_mutex);
-    vprintf(format, args);
-    pthread_mutex_unlock(&printf_mutex);
-
-    va_end(args);
-}
-
-void sig_handler(int signo) {
-    // http://www.thegeekstuff.com/2012/03/catch-signals-sample-c-code
-    if (signo == SIGUSR1) {
-        if(report_status == NULL)
-            fprintf(stderr, "Cannot report status.\n");
-        else {
-            for(int i = 0; i < CPU_SETSIZE; i++) {
-                report_status[i] = true;
-            }
-        }
-    }
-}
-
-using namespace su;
-
-void su::try_report(const su::task_parameters* task_p, unsigned int k, unsigned int max_k) {
-  if(__builtin_expect(report_status[task_p->tid], false)) {
-    sync_printf("tid:%u\tstart:%u\tstop:%u\tk:%u\ttotal:%u\n", task_p->tid, task_p->start, task_p->stop, k, max_k);
-    report_status[task_p->tid] = false;
-  }
-}
-
-
-template<class TFloat>
-PropStack<TFloat>::PropStack(uint32_t vecsize) 
-: prop_stack()
-, prop_map()
-, defaultsize(vecsize)
-{
-    prop_map.reserve(1000);
-}
-
-template<class TFloat>
-PropStack<TFloat>::~PropStack() {
-    // drain stack
-    for(unsigned int i = 0; i < prop_stack.size(); i++) {
-        TFloat *vec = prop_stack.top();
-        prop_stack.pop();
-        free(vec);
-    }
-
-    // drain the map
-    for(auto it = prop_map.begin(); it != prop_map.end(); it++) {
-        TFloat *vec = it->second;
-        free(vec);
-    }
-    prop_map.clear();
-}
-
-template<class TFloat>
-TFloat* PropStack<TFloat>::get(uint32_t i) {
-    return prop_map[i];
-}
-
-template<class TFloat>
-void PropStack<TFloat>::push(uint32_t node) {
-    TFloat* vec = prop_map[node];
-    prop_map.erase(node);
-    prop_stack.push(vec);
-}
-
-template<class TFloat>
-TFloat* PropStack<TFloat>::pop(uint32_t node) {
-    /*
-     * if we don't have any available vectors, create one
-     * add it to our record of known vectors so we can track our mallocs
-     */
-    TFloat *vec;
-    int err = 0;
-    if(prop_stack.empty()) {
-        err = posix_memalign((void **)&vec, 32, sizeof(TFloat) * defaultsize);
-        if(vec == NULL || err != 0) {
-            fprintf(stderr, "Failed to allocate %zd bytes, err %d; [%s]:%d\n",
-                    sizeof(TFloat) * defaultsize, err, __FILE__, __LINE__);
-            exit(EXIT_FAILURE);
-        }
-    }
-    else {
-        vec = prop_stack.top();
-        prop_stack.pop();
-    }
-
-    prop_map[node] = vec;
-    return vec;
-}
-
-// make sure they get instantiated
-template class su::PropStack<float>;
-template class su::PropStack<double>;
-
 
 double** su::deconvolute_stripes(std::vector<double*> &stripes, uint32_t n) {
     // would be better to just do striped_to_condensed_form
@@ -453,34 +348,6 @@ void progressbar(float progress) {
     std::cout.flush();
 }
 
-void su::initialize_stripes(std::vector<double*> &dm_stripes,
-                            std::vector<double*> &dm_stripes_total,
-                            bool want_total,
-                            const su::task_parameters* task_p) {
-    int err = 0;
-    for(unsigned int i = task_p->start; i < task_p->stop; i++){
-        err = posix_memalign((void **)&dm_stripes[i], 4096, sizeof(double) * task_p->n_samples);
-        if(dm_stripes[i] == NULL || err != 0) {
-            fprintf(stderr, "Failed to allocate %zd bytes, err %d; [%s]:%d\n",
-                    sizeof(double) * task_p->n_samples, err, __FILE__, __LINE__);
-            exit(EXIT_FAILURE);
-        }
-        for(unsigned int j = 0; j < task_p->n_samples; j++)
-            dm_stripes[i][j] = 0.;
-
-        if(want_total) {
-            err = posix_memalign((void **)&dm_stripes_total[i], 4096, sizeof(double) * task_p->n_samples);
-            if(dm_stripes_total[i] == NULL || err != 0) {
-                fprintf(stderr, "Failed to allocate %zd bytes err %d; [%s]:%d\n",
-                        sizeof(double) * task_p->n_samples, err, __FILE__, __LINE__);
-                exit(EXIT_FAILURE);
-            }
-            for(unsigned int j = 0; j < task_p->n_samples; j++)
-                dm_stripes_total[i][j] = 0.;
-        }
-    }
-}
-
 // Computes Faith's PD for the samples in  `table` over the phylogenetic
 // tree given by `tree`.
 // Assure that tree does not contain ids that are not in table
@@ -589,123 +456,6 @@ void su::unifrac_vaw(biom_interface &table,
   }
 }
 
-template<class TFloat>
-void su::set_proportions(TFloat* __restrict__ props,
-                         const BPTree &tree,
-                         uint32_t node,
-                         const biom_interface &table,
-                         PropStack<TFloat> &ps,
-                         bool normalize) {
-    if(tree.isleaf(node)) {
-       table.get_obs_data(tree.names[node], props);
-       if (normalize) {
-#pragma omp parallel for schedule(static)
-        for(unsigned int i = 0; i < table.n_samples; i++) {
-           props[i] /= table.sample_counts[i];
-        }
-       }
-
-    } else {
-        unsigned int current = tree.leftchild(node);
-        unsigned int right = tree.rightchild(node);
-
-#pragma omp parallel for schedule(static)
-        for(unsigned int i = 0; i < table.n_samples; i++)
-            props[i] = 0;
-
-        while(current <= right && current != 0) {
-            TFloat * __restrict__ vec = ps.get(current);  // pull from prop map
-            ps.push(current);  // remove from prop map, place back on stack
-
-#pragma omp parallel for schedule(static)
-            for(unsigned int i = 0; i < table.n_samples; i++)
-                props[i] = props[i] + vec[i];
-
-            current = tree.rightsibling(current);
-        }
-    }
-}
-
-// make sure they get instantiated
-template void su::set_proportions(float* __restrict__ props,
-                                  const BPTree &tree,
-                                  uint32_t node,
-                                  const biom_interface &table,
-                                  PropStack<float> &ps,
-                                  bool normalize);
-template void su::set_proportions(double* __restrict__ props,
-                                  const BPTree &tree,
-                                  uint32_t node,
-                                  const biom_interface &table,
-                                  PropStack<double> &ps,
-                                  bool normalize);
-
-template<class TFloat>
-void su::set_proportions_range(TFloat* __restrict__ props,
-                               const BPTree &tree,
-                               uint32_t node,
-                               const biom_interface &table, 
-                               unsigned int start, unsigned int end,
-                               PropStack<TFloat> &ps,
-                               bool normalize) {
-    const unsigned int els = end-start;
-    if(tree.isleaf(node)) {
-       table.get_obs_data_range(tree.names[node], start, end, normalize, props);
-    } else {
-        const unsigned int right = tree.rightchild(node);
-        unsigned int current = tree.leftchild(node);
-
-        for(unsigned int i = 0; i < els; i++)
-            props[i] = 0;
-
-        while(current <= right && current != 0) {
-            const TFloat * __restrict__ vec = ps.get(current);  // pull from prop map
-            ps.push(current);  // remove from prop map, place back on stack
-
-            for(unsigned int i = 0; i < els; i++)
-                props[i] += vec[i];
-
-            current = tree.rightsibling(current);
-        }
-    }
-}
-
-// make sure they get instantiated
-template void su::set_proportions_range(float* __restrict__ props,
-                                        const BPTree &tree,
-                                        uint32_t node,
-                                        const biom_interface &table,
-                                        unsigned int start, unsigned int end,
-                                        PropStack<float> &ps,
-                                        bool normalize);
-template void su::set_proportions_range(double* __restrict__ props,
-                                        const BPTree &tree,
-                                        uint32_t node,
-                                        const biom_interface &table,
-                                        unsigned int start, unsigned int end,
-                                        PropStack<double> &ps,
-                                        bool normalize);
-
-std::vector<double*> su::make_strides(unsigned int n_samples) {
-    uint32_t n_rotations = (n_samples + 1) / 2;
-    std::vector<double*> dm_stripes(n_rotations);
-
-    int err = 0;
-    for(unsigned int i = 0; i < n_rotations; i++) {
-        double* tmp;
-        err = posix_memalign((void **)&tmp, 32, sizeof(double) * n_samples);
-        if(tmp == NULL || err != 0) {
-            fprintf(stderr, "Failed to allocate %zd bytes, err %d; [%s]:%d\n",
-                    sizeof(double) * n_samples, err,  __FILE__, __LINE__);
-            exit(EXIT_FAILURE);
-        }
-        for(unsigned int j = 0; j < n_samples; j++)
-            tmp[j] = 0.0;
-        dm_stripes[i] = tmp;
-    }
-    return dm_stripes;
-}
-
 
 void su::process_stripes(biom_interface &table,
                          BPTree &tree_sheared,
@@ -718,11 +468,7 @@ void su::process_stripes(biom_interface &table,
 
     // register a signal handler so we can ask the master thread for its
     // progress
-    if (signal(SIGUSR1, sig_handler) == SIG_ERR)
-        fprintf(stderr, "Can't catch SIGUSR1\n");
-
-    report_status = (bool*)calloc(sizeof(bool), CPU_SETSIZE);
-    pthread_mutex_init(&printf_mutex, NULL);
+    register_report_status();
 
     // cannot use threading with openacc or openmp
     for(unsigned int tid = 0; tid < threads.size(); tid++) {
@@ -744,8 +490,5 @@ void su::process_stripes(biom_interface &table,
                                        &tasks[tid]);
     }
 
-    if(report_status != NULL) {
-        pthread_mutex_destroy(&printf_mutex);
-        free(report_status);
-    }
+    remove_report_status();
 }

--- a/sucpp/unifrac.cpp
+++ b/sucpp/unifrac.cpp
@@ -1,5 +1,14 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2016-2021, UniFrac development team.
+ * All rights reserved.
+ *
+ * See LICENSE file for more details
+ */
+
 #include "tree.hpp"
-#include "biom.hpp"
+#include "biom_interface.hpp"
 #include "unifrac.hpp"
 #include "affinity.hpp"
 #include <unordered_map>
@@ -17,7 +26,7 @@
 static pthread_mutex_t printf_mutex;
 static bool* report_status;
 
-std::string su::test_table_ids_are_subset_of_tree(su::biom &table, su::BPTree &tree) {
+std::string su::test_table_ids_are_subset_of_tree(su::biom_interface &table, su::BPTree &tree) {
     std::unordered_set<std::string> tip_names = tree.get_tip_names();
     std::unordered_set<std::string>::const_iterator hit;
     std::string a_missing_name = "";

--- a/sucpp/unifrac.cpp
+++ b/sucpp/unifrac.cpp
@@ -557,17 +557,7 @@ void unifracTT(const biom_interface &table,
                std::vector<double*> &dm_stripes_total,
                const su::task_parameters* task_p) {
     int err;
-#if defined(_OPENACC) || defined(_OPENMP)
     // no processor affinity whenusing openacc or openmp
-#else
-    // processor affinity
-    // processor affinity, when not using openacc or openmp
-    err = bind_to_core(task_p->tid);
-    if(err != 0) {
-        fprintf(stderr, "Unable to bind thread %d to core: %d\n", task_p->tid, err);
-        exit(EXIT_FAILURE);
-    }
-#endif
 
     if(table.n_samples != task_p->n_samples) {
         fprintf(stderr, "Task and table n_samples not equal\n");
@@ -762,15 +752,7 @@ void unifrac_vawTT(const biom_interface &table,
                           std::vector<double*> &dm_stripes_total,
                           const su::task_parameters* task_p) {
     int err;
-#if defined(_OPENACC) || defined(_OPENMP)
     // no processor affinity whenusing openacc or openmp
-#else
-    err = bind_to_core(task_p->tid);
-    if(err != 0) {
-        fprintf(stderr, "Unable to bind thread %d to core: %d\n", task_p->tid, err);
-        exit(EXIT_FAILURE);
-    }
-#endif
 
     if(table.n_samples != task_p->n_samples) {
         fprintf(stderr, "Task and table n_samples not equal\n");
@@ -1053,7 +1035,6 @@ void su::process_stripes(biom_interface &table,
     report_status = (bool*)calloc(sizeof(bool), CPU_SETSIZE);
     pthread_mutex_init(&printf_mutex, NULL);
 
-#if defined(_OPENACC) || defined(_OPENMP)
     // cannot use threading with openacc or openmp
     for(unsigned int tid = 0; tid < threads.size(); tid++) {
         if(variance_adjust)
@@ -1073,30 +1054,6 @@ void su::process_stripes(biom_interface &table,
                                        std::ref(dm_stripes_total),
                                        &tasks[tid]);
     }
-#else
-    for(unsigned int tid = 0; tid < threads.size(); tid++) {
-        if(variance_adjust)
-            threads[tid] = std::thread(su::unifrac_vaw,
-                                       std::ref(table),
-                                       std::ref(tree_sheared),
-                                       method,
-                                       std::ref(dm_stripes),
-                                       std::ref(dm_stripes_total),
-                                       &tasks[tid]);
-        else
-            threads[tid] = std::thread(su::unifrac,
-                                       std::ref(table),
-                                       std::ref(tree_sheared),
-                                       method,
-                                       std::ref(dm_stripes),
-                                       std::ref(dm_stripes_total),
-                                       &tasks[tid]);
-    }
-
-    for(unsigned int tid = 0; tid < threads.size(); tid++) {
-        threads[tid].join();
-    }
-#endif
 
     if(report_status != NULL) {
         pthread_mutex_destroy(&printf_mutex);

--- a/sucpp/unifrac.cpp
+++ b/sucpp/unifrac.cpp
@@ -468,7 +468,7 @@ void progressbar(float progress) {
 }
 
 template<class TFloat>
-void initialize_sample_counts(TFloat*& _counts, const su::task_parameters* task_p, const biom &table) {
+void initialize_sample_counts(TFloat*& _counts, const su::task_parameters* task_p, const biom_interface &table) {
     const unsigned int n_samples = task_p->n_samples;
     const uint64_t  n_samples_r = ((n_samples + UNIFRAC_BLOCK-1)/UNIFRAC_BLOCK)*UNIFRAC_BLOCK; // round up
     TFloat * counts = NULL;
@@ -522,7 +522,7 @@ void initialize_stripes(std::vector<double*> &dm_stripes,
 // Computes Faith's PD for the samples in  `table` over the phylogenetic
 // tree given by `tree`.
 // Assure that tree does not contain ids that are not in table
-void su::faith_pd(biom &table,
+void su::faith_pd(biom_interface &table,
                   BPTree &tree,
                   double* result) {
     PropStack<double> propstack(table.n_samples);
@@ -549,7 +549,7 @@ void su::faith_pd(biom &table,
 }
 
 template<class TaskT, class TFloat>
-void unifracTT(const biom &table,
+void unifracTT(const biom_interface &table,
                const BPTree &tree,
                const bool want_total,
                std::vector<double*> &dm_stripes,
@@ -714,7 +714,7 @@ void unifracTT(const biom &table,
     free(lengths);
 }
 
-void su::unifrac(biom &table,
+void su::unifrac(biom_interface &table,
                  BPTree &tree,
                  Method unifrac_method,
                  std::vector<double*> &dm_stripes,
@@ -754,7 +754,7 @@ void su::unifrac(biom &table,
 
 
 template<class TaskT, class TFloat>
-void unifrac_vawTT(const biom &table,
+void unifrac_vawTT(const biom_interface &table,
                    const BPTree &tree,
                           const bool want_total,
                           std::vector<double*> &dm_stripes,
@@ -878,7 +878,7 @@ void unifrac_vawTT(const biom &table,
     free(sample_total_counts);
 }
 
-void su::unifrac_vaw(biom &table,
+void su::unifrac_vaw(biom_interface &table,
                      BPTree &tree,
                      Method unifrac_method,
                      std::vector<double*> &dm_stripes,
@@ -920,7 +920,7 @@ template<class TFloat>
 void su::set_proportions(TFloat* __restrict__ props,
                          const BPTree &tree,
                          uint32_t node,
-                         const biom &table,
+                         const biom_interface &table,
                          PropStack<TFloat> &ps,
                          bool normalize) {
     if(tree.isleaf(node)) {
@@ -957,13 +957,13 @@ void su::set_proportions(TFloat* __restrict__ props,
 template void su::set_proportions(float* __restrict__ props,
                                   const BPTree &tree,
                                   uint32_t node,
-                                  const biom &table,
+                                  const biom_interface &table,
                                   PropStack<float> &ps,
                                   bool normalize);
 template void su::set_proportions(double* __restrict__ props,
                                   const BPTree &tree,
                                   uint32_t node,
-                                  const biom &table,
+                                  const biom_interface &table,
                                   PropStack<double> &ps,
                                   bool normalize);
 
@@ -971,7 +971,7 @@ template<class TFloat>
 void su::set_proportions_range(TFloat* __restrict__ props,
                                const BPTree &tree,
                                uint32_t node,
-                               const biom &table, 
+                               const biom_interface &table, 
                                unsigned int start, unsigned int end,
                                PropStack<TFloat> &ps,
                                bool normalize) {
@@ -1001,14 +1001,14 @@ void su::set_proportions_range(TFloat* __restrict__ props,
 template void su::set_proportions_range(float* __restrict__ props,
                                         const BPTree &tree,
                                         uint32_t node,
-                                        const biom &table,
+                                        const biom_interface &table,
                                         unsigned int start, unsigned int end,
                                         PropStack<float> &ps,
                                         bool normalize);
 template void su::set_proportions_range(double* __restrict__ props,
                                         const BPTree &tree,
                                         uint32_t node,
-                                        const biom &table,
+                                        const biom_interface &table,
                                         unsigned int start, unsigned int end,
                                         PropStack<double> &ps,
                                         bool normalize);
@@ -1034,7 +1034,7 @@ std::vector<double*> su::make_strides(unsigned int n_samples) {
 }
 
 
-void su::process_stripes(biom &table,
+void su::process_stripes(biom_interface &table,
                          BPTree &tree_sheared,
                          Method method,
                          bool variance_adjust,

--- a/sucpp/unifrac.cpp
+++ b/sucpp/unifrac.cpp
@@ -19,8 +19,8 @@
 #include <algorithm>
 #include <pthread.h>
 
-// embed in this file, to properly instantiate the templatized functions
-#include "unifrac_task.cpp"
+#include "unifrac_internal.hpp"
+#include "unifrac_cmp.hpp"
 
 
 static pthread_mutex_t printf_mutex;
@@ -68,6 +68,13 @@ void sig_handler(int signo) {
 }
 
 using namespace su;
+
+void su::try_report(const su::task_parameters* task_p, unsigned int k, unsigned int max_k) {
+  if(__builtin_expect(report_status[task_p->tid], false)) {
+    sync_printf("tid:%u\tstart:%u\tstop:%u\tk:%u\ttotal:%u\n", task_p->tid, task_p->start, task_p->stop, k, max_k);
+    report_status[task_p->tid] = false;
+  }
+}
 
 
 template<class TFloat>
@@ -137,38 +144,6 @@ TFloat* PropStack<TFloat>::pop(uint32_t node) {
 template class su::PropStack<float>;
 template class su::PropStack<double>;
 
-
-// Helper class with default constructor
-// The default is small enough to fit in L1 cache
-template<class TFloat>
-class PropStackFixed : public PropStack<TFloat> {
-  public:
-    static const uint32_t DEF_VEC_SIZE = 1024*sizeof(double)/sizeof(TFloat);
-
-    PropStackFixed() : PropStack<TFloat>(DEF_VEC_SIZE) {}
-};
-
-// Helper class that splits a large vec_size into several smaller chunks of def_size
-template<class TFloat> 
-class PropStackMulti {
-  protected:
-    const uint32_t vecsize;
-    std::vector<PropStackFixed<TFloat> > multi;
-
-  public:
-    PropStackMulti(uint32_t _vecsize) 
-    : vecsize(_vecsize)
-    , multi((vecsize + (PropStackFixed<TFloat>::DEF_VEC_SIZE-1))/PropStackFixed<TFloat>::DEF_VEC_SIZE) // round up
-    {}
-    ~PropStackMulti() {}
-
-    uint32_t get_num_stacks() const {return (vecsize + (PropStackFixed<TFloat>::DEF_VEC_SIZE-1))/PropStackFixed<TFloat>::DEF_VEC_SIZE;}
-
-    uint32_t get_start(uint32_t idx) const {return idx*PropStackFixed<TFloat>::DEF_VEC_SIZE;}
-    uint32_t get_end(uint32_t idx) const   {return std::min((idx+1)*PropStackFixed<TFloat>::DEF_VEC_SIZE, vecsize);}
-
-    PropStackFixed<TFloat> &get_prop_stack(uint32_t idx) {return multi[idx];}
-};
 
 double** su::deconvolute_stripes(std::vector<double*> &stripes, uint32_t n) {
     // would be better to just do striped_to_condensed_form
@@ -468,7 +443,7 @@ void progressbar(float progress) {
 }
 
 template<class TFloat>
-uint64_t initialize_sample_counts(TFloat*& _counts, const su::task_parameters* task_p, const biom_interface &table) {
+uint64_t initialize_sample_countsTT(TFloat*& _counts, const su::task_parameters* task_p, const biom_interface &table) {
     const unsigned int n_samples = task_p->n_samples;
     const uint64_t  n_samples_r = ((n_samples + UNIFRAC_BLOCK-1)/UNIFRAC_BLOCK)*UNIFRAC_BLOCK; // round up
     TFloat * counts = NULL;
@@ -492,10 +467,17 @@ uint64_t initialize_sample_counts(TFloat*& _counts, const su::task_parameters* t
    return n_samples_r;
 }
 
-void initialize_stripes(std::vector<double*> &dm_stripes,
-                        std::vector<double*> &dm_stripes_total,
-                        bool want_total,
-                        const su::task_parameters* task_p) {
+uint64_t su::initialize_sample_counts(double*& _counts, const su::task_parameters* task_p, const biom_interface &table) {
+   return initialize_sample_countsTT(_counts, task_p, table);
+}
+uint64_t su::initialize_sample_counts(float*& _counts, const su::task_parameters* task_p, const biom_interface &table) {
+   return initialize_sample_countsTT(_counts, task_p, table);
+}
+
+void su::initialize_stripes(std::vector<double*> &dm_stripes,
+                            std::vector<double*> &dm_stripes_total,
+                            bool want_total,
+                            const su::task_parameters* task_p) {
     int err = 0;
     for(unsigned int i = task_p->start; i < task_p->stop; i++){
         err = posix_memalign((void **)&dm_stripes[i], 4096, sizeof(double) * task_p->n_samples);
@@ -549,356 +531,26 @@ void su::faith_pd(biom_interface &table,
     }
 }
 
-template<class TaskT, class TFloat>
-void unifracTT(const biom_interface &table,
-               const BPTree &tree,
-               const bool want_total,
-               std::vector<double*> &dm_stripes,
-               std::vector<double*> &dm_stripes_total,
-               const su::task_parameters* task_p) {
-    int err;
-    // no processor affinity whenusing openacc or openmp
-
-    if(table.n_samples != task_p->n_samples) {
-        fprintf(stderr, "Task and table n_samples not equal\n");
-        exit(EXIT_FAILURE);
-    }
-    const unsigned int n_samples = task_p->n_samples;
-    const uint64_t  n_samples_r = ((n_samples + UNIFRAC_BLOCK-1)/UNIFRAC_BLOCK)*UNIFRAC_BLOCK; // round up
-
-
-    PropStackMulti<TFloat> propstack_multi(table.n_samples);
-
-    const unsigned int max_emb =  TaskT::RECOMMENDED_MAX_EMBS;
-
-    initialize_stripes(std::ref(dm_stripes), std::ref(dm_stripes_total), want_total, task_p);
-
-    TaskT taskObj(std::ref(dm_stripes), std::ref(dm_stripes_total),max_emb,task_p);
-
-    TFloat *lengths = NULL;
-    err = posix_memalign((void **)&lengths, 4096, sizeof(TFloat) * max_emb);
-    if(err != 0) {
-        fprintf(stderr, "posix_memalign(%d) failed: %d\n", sizeof(TFloat) * max_emb,  err);
-        exit(EXIT_FAILURE);
-    }
-#pragma acc enter data create(lengths[:max_emb])
-
-        /*
-         * The values in the example vectors correspond to index positions of an
-         * element in the resulting distance matrix. So, in the example below,
-         * the following can be interpreted:
-         *
-         * [0 1 2]
-         * [1 2 3]
-         *
-         * As comparing the sample for row 0 against the sample for col 1, the
-         * sample for row 1 against the sample for col 2, the sample for row 2
-         * against the sample for col 3.
-         *
-         * In other words, we're computing stripes of a distance matrix. In the
-         * following example, we're computing over 6 samples requiring 3
-         * stripes.
-         *
-         * A; stripe == 0
-         * [0 1 2 3 4 5]
-         * [1 2 3 4 5 0]
-         *
-         * B; stripe == 1
-         * [0 1 2 3 4 5]
-         * [2 3 4 5 0 1]
-         *
-         * C; stripe == 2
-         * [0 1 2 3 4 5]
-         * [3 4 5 0 1 2]
-         *
-         * The stripes end up computing the following positions in the distance
-         * matrix.
-         *
-         * x A B C x x
-         * x x A B C x
-         * x x x A B C
-         * C x x x A B
-         * B C x x x A
-         * A B C x x x
-         *
-         * However, we store those stripes as vectors, ie
-         * [ A A A A A A ]
-         *
-         * We end up performing N / 2 redundant calculations on the last stripe
-         * (see C) but that is small over large N.
-         */
-
-    unsigned int k = 0; // index in tree
-    const unsigned int max_k = (tree.nparens / 2) - 1;
-
-    const unsigned int num_prop_chunks = propstack_multi.get_num_stacks();
-    while (k<max_k) {
-          const unsigned int k_start = k;
-          unsigned int filled_emb = 0;
-
-          // chunk the progress to maximize cache reuse
-#pragma omp parallel for 
-          for (unsigned int ck=0; ck<num_prop_chunks; ck++) {
-            PropStack<TFloat> &propstack = propstack_multi.get_prop_stack(ck);
-            const unsigned int tstart = propstack_multi.get_start(ck);
-            const unsigned int tend = propstack_multi.get_end(ck);
-            unsigned int my_filled_emb = 0;
-            unsigned int my_k=k_start;
-
-            while ((my_filled_emb<max_emb) && (my_k<max_k)) {
-              const uint32_t node = tree.postorderselect(my_k);
-              my_k++;
-
-              TFloat *node_proportions = propstack.pop(node);
-              set_proportions_range(node_proportions, tree, node, table, tstart, tend, propstack);
-
-              if(task_p->bypass_tips && tree.isleaf(node))
-                  continue;
-
-              if (ck==0) { // they all do the same thing, so enough for the first to update the global state
-                lengths[filled_emb] = tree.lengths[node];
-                filled_emb++;
-              }
-              taskObj.embed_proportions_range(node_proportions, tstart, tend, my_filled_emb);
-              my_filled_emb++;
-            }
-            if (ck==0) { // they all do the same thing, so enough for the first to update the global state
-              k=my_k;
-            }
-          }
-
-          taskObj.sync_embedded_proportions(filled_emb);
-#ifdef _OPENACC
-          // lengths may be still in use in async mode, wait
-#pragma acc wait
-#pragma acc update device(lengths[:filled_emb])
-#endif
-          taskObj._run(filled_emb,lengths);
-          filled_emb=0;
-
-          if(__builtin_expect(report_status[task_p->tid], false)) {
-              sync_printf("tid:%d\tstart:%d\tstop:%d\tk:%d\ttotal:%d\n", task_p->tid, task_p->start, task_p->stop, k, max_k);
-              report_status[task_p->tid] = false;
-          }
-    }
-
-#pragma acc wait
-
-    if(want_total) {
-        const unsigned int start_idx = task_p->start;
-        const unsigned int stop_idx = task_p->stop;
-
-        TFloat * const dm_stripes_buf = taskObj.dm_stripes.buf;
-        const TFloat * const dm_stripes_total_buf = taskObj.dm_stripes_total.buf;
-
-#pragma acc parallel loop collapse(2) present(dm_stripes_buf,dm_stripes_total_buf)
-        for(unsigned int i = start_idx; i < stop_idx; i++)
-            for(unsigned int j = 0; j < n_samples; j++) {
-                unsigned int idx = (i-start_idx)*n_samples_r+j;
-                dm_stripes_buf[idx]=dm_stripes_buf[idx]/dm_stripes_total_buf[idx];
-                // taskObj.dm_stripes[i][j] = taskObj.dm_stripes[i][j] / taskObj.dm_stripes_total[i][j];
-            }
-        
-    }
-
-#pragma acc exit data delete(lengths[:max_emb])
-    free(lengths);
-}
-
+/*
+ * Defined in unifrac_cmd.cpp
 void su::unifrac(biom_interface &table,
                  BPTree &tree,
                  Method unifrac_method,
                  std::vector<double*> &dm_stripes,
                  std::vector<double*> &dm_stripes_total,
-                 const su::task_parameters* task_p) {
-    switch(unifrac_method) {
-        case unweighted:
-            unifracTT<SUCMP_NM::UnifracUnweightedTask<double>,double>(           table, tree, true,  dm_stripes,dm_stripes_total,task_p);
-            break;
-        case weighted_normalized:
-            unifracTT<SUCMP_NM::UnifracNormalizedWeightedTask<double>,double>(   table, tree, true,  dm_stripes,dm_stripes_total,task_p);
-            break;
-        case weighted_unnormalized:
-            unifracTT<SUCMP_NM::UnifracUnnormalizedWeightedTask<double>,double>( table, tree, false, dm_stripes,dm_stripes_total,task_p);
-            break;
-        case generalized:
-            unifracTT<SUCMP_NM::UnifracGeneralizedTask<double>,double>(          table, tree, true,  dm_stripes,dm_stripes_total,task_p);
-            break;
-        case unweighted_fp32:
-            unifracTT<SUCMP_NM::UnifracUnweightedTask<float >,float>(            table, tree, true,  dm_stripes,dm_stripes_total,task_p);
-            break;
-        case weighted_normalized_fp32:
-            unifracTT<SUCMP_NM::UnifracNormalizedWeightedTask<float >,float>(    table, tree, true,  dm_stripes,dm_stripes_total,task_p);
-            break;
-        case weighted_unnormalized_fp32:
-            unifracTT<SUCMP_NM::UnifracUnnormalizedWeightedTask<float >,float>(  table, tree, false, dm_stripes,dm_stripes_total,task_p);
-            break;
-        case generalized_fp32:
-            unifracTT<SUCMP_NM::UnifracGeneralizedTask<float >,float>(           table, tree, true,  dm_stripes,dm_stripes_total,task_p);
-            break;
-        default:
-            fprintf(stderr, "Unknown unifrac task\n");
-            exit(1);
-            break;
-    }
-}
+                 const su::task_parameters* task_p)
 
+*/
 
-template<class TaskT, class TFloat>
-void unifrac_vawTT(const biom_interface &table,
-                   const BPTree &tree,
-                          const bool want_total,
-                          std::vector<double*> &dm_stripes,
-                          std::vector<double*> &dm_stripes_total,
-                          const su::task_parameters* task_p) {
-    int err;
-    // no processor affinity whenusing openacc or openmp
-
-    if(table.n_samples != task_p->n_samples) {
-        fprintf(stderr, "Task and table n_samples not equal\n");
-        exit(EXIT_FAILURE);
-    }
-    const unsigned int n_samples = task_p->n_samples;
-    const uint64_t  n_samples_r = ((n_samples + UNIFRAC_BLOCK-1)/UNIFRAC_BLOCK)*UNIFRAC_BLOCK; // round up
-
-    PropStackMulti<TFloat> propstack_multi(table.n_samples);
-    PropStackMulti<TFloat> countstack_multi(table.n_samples);
-
-    const unsigned int max_emb = TaskT::RECOMMENDED_MAX_EMBS;
-
-    TFloat *sample_total_counts;
-
-    initialize_sample_counts<TFloat>(sample_total_counts, task_p, table);
-#pragma acc enter data copyin(sample_total_counts[:n_samples_r])
-    initialize_stripes(std::ref(dm_stripes), std::ref(dm_stripes_total), want_total, task_p);
-
-    TaskT taskObj(std::ref(dm_stripes), std::ref(dm_stripes_total), sample_total_counts, max_emb, task_p);
-
-    TFloat *lengths = NULL;
-    err = posix_memalign((void **)&lengths, 4096, sizeof(TFloat) * max_emb);
-    if(err != 0) {
-        fprintf(stderr, "posix_memalign(%d) failed: %d\n", sizeof(TFloat) * max_emb, err);
-        exit(EXIT_FAILURE);
-    }
-#pragma acc enter data create(lengths[:max_emb])
-
-    unsigned int k = 0; // index in tree
-    const unsigned int max_k = (tree.nparens / 2) - 1;
-
-    const unsigned int num_prop_chunks = propstack_multi.get_num_stacks();
-    while (k<max_k) {
-          const unsigned int k_start = k;
-          unsigned int filled_emb = 0;
-
-          // chunk the progress to maximize cache reuse
-#pragma omp parallel for 
-          for (unsigned int ck=0; ck<num_prop_chunks; ck++) {
-            PropStack<TFloat> &propstack = propstack_multi.get_prop_stack(ck);
-            PropStack<TFloat> &countstack = countstack_multi.get_prop_stack(ck);
-            const unsigned int tstart = propstack_multi.get_start(ck);
-            const unsigned int tend = propstack_multi.get_end(ck);
-            unsigned int my_filled_emb = 0;
-            unsigned int my_k=k_start;
-
-            while ((my_filled_emb<max_emb) && (my_k<max_k)) {
-              const uint32_t node = tree.postorderselect(my_k);
-              my_k++;
-
-              TFloat *node_proportions = propstack.pop(node);
-              TFloat *node_counts = countstack.pop(node);
-
-              set_proportions_range(node_proportions, tree, node, table, tstart, tend, propstack);
-              set_proportions_range(node_counts, tree, node, table, tstart, tend, countstack, false);
-
-              if(task_p->bypass_tips && tree.isleaf(node))
-                  continue;
-
-              if (ck==0) { // they all do the same thing, so enough for the first to update the global state
-                lengths[filled_emb] = tree.lengths[node];
-                filled_emb++;
-              }
-              taskObj.embed_range(node_proportions, node_counts, tstart, tend, my_filled_emb);
-              my_filled_emb++;
-            }
-            if (ck==0) { // they all do the same thing, so enough for the first to update the global state
-              k=my_k;
-            }
-          }
-
-#pragma acc wait
-#pragma acc update device(lengths[:filled_emb])
-          taskObj.sync_embedded(filled_emb);
-          taskObj._run(filled_emb,lengths);
-          filled_emb = 0;
-
-          if(__builtin_expect(report_status[task_p->tid], false)) {
-              sync_printf("tid:%d\tstart:%d\tstop:%d\tk:%d\ttotal:%d\n", task_p->tid, task_p->start, task_p->stop, k, max_k);
-              report_status[task_p->tid] = false;
-          }
-    }
-
-#pragma acc wait
-    if(want_total) {
-        const unsigned int start_idx = task_p->start;
-        const unsigned int stop_idx = task_p->stop;
-
-        TFloat * const dm_stripes_buf = taskObj.dm_stripes.buf;
-        const TFloat * const dm_stripes_total_buf = taskObj.dm_stripes_total.buf;
-
-#pragma acc parallel loop collapse(2) present(dm_stripes_buf,dm_stripes_total_buf)
-        for(unsigned int i = start_idx; i < stop_idx; i++)
-            for(unsigned int j = 0; j < n_samples; j++) {
-                unsigned int idx = (i-start_idx)*n_samples_r+j;
-                dm_stripes_buf[idx]=dm_stripes_buf[idx]/dm_stripes_total_buf[idx];
-                // taskObj.dm_stripes[i][j] = taskObj.dm_stripes[i][j] / taskObj.dm_stripes_total[i][j];
-            }
-
-    }
-
-
-#pragma acc exit data delete(lengths[:max_emb])
-#pragma acc exit data delete(sample_total_counts[:n_samples_r])
-    free(lengths);
-    free(sample_total_counts);
-}
-
+/*
+ *  Defined in unifrac_cmd.cpp
 void su::unifrac_vaw(biom_interface &table,
                      BPTree &tree,
                      Method unifrac_method,
                      std::vector<double*> &dm_stripes,
                      std::vector<double*> &dm_stripes_total,
-                     const su::task_parameters* task_p) {
-    switch(unifrac_method) {
-        case unweighted:
-            unifrac_vawTT<SUCMP_NM::UnifracVawUnweightedTask<double>,double>(           table, tree, true,  dm_stripes,dm_stripes_total,task_p);
-            break;
-        case weighted_normalized:
-            unifrac_vawTT<SUCMP_NM::UnifracVawNormalizedWeightedTask<double>,double>(   table, tree, true,  dm_stripes,dm_stripes_total,task_p);
-            break;
-        case weighted_unnormalized:
-            unifrac_vawTT<SUCMP_NM::UnifracVawUnnormalizedWeightedTask<double>,double>( table, tree, false, dm_stripes,dm_stripes_total,task_p);
-            break;
-        case generalized:
-            unifrac_vawTT<SUCMP_NM::UnifracVawGeneralizedTask<double>,double>(          table, tree, true,  dm_stripes,dm_stripes_total,task_p);
-            break;
-        case unweighted_fp32:
-            unifrac_vawTT<SUCMP_NM::UnifracVawUnweightedTask<float >,float >(           table, tree, true,  dm_stripes,dm_stripes_total,task_p);
-            break;
-        case weighted_normalized_fp32:
-            unifrac_vawTT<SUCMP_NM::UnifracVawNormalizedWeightedTask<float >,float >(   table, tree, true,  dm_stripes,dm_stripes_total,task_p);
-            break;
-        case weighted_unnormalized_fp32:
-            unifrac_vawTT<SUCMP_NM::UnifracVawUnnormalizedWeightedTask<float >,float >( table, tree, false, dm_stripes,dm_stripes_total,task_p);
-            break;
-        case generalized_fp32:
-            unifrac_vawTT<SUCMP_NM::UnifracVawGeneralizedTask<float >,float >(          table, tree, true,  dm_stripes,dm_stripes_total,task_p);
-            break;
-        default:
-            fprintf(stderr, "Unknown unifrac task\n");
-            exit(1);
-            break;
-    }
-}
+                     const su::task_parameters* task_p)
+ */
 
 template<class TFloat>
 void su::set_proportions(TFloat* __restrict__ props,

--- a/sucpp/unifrac.cpp
+++ b/sucpp/unifrac.cpp
@@ -722,28 +722,28 @@ void su::unifrac(biom_interface &table,
                  const su::task_parameters* task_p) {
     switch(unifrac_method) {
         case unweighted:
-            unifracTT<UnifracUnweightedTask<double>,double>(           table, tree, true,  dm_stripes,dm_stripes_total,task_p);
+            unifracTT<SUCMP_NM::UnifracUnweightedTask<double>,double>(           table, tree, true,  dm_stripes,dm_stripes_total,task_p);
             break;
         case weighted_normalized:
-            unifracTT<UnifracNormalizedWeightedTask<double>,double>(   table, tree, true,  dm_stripes,dm_stripes_total,task_p);
+            unifracTT<SUCMP_NM::UnifracNormalizedWeightedTask<double>,double>(   table, tree, true,  dm_stripes,dm_stripes_total,task_p);
             break;
         case weighted_unnormalized:
-            unifracTT<UnifracUnnormalizedWeightedTask<double>,double>( table, tree, false, dm_stripes,dm_stripes_total,task_p);
+            unifracTT<SUCMP_NM::UnifracUnnormalizedWeightedTask<double>,double>( table, tree, false, dm_stripes,dm_stripes_total,task_p);
             break;
         case generalized:
-            unifracTT<UnifracGeneralizedTask<double>,double>(          table, tree, true,  dm_stripes,dm_stripes_total,task_p);
+            unifracTT<SUCMP_NM::UnifracGeneralizedTask<double>,double>(          table, tree, true,  dm_stripes,dm_stripes_total,task_p);
             break;
         case unweighted_fp32:
-            unifracTT<UnifracUnweightedTask<float >,float>(            table, tree, true,  dm_stripes,dm_stripes_total,task_p);
+            unifracTT<SUCMP_NM::UnifracUnweightedTask<float >,float>(            table, tree, true,  dm_stripes,dm_stripes_total,task_p);
             break;
         case weighted_normalized_fp32:
-            unifracTT<UnifracNormalizedWeightedTask<float >,float>(    table, tree, true,  dm_stripes,dm_stripes_total,task_p);
+            unifracTT<SUCMP_NM::UnifracNormalizedWeightedTask<float >,float>(    table, tree, true,  dm_stripes,dm_stripes_total,task_p);
             break;
         case weighted_unnormalized_fp32:
-            unifracTT<UnifracUnnormalizedWeightedTask<float >,float>(  table, tree, false, dm_stripes,dm_stripes_total,task_p);
+            unifracTT<SUCMP_NM::UnifracUnnormalizedWeightedTask<float >,float>(  table, tree, false, dm_stripes,dm_stripes_total,task_p);
             break;
         case generalized_fp32:
-            unifracTT<UnifracGeneralizedTask<float >,float>(           table, tree, true,  dm_stripes,dm_stripes_total,task_p);
+            unifracTT<SUCMP_NM::UnifracGeneralizedTask<float >,float>(           table, tree, true,  dm_stripes,dm_stripes_total,task_p);
             break;
         default:
             fprintf(stderr, "Unknown unifrac task\n");
@@ -886,28 +886,28 @@ void su::unifrac_vaw(biom_interface &table,
                      const su::task_parameters* task_p) {
     switch(unifrac_method) {
         case unweighted:
-            unifrac_vawTT<UnifracVawUnweightedTask<double>,double>(           table, tree, true,  dm_stripes,dm_stripes_total,task_p);
+            unifrac_vawTT<SUCMP_NM::UnifracVawUnweightedTask<double>,double>(           table, tree, true,  dm_stripes,dm_stripes_total,task_p);
             break;
         case weighted_normalized:
-            unifrac_vawTT<UnifracVawNormalizedWeightedTask<double>,double>(   table, tree, true,  dm_stripes,dm_stripes_total,task_p);
+            unifrac_vawTT<SUCMP_NM::UnifracVawNormalizedWeightedTask<double>,double>(   table, tree, true,  dm_stripes,dm_stripes_total,task_p);
             break;
         case weighted_unnormalized:
-            unifrac_vawTT<UnifracVawUnnormalizedWeightedTask<double>,double>( table, tree, false, dm_stripes,dm_stripes_total,task_p);
+            unifrac_vawTT<SUCMP_NM::UnifracVawUnnormalizedWeightedTask<double>,double>( table, tree, false, dm_stripes,dm_stripes_total,task_p);
             break;
         case generalized:
-            unifrac_vawTT<UnifracVawGeneralizedTask<double>,double>(          table, tree, true,  dm_stripes,dm_stripes_total,task_p);
+            unifrac_vawTT<SUCMP_NM::UnifracVawGeneralizedTask<double>,double>(          table, tree, true,  dm_stripes,dm_stripes_total,task_p);
             break;
         case unweighted_fp32:
-            unifrac_vawTT<UnifracVawUnweightedTask<float >,float >(           table, tree, true,  dm_stripes,dm_stripes_total,task_p);
+            unifrac_vawTT<SUCMP_NM::UnifracVawUnweightedTask<float >,float >(           table, tree, true,  dm_stripes,dm_stripes_total,task_p);
             break;
         case weighted_normalized_fp32:
-            unifrac_vawTT<UnifracVawNormalizedWeightedTask<float >,float >(   table, tree, true,  dm_stripes,dm_stripes_total,task_p);
+            unifrac_vawTT<SUCMP_NM::UnifracVawNormalizedWeightedTask<float >,float >(   table, tree, true,  dm_stripes,dm_stripes_total,task_p);
             break;
         case weighted_unnormalized_fp32:
-            unifrac_vawTT<UnifracVawUnnormalizedWeightedTask<float >,float >( table, tree, false, dm_stripes,dm_stripes_total,task_p);
+            unifrac_vawTT<SUCMP_NM::UnifracVawUnnormalizedWeightedTask<float >,float >( table, tree, false, dm_stripes,dm_stripes_total,task_p);
             break;
         case generalized_fp32:
-            unifrac_vawTT<UnifracVawGeneralizedTask<float >,float >(          table, tree, true,  dm_stripes,dm_stripes_total,task_p);
+            unifrac_vawTT<SUCMP_NM::UnifracVawGeneralizedTask<float >,float >(          table, tree, true,  dm_stripes,dm_stripes_total,task_p);
             break;
         default:
             fprintf(stderr, "Unknown unifrac task\n");

--- a/sucpp/unifrac.cpp
+++ b/sucpp/unifrac.cpp
@@ -517,11 +517,11 @@ void su::faith_pd(biom_interface &table,
 static int proc_use_acc = -1;
 
 inline bool use_acc() {
- if (proc_use_acc!=-10) return (proc_use_acc!=0);
+ if (proc_use_acc!=-1) return (proc_use_acc!=0);
  int has_nvidia_gpu_rc = access("/proc/driver/nvidia/gpus", F_OK);
 
  if (has_nvidia_gpu_rc != 0) {
-   printf("INFO: GPU not found, using CPU\n");
+   printf("INFO (unifrac): GPU not found, using CPU\n");
    proc_use_acc=0;
    return false;
  }
@@ -530,13 +530,13 @@ inline bool use_acc() {
    std::string env_s(env_p);
    if ((env_s=="NO") || (env_s=="N") || (env_s=="no") || (env_s=="n") ||
        (env_s=="NEVER") || (env_s=="never")) {
-     printf("INFO: Use of GPU explicitly disabled, using CPU\n");
+     printf("INFO (unifrac): Use of GPU explicitly disabled, using CPU\n");
      proc_use_acc=0;
      return false;
    }
  }
 
- printf("INFO: Using GPU\n");
+ printf("INFO (unifrac): Using GPU\n");
  proc_use_acc=1;
  return true;
 }

--- a/sucpp/unifrac.cpp
+++ b/sucpp/unifrac.cpp
@@ -453,38 +453,6 @@ void progressbar(float progress) {
     std::cout.flush();
 }
 
-template<class TFloat>
-uint64_t initialize_sample_countsTT(TFloat*& _counts, const su::task_parameters* task_p, const biom_interface &table) {
-    const unsigned int n_samples = task_p->n_samples;
-    const uint64_t  n_samples_r = ((n_samples + UNIFRAC_BLOCK-1)/UNIFRAC_BLOCK)*UNIFRAC_BLOCK; // round up
-    TFloat * counts = NULL;
-    int err = 0;
-    err = posix_memalign((void **)&counts, 4096, sizeof(TFloat) * n_samples_r);
-    if(counts == NULL || err != 0) {
-        fprintf(stderr, "Failed to allocate %zd bytes, err %d; [%s]:%d\n",
-                sizeof(TFloat) * n_samples_r, err, __FILE__, __LINE__);
-        exit(EXIT_FAILURE);
-    }
-    for(unsigned int i = 0; i < n_samples; i++) {
-        counts[i] = table.sample_counts[i];
-    }
-   // avoid NaNs
-   for(unsigned int i = n_samples; i < n_samples_r; i++) {
-       counts[i] = 0.0;
-   }
-
-   _counts=counts;
-
-   return n_samples_r;
-}
-
-uint64_t su::initialize_sample_counts(double*& _counts, const su::task_parameters* task_p, const biom_interface &table) {
-   return initialize_sample_countsTT(_counts, task_p, table);
-}
-uint64_t su::initialize_sample_counts(float*& _counts, const su::task_parameters* task_p, const biom_interface &table) {
-   return initialize_sample_countsTT(_counts, task_p, table);
-}
-
 void su::initialize_stripes(std::vector<double*> &dm_stripes,
                             std::vector<double*> &dm_stripes_total,
                             bool want_total,

--- a/sucpp/unifrac.hpp
+++ b/sucpp/unifrac.hpp
@@ -11,11 +11,11 @@
 #include <vector>
 #include <unordered_map>
 #include <thread>
-#include "unifrac_task.hpp"
 #include <pthread.h>
 
 #ifndef __UNIFRAC
 
+#include "task_parameters.hpp"
 #include "biom_interface.hpp"
 
     namespace su {

--- a/sucpp/unifrac.hpp
+++ b/sucpp/unifrac.hpp
@@ -1,3 +1,12 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2016-2021, UniFrac development team.
+ * All rights reserved.
+ *
+ * See LICENSE file for more details
+ */
+
 #include <stack>
 #include <vector>
 #include <unordered_map>
@@ -6,6 +15,9 @@
 #include <pthread.h>
 
 #ifndef __UNIFRAC
+
+#include "biom_interface.hpp"
+
     namespace su {
         enum Method {unweighted, weighted_normalized, weighted_unnormalized, generalized, unweighted_fp32, weighted_normalized_fp32, weighted_unnormalized_fp32, generalized_fp32};
 
@@ -23,17 +35,17 @@
                 TFloat* get(uint32_t i);
         };
 
-        void faith_pd(biom &table, BPTree &tree, double* result);
+        void faith_pd(biom_interface &table, BPTree &tree, double* result);
 
-        std::string test_table_ids_are_subset_of_tree(biom &table, BPTree &tree);
-        void unifrac(biom &table, 
+        std::string test_table_ids_are_subset_of_tree(biom_interface &table, BPTree &tree);
+        void unifrac(biom_interface &table, 
                      BPTree &tree, 
                      Method unifrac_method,
                      std::vector<double*> &dm_stripes,
                      std::vector<double*> &dm_stripes_total,
                      const task_parameters* task_p);
         
-        void unifrac_vaw(biom &table, 
+        void unifrac_vaw(biom_interface &table, 
                          BPTree &tree, 
                          Method unifrac_method,
                          std::vector<double*> &dm_stripes,
@@ -79,14 +91,14 @@
         template<class TFloat>
         void set_proportions(TFloat* __restrict__ props, 
                              const BPTree &tree, uint32_t node, 
-                             const biom &table, 
+                             const biom_interface &table, 
                              PropStack<TFloat> &ps,
                              bool normalize = true);
 
         template<class TFloat>
         void set_proportions_range(TFloat* __restrict__ props,
                                    const BPTree &tree, uint32_t node,
-                                   const biom &table,unsigned int start, unsigned int end,
+                                   const biom_interface &table,unsigned int start, unsigned int end,
                                    PropStack<TFloat> &ps,
                                    bool normalize = true);
 
@@ -117,7 +129,7 @@
         }
 
         // process the stripes described by tasks
-        void process_stripes(biom &table, 
+        void process_stripes(biom_interface &table, 
                              BPTree &tree_sheared, 
                              Method method,
                              bool variance_adjust,

--- a/sucpp/unifrac.hpp
+++ b/sucpp/unifrac.hpp
@@ -21,20 +21,6 @@
     namespace su {
         enum Method {unweighted, weighted_normalized, weighted_unnormalized, generalized, unweighted_fp32, weighted_normalized_fp32, weighted_unnormalized_fp32, generalized_fp32};
 
-        template<class TFloat> 
-        class PropStack {
-            private:
-                std::stack<TFloat*> prop_stack;
-                std::unordered_map<uint32_t, TFloat*> prop_map;
-                uint32_t defaultsize;
-            public:
-                PropStack(uint32_t vecsize);
-                virtual ~PropStack();
-                TFloat* pop(uint32_t i);
-                void push(uint32_t i);
-                TFloat* get(uint32_t i);
-        };
-
         void faith_pd(biom_interface &table, BPTree &tree, double* result);
 
         std::string test_table_ids_are_subset_of_tree(biom_interface &table, BPTree &tree);
@@ -87,22 +73,6 @@
         template<class TReal> void condensed_form_to_matrix_T(const double*  __restrict__ cf, const uint32_t n, TReal*  __restrict__ buf2d);
         void condensed_form_to_matrix(const double*  __restrict__ cf, const uint32_t n, double*  __restrict__ buf2d);
         void condensed_form_to_matrix_fp32(const double*  __restrict__ cf, const uint32_t n, float*  __restrict__ buf2d);
-
-        template<class TFloat>
-        void set_proportions(TFloat* __restrict__ props, 
-                             const BPTree &tree, uint32_t node, 
-                             const biom_interface &table, 
-                             PropStack<TFloat> &ps,
-                             bool normalize = true);
-
-        template<class TFloat>
-        void set_proportions_range(TFloat* __restrict__ props,
-                                   const BPTree &tree, uint32_t node,
-                                   const biom_interface &table,unsigned int start, unsigned int end,
-                                   PropStack<TFloat> &ps,
-                                   bool normalize = true);
-
-        std::vector<double*> make_strides(unsigned int n_samples);
 
         inline uint64_t comb_2(uint64_t N) {
             // based off of _comb_int_long

--- a/sucpp/unifrac.hpp
+++ b/sucpp/unifrac.hpp
@@ -29,7 +29,7 @@
                 uint32_t defaultsize;
             public:
                 PropStack(uint32_t vecsize);
-                ~PropStack();
+                virtual ~PropStack();
                 TFloat* pop(uint32_t i);
                 void push(uint32_t i);
                 TFloat* get(uint32_t i);

--- a/sucpp/unifrac_cmp.cpp
+++ b/sucpp/unifrac_cmp.cpp
@@ -1,0 +1,370 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2016-2021, UniFrac development team.
+ * All rights reserved.
+ *
+ * See LICENSE file for more details
+ */
+
+#include "tree.hpp"
+#include "biom_interface.hpp"
+#include "unifrac.hpp"
+#include <unordered_map>
+#include <cstdlib>
+#include <thread>
+#include <algorithm>
+
+#include "unifrac_internal.hpp"
+#include "unifrac_cmp.hpp"
+
+// embed in this file, to properly instantiate the templatized functions
+#include "unifrac_task.cpp"
+
+using namespace su;
+
+template<class TaskT, class TFloat>
+void unifracTT(const biom_interface &table,
+               const BPTree &tree,
+               const bool want_total,
+               std::vector<double*> &dm_stripes,
+               std::vector<double*> &dm_stripes_total,
+               const su::task_parameters* task_p) {
+    int err;
+    // no processor affinity whenusing openacc or openmp
+
+    if(table.n_samples != task_p->n_samples) {
+        fprintf(stderr, "Task and table n_samples not equal\n");
+        exit(EXIT_FAILURE);
+    }
+    const unsigned int n_samples = task_p->n_samples;
+    const uint64_t  n_samples_r = ((n_samples + UNIFRAC_BLOCK-1)/UNIFRAC_BLOCK)*UNIFRAC_BLOCK; // round up
+
+
+    PropStackMulti<TFloat> propstack_multi(table.n_samples);
+
+    const unsigned int max_emb =  TaskT::RECOMMENDED_MAX_EMBS;
+
+    initialize_stripes(std::ref(dm_stripes), std::ref(dm_stripes_total), want_total, task_p);
+
+    TaskT taskObj(std::ref(dm_stripes), std::ref(dm_stripes_total),max_emb,task_p);
+
+    TFloat *lengths = NULL;
+    err = posix_memalign((void **)&lengths, 4096, sizeof(TFloat) * max_emb);
+    if(err != 0) {
+        fprintf(stderr, "posix_memalign(%d) failed: %d\n", sizeof(TFloat) * max_emb,  err);
+        exit(EXIT_FAILURE);
+    }
+#pragma acc enter data create(lengths[:max_emb])
+
+        /*
+         * The values in the example vectors correspond to index positions of an
+         * element in the resulting distance matrix. So, in the example below,
+         * the following can be interpreted:
+         *
+         * [0 1 2]
+         * [1 2 3]
+         *
+         * As comparing the sample for row 0 against the sample for col 1, the
+         * sample for row 1 against the sample for col 2, the sample for row 2
+         * against the sample for col 3.
+         *
+         * In other words, we're computing stripes of a distance matrix. In the
+         * following example, we're computing over 6 samples requiring 3
+         * stripes.
+         *
+         * A; stripe == 0
+         * [0 1 2 3 4 5]
+         * [1 2 3 4 5 0]
+         *
+         * B; stripe == 1
+         * [0 1 2 3 4 5]
+         * [2 3 4 5 0 1]
+         *
+         * C; stripe == 2
+         * [0 1 2 3 4 5]
+         * [3 4 5 0 1 2]
+         *
+         * The stripes end up computing the following positions in the distance
+         * matrix.
+         *
+         * x A B C x x
+         * x x A B C x
+         * x x x A B C
+         * C x x x A B
+         * B C x x x A
+         * A B C x x x
+         *
+         * However, we store those stripes as vectors, ie
+         * [ A A A A A A ]
+         *
+         * We end up performing N / 2 redundant calculations on the last stripe
+         * (see C) but that is small over large N.
+         */
+
+    unsigned int k = 0; // index in tree
+    const unsigned int max_k = (tree.nparens / 2) - 1;
+
+    const unsigned int num_prop_chunks = propstack_multi.get_num_stacks();
+    while (k<max_k) {
+          const unsigned int k_start = k;
+          unsigned int filled_emb = 0;
+
+          // chunk the progress to maximize cache reuse
+#pragma omp parallel for 
+          for (unsigned int ck=0; ck<num_prop_chunks; ck++) {
+            PropStack<TFloat> &propstack = propstack_multi.get_prop_stack(ck);
+            const unsigned int tstart = propstack_multi.get_start(ck);
+            const unsigned int tend = propstack_multi.get_end(ck);
+            unsigned int my_filled_emb = 0;
+            unsigned int my_k=k_start;
+
+            while ((my_filled_emb<max_emb) && (my_k<max_k)) {
+              const uint32_t node = tree.postorderselect(my_k);
+              my_k++;
+
+              TFloat *node_proportions = propstack.pop(node);
+              set_proportions_range(node_proportions, tree, node, table, tstart, tend, propstack);
+
+              if(task_p->bypass_tips && tree.isleaf(node))
+                  continue;
+
+              if (ck==0) { // they all do the same thing, so enough for the first to update the global state
+                lengths[filled_emb] = tree.lengths[node];
+                filled_emb++;
+              }
+              taskObj.embed_proportions_range(node_proportions, tstart, tend, my_filled_emb);
+              my_filled_emb++;
+            }
+            if (ck==0) { // they all do the same thing, so enough for the first to update the global state
+              k=my_k;
+            }
+          }
+
+          taskObj.sync_embedded_proportions(filled_emb);
+#ifdef _OPENACC
+          // lengths may be still in use in async mode, wait
+#pragma acc wait
+#pragma acc update device(lengths[:filled_emb])
+#endif
+          taskObj._run(filled_emb,lengths);
+          filled_emb=0;
+
+          su::try_report(task_p, k, max_k);
+    }
+
+#pragma acc wait
+
+    if(want_total) {
+        const unsigned int start_idx = task_p->start;
+        const unsigned int stop_idx = task_p->stop;
+
+        TFloat * const dm_stripes_buf = taskObj.dm_stripes.buf;
+        const TFloat * const dm_stripes_total_buf = taskObj.dm_stripes_total.buf;
+
+#pragma acc parallel loop collapse(2) present(dm_stripes_buf,dm_stripes_total_buf)
+        for(unsigned int i = start_idx; i < stop_idx; i++)
+            for(unsigned int j = 0; j < n_samples; j++) {
+                unsigned int idx = (i-start_idx)*n_samples_r+j;
+                dm_stripes_buf[idx]=dm_stripes_buf[idx]/dm_stripes_total_buf[idx];
+                // taskObj.dm_stripes[i][j] = taskObj.dm_stripes[i][j] / taskObj.dm_stripes_total[i][j];
+            }
+        
+    }
+
+#pragma acc exit data delete(lengths[:max_emb])
+    free(lengths);
+}
+
+void su::unifrac(biom_interface &table,
+                 BPTree &tree,
+                 Method unifrac_method,
+                 std::vector<double*> &dm_stripes,
+                 std::vector<double*> &dm_stripes_total,
+                 const su::task_parameters* task_p) {
+    switch(unifrac_method) {
+        case unweighted:
+            unifracTT<SUCMP_NM::UnifracUnweightedTask<double>,double>(           table, tree, true,  dm_stripes,dm_stripes_total,task_p);
+            break;
+        case weighted_normalized:
+            unifracTT<SUCMP_NM::UnifracNormalizedWeightedTask<double>,double>(   table, tree, true,  dm_stripes,dm_stripes_total,task_p);
+            break;
+        case weighted_unnormalized:
+            unifracTT<SUCMP_NM::UnifracUnnormalizedWeightedTask<double>,double>( table, tree, false, dm_stripes,dm_stripes_total,task_p);
+            break;
+        case generalized:
+            unifracTT<SUCMP_NM::UnifracGeneralizedTask<double>,double>(          table, tree, true,  dm_stripes,dm_stripes_total,task_p);
+            break;
+        case unweighted_fp32:
+            unifracTT<SUCMP_NM::UnifracUnweightedTask<float >,float>(            table, tree, true,  dm_stripes,dm_stripes_total,task_p);
+            break;
+        case weighted_normalized_fp32:
+            unifracTT<SUCMP_NM::UnifracNormalizedWeightedTask<float >,float>(    table, tree, true,  dm_stripes,dm_stripes_total,task_p);
+            break;
+        case weighted_unnormalized_fp32:
+            unifracTT<SUCMP_NM::UnifracUnnormalizedWeightedTask<float >,float>(  table, tree, false, dm_stripes,dm_stripes_total,task_p);
+            break;
+        case generalized_fp32:
+            unifracTT<SUCMP_NM::UnifracGeneralizedTask<float >,float>(           table, tree, true,  dm_stripes,dm_stripes_total,task_p);
+            break;
+        default:
+            fprintf(stderr, "Unknown unifrac task\n");
+            exit(1);
+            break;
+    }
+}
+
+
+template<class TaskT, class TFloat>
+void unifrac_vawTT(const biom_interface &table,
+                   const BPTree &tree,
+                          const bool want_total,
+                          std::vector<double*> &dm_stripes,
+                          std::vector<double*> &dm_stripes_total,
+                          const su::task_parameters* task_p) {
+    int err;
+    // no processor affinity whenusing openacc or openmp
+
+    if(table.n_samples != task_p->n_samples) {
+        fprintf(stderr, "Task and table n_samples not equal\n");
+        exit(EXIT_FAILURE);
+    }
+    const unsigned int n_samples = task_p->n_samples;
+    const uint64_t  n_samples_r = ((n_samples + UNIFRAC_BLOCK-1)/UNIFRAC_BLOCK)*UNIFRAC_BLOCK; // round up
+
+    PropStackMulti<TFloat> propstack_multi(table.n_samples);
+    PropStackMulti<TFloat> countstack_multi(table.n_samples);
+
+    const unsigned int max_emb = TaskT::RECOMMENDED_MAX_EMBS;
+
+    TFloat *sample_total_counts;
+
+    su::initialize_sample_counts(sample_total_counts, task_p, table);
+#pragma acc enter data copyin(sample_total_counts[:n_samples_r])
+    initialize_stripes(std::ref(dm_stripes), std::ref(dm_stripes_total), want_total, task_p);
+
+    TaskT taskObj(std::ref(dm_stripes), std::ref(dm_stripes_total), sample_total_counts, max_emb, task_p);
+
+    TFloat *lengths = NULL;
+    err = posix_memalign((void **)&lengths, 4096, sizeof(TFloat) * max_emb);
+    if(err != 0) {
+        fprintf(stderr, "posix_memalign(%d) failed: %d\n", sizeof(TFloat) * max_emb, err);
+        exit(EXIT_FAILURE);
+    }
+#pragma acc enter data create(lengths[:max_emb])
+
+    unsigned int k = 0; // index in tree
+    const unsigned int max_k = (tree.nparens / 2) - 1;
+
+    const unsigned int num_prop_chunks = propstack_multi.get_num_stacks();
+    while (k<max_k) {
+          const unsigned int k_start = k;
+          unsigned int filled_emb = 0;
+
+          // chunk the progress to maximize cache reuse
+#pragma omp parallel for 
+          for (unsigned int ck=0; ck<num_prop_chunks; ck++) {
+            PropStack<TFloat> &propstack = propstack_multi.get_prop_stack(ck);
+            PropStack<TFloat> &countstack = countstack_multi.get_prop_stack(ck);
+            const unsigned int tstart = propstack_multi.get_start(ck);
+            const unsigned int tend = propstack_multi.get_end(ck);
+            unsigned int my_filled_emb = 0;
+            unsigned int my_k=k_start;
+
+            while ((my_filled_emb<max_emb) && (my_k<max_k)) {
+              const uint32_t node = tree.postorderselect(my_k);
+              my_k++;
+
+              TFloat *node_proportions = propstack.pop(node);
+              TFloat *node_counts = countstack.pop(node);
+
+              set_proportions_range(node_proportions, tree, node, table, tstart, tend, propstack);
+              set_proportions_range(node_counts, tree, node, table, tstart, tend, countstack, false);
+
+              if(task_p->bypass_tips && tree.isleaf(node))
+                  continue;
+
+              if (ck==0) { // they all do the same thing, so enough for the first to update the global state
+                lengths[filled_emb] = tree.lengths[node];
+                filled_emb++;
+              }
+              taskObj.embed_range(node_proportions, node_counts, tstart, tend, my_filled_emb);
+              my_filled_emb++;
+            }
+            if (ck==0) { // they all do the same thing, so enough for the first to update the global state
+              k=my_k;
+            }
+          }
+
+#pragma acc wait
+#pragma acc update device(lengths[:filled_emb])
+          taskObj.sync_embedded(filled_emb);
+          taskObj._run(filled_emb,lengths);
+          filled_emb = 0;
+
+          su::try_report(task_p, k, max_k);
+    }
+
+#pragma acc wait
+    if(want_total) {
+        const unsigned int start_idx = task_p->start;
+        const unsigned int stop_idx = task_p->stop;
+
+        TFloat * const dm_stripes_buf = taskObj.dm_stripes.buf;
+        const TFloat * const dm_stripes_total_buf = taskObj.dm_stripes_total.buf;
+
+#pragma acc parallel loop collapse(2) present(dm_stripes_buf,dm_stripes_total_buf)
+        for(unsigned int i = start_idx; i < stop_idx; i++)
+            for(unsigned int j = 0; j < n_samples; j++) {
+                unsigned int idx = (i-start_idx)*n_samples_r+j;
+                dm_stripes_buf[idx]=dm_stripes_buf[idx]/dm_stripes_total_buf[idx];
+                // taskObj.dm_stripes[i][j] = taskObj.dm_stripes[i][j] / taskObj.dm_stripes_total[i][j];
+            }
+
+    }
+
+
+#pragma acc exit data delete(lengths[:max_emb])
+#pragma acc exit data delete(sample_total_counts[:n_samples_r])
+    free(lengths);
+    free(sample_total_counts);
+}
+
+void su::unifrac_vaw(biom_interface &table,
+                     BPTree &tree,
+                     Method unifrac_method,
+                     std::vector<double*> &dm_stripes,
+                     std::vector<double*> &dm_stripes_total,
+                     const su::task_parameters* task_p) {
+    switch(unifrac_method) {
+        case unweighted:
+            unifrac_vawTT<SUCMP_NM::UnifracVawUnweightedTask<double>,double>(           table, tree, true,  dm_stripes,dm_stripes_total,task_p);
+            break;
+        case weighted_normalized:
+            unifrac_vawTT<SUCMP_NM::UnifracVawNormalizedWeightedTask<double>,double>(   table, tree, true,  dm_stripes,dm_stripes_total,task_p);
+            break;
+        case weighted_unnormalized:
+            unifrac_vawTT<SUCMP_NM::UnifracVawUnnormalizedWeightedTask<double>,double>( table, tree, false, dm_stripes,dm_stripes_total,task_p);
+            break;
+        case generalized:
+            unifrac_vawTT<SUCMP_NM::UnifracVawGeneralizedTask<double>,double>(          table, tree, true,  dm_stripes,dm_stripes_total,task_p);
+            break;
+        case unweighted_fp32:
+            unifrac_vawTT<SUCMP_NM::UnifracVawUnweightedTask<float >,float >(           table, tree, true,  dm_stripes,dm_stripes_total,task_p);
+            break;
+        case weighted_normalized_fp32:
+            unifrac_vawTT<SUCMP_NM::UnifracVawNormalizedWeightedTask<float >,float >(   table, tree, true,  dm_stripes,dm_stripes_total,task_p);
+            break;
+        case weighted_unnormalized_fp32:
+            unifrac_vawTT<SUCMP_NM::UnifracVawUnnormalizedWeightedTask<float >,float >( table, tree, false, dm_stripes,dm_stripes_total,task_p);
+            break;
+        case generalized_fp32:
+            unifrac_vawTT<SUCMP_NM::UnifracVawGeneralizedTask<float >,float >(          table, tree, true,  dm_stripes,dm_stripes_total,task_p);
+            break;
+        default:
+            fprintf(stderr, "Unknown unifrac task\n");
+            exit(1);
+            break;
+    }
+}
+

--- a/sucpp/unifrac_cmp.cpp
+++ b/sucpp/unifrac_cmp.cpp
@@ -9,7 +9,6 @@
 
 #include "tree.hpp"
 #include "biom_interface.hpp"
-#include "unifrac.hpp"
 #include <unordered_map>
 #include <cstdlib>
 #include <thread>

--- a/sucpp/unifrac_cmp.hpp
+++ b/sucpp/unifrac_cmp.hpp
@@ -1,0 +1,1 @@
+/* Empty for now */

--- a/sucpp/unifrac_cmp.hpp
+++ b/sucpp/unifrac_cmp.hpp
@@ -1,1 +1,39 @@
-/* Empty for now */
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2016-2021, UniFrac development team.
+ * All rights reserved.
+ *
+ * See LICENSE file for more details
+ */
+
+#ifdef SUCMP_NM
+
+/* Note: Allow multiple definitions of this header, using different SUCMP_NM */
+
+#include "task_parameters.hpp"
+#include "tree.hpp"
+#include "biom_interface.hpp"
+
+#include "unifrac.hpp"
+#include "unifrac_internal.hpp"
+
+namespace SUCMP_NM {
+
+  void unifrac(const su::biom_interface &table,
+               const su::BPTree &tree,
+               su::Method unifrac_method,
+               std::vector<double*> &dm_stripes,
+               std::vector<double*> &dm_stripes_total,
+               const su::task_parameters* task_p);
+
+  void unifrac_vaw(const su::biom_interface &table,
+                   const su::BPTree &tree,
+                   su::Method unifrac_method,
+                   std::vector<double*> &dm_stripes,
+                   std::vector<double*> &dm_stripes_total,
+                   const su::task_parameters* task_p);
+
+}
+
+#endif /* SUCMP_NM */

--- a/sucpp/unifrac_cmp.hpp
+++ b/sucpp/unifrac_cmp.hpp
@@ -15,7 +15,6 @@
 #include "tree.hpp"
 #include "biom_interface.hpp"
 
-#include "unifrac.hpp"
 #include "unifrac_internal.hpp"
 
 namespace SUCMP_NM {

--- a/sucpp/unifrac_internal.cpp
+++ b/sucpp/unifrac_internal.cpp
@@ -1,0 +1,290 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2016-2021, UniFrac development team.
+ * All rights reserved.
+ *
+ * See LICENSE file for more details
+ */
+
+#include "tree.hpp"
+#include "biom_interface.hpp"
+#include "affinity.hpp"
+#include <cstdlib>
+#include <thread>
+#include <signal.h>
+#include <stdarg.h>
+#include <algorithm>
+#include <pthread.h>
+#include <unistd.h>
+
+#include "unifrac_internal.hpp"
+
+static pthread_mutex_t printf_mutex;
+static bool* report_status;
+
+static int sync_printf(const char *format, ...) {
+    // https://stackoverflow.com/a/23587285/19741
+    va_list args;
+    va_start(args, format);
+
+    pthread_mutex_lock(&printf_mutex);
+    vprintf(format, args);
+    pthread_mutex_unlock(&printf_mutex);
+
+    va_end(args);
+}
+
+static void sig_handler(int signo) {
+    // http://www.thegeekstuff.com/2012/03/catch-signals-sample-c-code
+    if (signo == SIGUSR1) {
+        if(report_status == NULL)
+            fprintf(stderr, "Cannot report status.\n");
+        else {
+            for(int i = 0; i < CPU_SETSIZE; i++) {
+                report_status[i] = true;
+            }
+        }
+    }
+}
+
+using namespace su;
+
+void su::try_report(const su::task_parameters* task_p, unsigned int k, unsigned int max_k) {
+  if(__builtin_expect(report_status[task_p->tid], false)) {
+    sync_printf("tid:%u\tstart:%u\tstop:%u\tk:%u\ttotal:%u\n", task_p->tid, task_p->start, task_p->stop, k, max_k);
+    report_status[task_p->tid] = false;
+  }
+}
+
+void su::register_report_status() {
+    // register a signal handler so we can ask the master thread for its
+    // progress
+    if (signal(SIGUSR1, sig_handler) == SIG_ERR)
+        fprintf(stderr, "Can't catch SIGUSR1\n");
+
+    report_status = (bool*)calloc(sizeof(bool), CPU_SETSIZE);
+    pthread_mutex_init(&printf_mutex, NULL);
+}
+
+void su::remove_report_status() {
+    if(report_status != NULL) {
+        pthread_mutex_destroy(&printf_mutex);
+        free(report_status);
+        report_status = NULL;
+    }
+}
+
+template<class TFloat>
+PropStack<TFloat>::PropStack(uint32_t vecsize) 
+: prop_stack()
+, prop_map()
+, defaultsize(vecsize)
+{
+    prop_map.reserve(1000);
+}
+
+template<class TFloat>
+PropStack<TFloat>::~PropStack() {
+    // drain stack
+    for(unsigned int i = 0; i < prop_stack.size(); i++) {
+        TFloat *vec = prop_stack.top();
+        prop_stack.pop();
+        free(vec);
+    }
+
+    // drain the map
+    for(auto it = prop_map.begin(); it != prop_map.end(); it++) {
+        TFloat *vec = it->second;
+        free(vec);
+    }
+    prop_map.clear();
+}
+
+template<class TFloat>
+TFloat* PropStack<TFloat>::get(uint32_t i) {
+    return prop_map[i];
+}
+
+template<class TFloat>
+void PropStack<TFloat>::push(uint32_t node) {
+    TFloat* vec = prop_map[node];
+    prop_map.erase(node);
+    prop_stack.push(vec);
+}
+
+template<class TFloat>
+TFloat* PropStack<TFloat>::pop(uint32_t node) {
+    /*
+     * if we don't have any available vectors, create one
+     * add it to our record of known vectors so we can track our mallocs
+     */
+    TFloat *vec;
+    int err = 0;
+    if(prop_stack.empty()) {
+        err = posix_memalign((void **)&vec, 32, sizeof(TFloat) * defaultsize);
+        if(vec == NULL || err != 0) {
+            fprintf(stderr, "Failed to allocate %zd bytes, err %d; [%s]:%d\n",
+                    sizeof(TFloat) * defaultsize, err, __FILE__, __LINE__);
+            exit(EXIT_FAILURE);
+        }
+    }
+    else {
+        vec = prop_stack.top();
+        prop_stack.pop();
+    }
+
+    prop_map[node] = vec;
+    return vec;
+}
+
+// make sure they get instantiated
+template class su::PropStack<float>;
+template class su::PropStack<double>;
+
+
+void su::initialize_stripes(std::vector<double*> &dm_stripes,
+                            std::vector<double*> &dm_stripes_total,
+                            bool want_total,
+                            const su::task_parameters* task_p) {
+    int err = 0;
+    for(unsigned int i = task_p->start; i < task_p->stop; i++){
+        err = posix_memalign((void **)&dm_stripes[i], 4096, sizeof(double) * task_p->n_samples);
+        if(dm_stripes[i] == NULL || err != 0) {
+            fprintf(stderr, "Failed to allocate %zd bytes, err %d; [%s]:%d\n",
+                    sizeof(double) * task_p->n_samples, err, __FILE__, __LINE__);
+            exit(EXIT_FAILURE);
+        }
+        for(unsigned int j = 0; j < task_p->n_samples; j++)
+            dm_stripes[i][j] = 0.;
+
+        if(want_total) {
+            err = posix_memalign((void **)&dm_stripes_total[i], 4096, sizeof(double) * task_p->n_samples);
+            if(dm_stripes_total[i] == NULL || err != 0) {
+                fprintf(stderr, "Failed to allocate %zd bytes err %d; [%s]:%d\n",
+                        sizeof(double) * task_p->n_samples, err, __FILE__, __LINE__);
+                exit(EXIT_FAILURE);
+            }
+            for(unsigned int j = 0; j < task_p->n_samples; j++)
+                dm_stripes_total[i][j] = 0.;
+        }
+    }
+}
+
+template<class TFloat>
+void su::set_proportions(TFloat* __restrict__ props,
+                         const BPTree &tree,
+                         uint32_t node,
+                         const biom_interface &table,
+                         PropStack<TFloat> &ps,
+                         bool normalize) {
+    if(tree.isleaf(node)) {
+       table.get_obs_data(tree.names[node], props);
+       if (normalize) {
+#pragma omp parallel for schedule(static)
+        for(unsigned int i = 0; i < table.n_samples; i++) {
+           props[i] /= table.sample_counts[i];
+        }
+       }
+
+    } else {
+        unsigned int current = tree.leftchild(node);
+        unsigned int right = tree.rightchild(node);
+
+#pragma omp parallel for schedule(static)
+        for(unsigned int i = 0; i < table.n_samples; i++)
+            props[i] = 0;
+
+        while(current <= right && current != 0) {
+            TFloat * __restrict__ vec = ps.get(current);  // pull from prop map
+            ps.push(current);  // remove from prop map, place back on stack
+
+#pragma omp parallel for schedule(static)
+            for(unsigned int i = 0; i < table.n_samples; i++)
+                props[i] = props[i] + vec[i];
+
+            current = tree.rightsibling(current);
+        }
+    }
+}
+
+// make sure they get instantiated
+template void su::set_proportions(float* __restrict__ props,
+                                  const BPTree &tree,
+                                  uint32_t node,
+                                  const biom_interface &table,
+                                  PropStack<float> &ps,
+                                  bool normalize);
+template void su::set_proportions(double* __restrict__ props,
+                                  const BPTree &tree,
+                                  uint32_t node,
+                                  const biom_interface &table,
+                                  PropStack<double> &ps,
+                                  bool normalize);
+
+template<class TFloat>
+void su::set_proportions_range(TFloat* __restrict__ props,
+                               const BPTree &tree,
+                               uint32_t node,
+                               const biom_interface &table, 
+                               unsigned int start, unsigned int end,
+                               PropStack<TFloat> &ps,
+                               bool normalize) {
+    const unsigned int els = end-start;
+    if(tree.isleaf(node)) {
+       table.get_obs_data_range(tree.names[node], start, end, normalize, props);
+    } else {
+        const unsigned int right = tree.rightchild(node);
+        unsigned int current = tree.leftchild(node);
+
+        for(unsigned int i = 0; i < els; i++)
+            props[i] = 0;
+
+        while(current <= right && current != 0) {
+            const TFloat * __restrict__ vec = ps.get(current);  // pull from prop map
+            ps.push(current);  // remove from prop map, place back on stack
+
+            for(unsigned int i = 0; i < els; i++)
+                props[i] += vec[i];
+
+            current = tree.rightsibling(current);
+        }
+    }
+}
+
+// make sure they get instantiated
+template void su::set_proportions_range(float* __restrict__ props,
+                                        const BPTree &tree,
+                                        uint32_t node,
+                                        const biom_interface &table,
+                                        unsigned int start, unsigned int end,
+                                        PropStack<float> &ps,
+                                        bool normalize);
+template void su::set_proportions_range(double* __restrict__ props,
+                                        const BPTree &tree,
+                                        uint32_t node,
+                                        const biom_interface &table,
+                                        unsigned int start, unsigned int end,
+                                        PropStack<double> &ps,
+                                        bool normalize);
+
+std::vector<double*> su::make_strides(unsigned int n_samples) {
+    uint32_t n_rotations = (n_samples + 1) / 2;
+    std::vector<double*> dm_stripes(n_rotations);
+
+    int err = 0;
+    for(unsigned int i = 0; i < n_rotations; i++) {
+        double* tmp;
+        err = posix_memalign((void **)&tmp, 32, sizeof(double) * n_samples);
+        if(tmp == NULL || err != 0) {
+            fprintf(stderr, "Failed to allocate %zd bytes, err %d; [%s]:%d\n",
+                    sizeof(double) * n_samples, err,  __FILE__, __LINE__);
+            exit(EXIT_FAILURE);
+        }
+        for(unsigned int j = 0; j < n_samples; j++)
+            tmp[j] = 0.0;
+        dm_stripes[i] = tmp;
+    }
+    return dm_stripes;
+}
+

--- a/sucpp/unifrac_internal.hpp
+++ b/sucpp/unifrac_internal.hpp
@@ -57,9 +57,6 @@ namespace su {
                          bool want_total,
                          const su::task_parameters* task_p);
 
- uint64_t initialize_sample_counts(double*& _counts, const su::task_parameters* task_p, const biom_interface &table);
- uint64_t initialize_sample_counts(float*& _counts, const su::task_parameters* task_p, const biom_interface &table);
-
 }
 
 #endif

--- a/sucpp/unifrac_internal.hpp
+++ b/sucpp/unifrac_internal.hpp
@@ -1,0 +1,64 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2016-2021, UniFrac development team.
+ * All rights reserved.
+ *
+ * See LICENSE file for more details
+ */
+
+#ifndef __UNIFRAC_INTERNAL
+#define __UNIFRAC_INTERNAL 1
+
+#include <vector>
+#include "biom_interface.hpp"
+#include "task_parameters.hpp"
+
+namespace su {
+ // helper reporting function
+ void try_report(const su::task_parameters* task_p, unsigned int k, unsigned int max_k);
+
+
+ // Helper class with default constructor
+ // The default is small enough to fit in L1 cache
+ template<class TFloat>
+ class PropStackFixed : public PropStack<TFloat> {
+  public:
+    static const uint32_t DEF_VEC_SIZE = 1024*sizeof(double)/sizeof(TFloat);
+
+    PropStackFixed() : PropStack<TFloat>(DEF_VEC_SIZE) {}
+ };
+
+ // Helper class that splits a large vec_size into several smaller chunks of def_size
+ template<class TFloat>
+ class PropStackMulti {
+  protected:
+    const uint32_t vecsize;
+    std::vector<PropStackFixed<TFloat> > multi;
+
+  public:
+    PropStackMulti(uint32_t _vecsize)
+    : vecsize(_vecsize)
+    , multi((vecsize + (PropStackFixed<TFloat>::DEF_VEC_SIZE-1))/PropStackFixed<TFloat>::DEF_VEC_SIZE) // round up
+    {}
+    ~PropStackMulti() {}
+
+    uint32_t get_num_stacks() const {return (vecsize + (PropStackFixed<TFloat>::DEF_VEC_SIZE-1))/PropStackFixed<TFloat>::DEF_VEC_SIZE;}
+
+    uint32_t get_start(uint32_t idx) const {return idx*PropStackFixed<TFloat>::DEF_VEC_SIZE;}
+    uint32_t get_end(uint32_t idx) const   {return std::min((idx+1)*PropStackFixed<TFloat>::DEF_VEC_SIZE, vecsize);}
+
+    PropStackFixed<TFloat> &get_prop_stack(uint32_t idx) {return multi[idx];}
+ };
+
+ void initialize_stripes(std::vector<double*> &dm_stripes,
+                         std::vector<double*> &dm_stripes_total,
+                         bool want_total,
+                         const su::task_parameters* task_p);
+
+ uint64_t initialize_sample_counts(double*& _counts, const su::task_parameters* task_p, const biom_interface &table);
+ uint64_t initialize_sample_counts(float*& _counts, const su::task_parameters* task_p, const biom_interface &table);
+
+}
+
+#endif

--- a/sucpp/unifrac_internal.hpp
+++ b/sucpp/unifrac_internal.hpp
@@ -11,14 +11,31 @@
 #define __UNIFRAC_INTERNAL 1
 
 #include <vector>
+#include <stack>
+#include <unordered_map>
 #include "biom_interface.hpp"
 #include "task_parameters.hpp"
 #include "unifrac.hpp"
 
 namespace su {
- // helper reporting function
+ // helper reporting functions
+ void register_report_status();
+ void remove_report_status();
  void try_report(const su::task_parameters* task_p, unsigned int k, unsigned int max_k);
 
+ template<class TFloat>
+ class PropStack {
+   private:
+     std::stack<TFloat*> prop_stack;
+     std::unordered_map<uint32_t, TFloat*> prop_map;
+     uint32_t defaultsize;
+   public:
+     PropStack(uint32_t vecsize);
+     virtual ~PropStack();
+     TFloat* pop(uint32_t i);
+     void push(uint32_t i);
+     TFloat* get(uint32_t i);
+ };
 
  // Helper class with default constructor
  // The default is small enough to fit in L1 cache
@@ -52,10 +69,27 @@ namespace su {
     PropStackFixed<TFloat> &get_prop_stack(uint32_t idx) {return multi[idx];}
  };
 
+ template<class TFloat>
+ void set_proportions(TFloat* __restrict__ props,
+                      const BPTree &tree, uint32_t node,
+                      const biom_interface &table,
+                      PropStack<TFloat> &ps,
+                      bool normalize = true);
+
+ template<class TFloat>
+ void set_proportions_range(TFloat* __restrict__ props,
+                            const BPTree &tree, uint32_t node,
+                            const biom_interface &table,unsigned int start, unsigned int end,
+                            PropStack<TFloat> &ps,
+                            bool normalize = true);
+
+
  void initialize_stripes(std::vector<double*> &dm_stripes,
                          std::vector<double*> &dm_stripes_total,
                          bool want_total,
                          const su::task_parameters* task_p);
+
+  std::vector<double*> make_strides(unsigned int n_samples);
 
 }
 

--- a/sucpp/unifrac_internal.hpp
+++ b/sucpp/unifrac_internal.hpp
@@ -13,6 +13,7 @@
 #include <vector>
 #include "biom_interface.hpp"
 #include "task_parameters.hpp"
+#include "unifrac.hpp"
 
 namespace su {
  // helper reporting function

--- a/sucpp/unifrac_task.cpp
+++ b/sucpp/unifrac_task.cpp
@@ -6,7 +6,7 @@
 
 
 template<class TFloat>
-void su::UnifracUnnormalizedWeightedTask<TFloat>::_run(unsigned int filled_embs, const TFloat * __restrict__ lengths) {
+void SUCMP_NM::UnifracUnnormalizedWeightedTask<TFloat>::_run(unsigned int filled_embs, const TFloat * __restrict__ lengths) {
     const unsigned int start_idx = this->task_p->start;
     const unsigned int stop_idx = this->task_p->stop;
     const unsigned int n_samples = this->task_p->n_samples;
@@ -19,7 +19,7 @@ void su::UnifracUnnormalizedWeightedTask<TFloat>::_run(unsigned int filled_embs,
     bool * const __restrict__ zcheck = this->zcheck;
     TFloat * const __restrict__ sums = this->sums;
 
-    const unsigned int step_size = su::UnifracUnnormalizedWeightedTask<TFloat>::step_size;
+    const unsigned int step_size = SUCMP_NM::UnifracUnnormalizedWeightedTask<TFloat>::step_size;
     const unsigned int sample_steps = (n_samples+(step_size-1))/step_size; // round up
 
     // check for zero values and pre-compute single column sums
@@ -48,7 +48,7 @@ void su::UnifracUnnormalizedWeightedTask<TFloat>::_run(unsigned int filled_embs,
 
     // now do the real compute
 #ifdef _OPENACC
-    const unsigned int acc_vector_size = su::UnifracUnnormalizedWeightedTask<TFloat>::acc_vector_size;
+    const unsigned int acc_vector_size = SUCMP_NM::UnifracUnnormalizedWeightedTask<TFloat>::acc_vector_size;
 #pragma acc parallel loop collapse(3) vector_length(acc_vector_size) present(embedded_proportions,dm_stripes_buf,lengths,zcheck,sums) async
 #else
     // use dynamic scheduling due to non-homogeneity in the loop
@@ -120,7 +120,7 @@ void su::UnifracUnnormalizedWeightedTask<TFloat>::_run(unsigned int filled_embs,
 }
 
 template<class TFloat>
-void su::UnifracVawUnnormalizedWeightedTask<TFloat>::_run(unsigned int filled_embs, const TFloat * __restrict__ lengths) {
+void SUCMP_NM::UnifracVawUnnormalizedWeightedTask<TFloat>::_run(unsigned int filled_embs, const TFloat * __restrict__ lengths) {
     const unsigned int start_idx = this->task_p->start;
     const unsigned int stop_idx = this->task_p->stop;
     const unsigned int n_samples = this->task_p->n_samples;
@@ -132,12 +132,12 @@ void su::UnifracVawUnnormalizedWeightedTask<TFloat>::_run(unsigned int filled_em
     const TFloat * const __restrict__ sample_total_counts = this->sample_total_counts;
     TFloat * const __restrict__ dm_stripes_buf = this->dm_stripes.buf;
 
-    const unsigned int step_size = su::UnifracVawUnnormalizedWeightedTask<TFloat>::step_size;
+    const unsigned int step_size = SUCMP_NM::UnifracVawUnnormalizedWeightedTask<TFloat>::step_size;
     const unsigned int sample_steps = (n_samples+(step_size-1))/step_size; // round up
 
     // point of thread
 #ifdef _OPENACC
-    const unsigned int acc_vector_size = su::UnifracVawUnnormalizedWeightedTask<TFloat>::acc_vector_size;
+    const unsigned int acc_vector_size = SUCMP_NM::UnifracVawUnnormalizedWeightedTask<TFloat>::acc_vector_size;
 #pragma acc parallel loop collapse(3) vector_length(acc_vector_size) present(embedded_proportions,embedded_counts,sample_total_counts,dm_stripes_buf,lengths) async
 #else
 #pragma omp parallel for default(shared) schedule(dynamic,1)
@@ -188,7 +188,7 @@ void su::UnifracVawUnnormalizedWeightedTask<TFloat>::_run(unsigned int filled_em
 }
 
 template<class TFloat>
-void su::UnifracNormalizedWeightedTask<TFloat>::_run(unsigned int filled_embs, const TFloat * __restrict__ lengths) {
+void SUCMP_NM::UnifracNormalizedWeightedTask<TFloat>::_run(unsigned int filled_embs, const TFloat * __restrict__ lengths) {
     const unsigned int start_idx = this->task_p->start;
     const unsigned int stop_idx = this->task_p->stop;
     const unsigned int n_samples = this->task_p->n_samples;
@@ -202,7 +202,7 @@ void su::UnifracNormalizedWeightedTask<TFloat>::_run(unsigned int filled_embs, c
     bool * const __restrict__ zcheck = this->zcheck;
     TFloat * const __restrict__ sums = this->sums;
 
-    const unsigned int step_size = su::UnifracNormalizedWeightedTask<TFloat>::step_size;
+    const unsigned int step_size = SUCMP_NM::UnifracNormalizedWeightedTask<TFloat>::step_size;
     const unsigned int sample_steps = (n_samples+(step_size-1))/step_size; // round up
 
     // check for zero values and pre-compute single column sums
@@ -230,7 +230,7 @@ void su::UnifracNormalizedWeightedTask<TFloat>::_run(unsigned int filled_embs, c
 
     // point of thread
 #ifdef _OPENACC
-    const unsigned int acc_vector_size = su::UnifracNormalizedWeightedTask<TFloat>::acc_vector_size;
+    const unsigned int acc_vector_size = SUCMP_NM::UnifracNormalizedWeightedTask<TFloat>::acc_vector_size;
 #pragma acc parallel loop collapse(3) vector_length(acc_vector_size) present(embedded_proportions,dm_stripes_buf,dm_stripes_total_buf,lengths,zcheck,sums) async
 #else
     // use dynamic scheduling due to non-homogeneity in the loop
@@ -308,7 +308,7 @@ void su::UnifracNormalizedWeightedTask<TFloat>::_run(unsigned int filled_embs, c
 }
 
 template<class TFloat>
-void su::UnifracVawNormalizedWeightedTask<TFloat>::_run(unsigned int filled_embs, const TFloat * __restrict__ lengths) {
+void SUCMP_NM::UnifracVawNormalizedWeightedTask<TFloat>::_run(unsigned int filled_embs, const TFloat * __restrict__ lengths) {
     const unsigned int start_idx = this->task_p->start;
     const unsigned int stop_idx = this->task_p->stop;
     const unsigned int n_samples = this->task_p->n_samples;
@@ -321,12 +321,12 @@ void su::UnifracVawNormalizedWeightedTask<TFloat>::_run(unsigned int filled_embs
     TFloat * const __restrict__ dm_stripes_buf = this->dm_stripes.buf;
     TFloat * const __restrict__ dm_stripes_total_buf = this->dm_stripes_total.buf;
 
-    const unsigned int step_size = su::UnifracVawNormalizedWeightedTask<TFloat>::step_size;
+    const unsigned int step_size = SUCMP_NM::UnifracVawNormalizedWeightedTask<TFloat>::step_size;
     const unsigned int sample_steps = (n_samples+(step_size-1))/step_size; // round up
 
     // point of thread
 #ifdef _OPENACC
-    const unsigned int acc_vector_size = su::UnifracVawNormalizedWeightedTask<TFloat>::acc_vector_size;
+    const unsigned int acc_vector_size = SUCMP_NM::UnifracVawNormalizedWeightedTask<TFloat>::acc_vector_size;
 #pragma acc parallel loop collapse(3) vector_length(acc_vector_size) present(embedded_proportions,embedded_counts,sample_total_counts,dm_stripes_buf,dm_stripes_total_buf,lengths) async
 #else
 #pragma omp parallel for schedule(dynamic,1) default(shared)
@@ -383,7 +383,7 @@ void su::UnifracVawNormalizedWeightedTask<TFloat>::_run(unsigned int filled_embs
 }
 
 template<class TFloat>
-void su::UnifracGeneralizedTask<TFloat>::_run(unsigned int filled_embs, const TFloat * __restrict__ lengths) {
+void SUCMP_NM::UnifracGeneralizedTask<TFloat>::_run(unsigned int filled_embs, const TFloat * __restrict__ lengths) {
     const unsigned int start_idx = this->task_p->start;
     const unsigned int stop_idx = this->task_p->stop;
     const unsigned int n_samples = this->task_p->n_samples;
@@ -396,12 +396,12 @@ void su::UnifracGeneralizedTask<TFloat>::_run(unsigned int filled_embs, const TF
 
     const TFloat g_unifrac_alpha = this->task_p->g_unifrac_alpha;
 
-    const unsigned int step_size = su::UnifracGeneralizedTask<TFloat>::step_size;
+    const unsigned int step_size = SUCMP_NM::UnifracGeneralizedTask<TFloat>::step_size;
     const unsigned int sample_steps = (n_samples+(step_size-1))/step_size; // round up
 
     // point of thread
 #ifdef _OPENACC
-    const unsigned int acc_vector_size = su::UnifracGeneralizedTask<TFloat>::acc_vector_size;
+    const unsigned int acc_vector_size = SUCMP_NM::UnifracGeneralizedTask<TFloat>::acc_vector_size;
 #pragma acc parallel loop collapse(3) vector_length(acc_vector_size) present(embedded_proportions,dm_stripes_buf,dm_stripes_total_buf,lengths) async
 #else
 #pragma omp parallel for schedule(dynamic,1) default(shared)
@@ -456,7 +456,7 @@ void su::UnifracGeneralizedTask<TFloat>::_run(unsigned int filled_embs, const TF
 }
 
 template<class TFloat>
-void su::UnifracVawGeneralizedTask<TFloat>::_run(unsigned int filled_embs, const TFloat * __restrict__ lengths) {
+void SUCMP_NM::UnifracVawGeneralizedTask<TFloat>::_run(unsigned int filled_embs, const TFloat * __restrict__ lengths) {
     const unsigned int start_idx = this->task_p->start;
     const unsigned int stop_idx = this->task_p->stop;
     const unsigned int n_samples = this->task_p->n_samples;
@@ -471,13 +471,13 @@ void su::UnifracVawGeneralizedTask<TFloat>::_run(unsigned int filled_embs, const
     TFloat * const __restrict__ dm_stripes_buf = this->dm_stripes.buf;
     TFloat * const __restrict__ dm_stripes_total_buf = this->dm_stripes_total.buf;
 
-    const unsigned int step_size = su::UnifracVawGeneralizedTask<TFloat>::step_size;
+    const unsigned int step_size = SUCMP_NM::UnifracVawGeneralizedTask<TFloat>::step_size;
     const unsigned int sample_steps = (n_samples+(step_size-1))/step_size; // round up
     // quick hack, to be finished
 
     // point of thread
 #ifdef _OPENACC
-    const unsigned int acc_vector_size = su::UnifracVawGeneralizedTask<TFloat>::acc_vector_size;
+    const unsigned int acc_vector_size = SUCMP_NM::UnifracVawGeneralizedTask<TFloat>::acc_vector_size;
 #pragma acc parallel loop collapse(3) vector_length(acc_vector_size) present(embedded_proportions,embedded_counts,sample_total_counts,dm_stripes_buf,dm_stripes_total_buf,lengths) async
 #else
 #pragma omp parallel for schedule(dynamic,1) default(shared)
@@ -536,7 +536,7 @@ void su::UnifracVawGeneralizedTask<TFloat>::_run(unsigned int filled_embs, const
 }
 
 template<class TFloat>
-void su::UnifracUnweightedTask<TFloat>::_run(unsigned int filled_embs, const TFloat * __restrict__ lengths) {
+void SUCMP_NM::UnifracUnweightedTask<TFloat>::_run(unsigned int filled_embs, const TFloat * __restrict__ lengths) {
     const unsigned int start_idx = this->task_p->start;
     const unsigned int stop_idx = this->task_p->stop;
     const unsigned int n_samples = this->task_p->n_samples;
@@ -549,7 +549,7 @@ void su::UnifracUnweightedTask<TFloat>::_run(unsigned int filled_embs, const TFl
 
     TFloat * const __restrict__ sums = this->sums;
 
-    const unsigned int step_size = su::UnifracUnweightedTask<TFloat>::step_size;
+    const unsigned int step_size = SUCMP_NM::UnifracUnweightedTask<TFloat>::step_size;
     const unsigned int sample_steps = (n_samples+(step_size-1))/step_size; // round up
 
     const unsigned int filled_embs_els = filled_embs/64;
@@ -616,7 +616,7 @@ void su::UnifracUnweightedTask<TFloat>::_run(unsigned int filled_embs, const TFl
     // point of thread
 #ifdef _OPENACC
 #pragma acc wait
-    const unsigned int acc_vector_size = su::UnifracUnweightedTask<TFloat>::acc_vector_size;
+    const unsigned int acc_vector_size = SUCMP_NM::UnifracUnweightedTask<TFloat>::acc_vector_size;
 #pragma acc parallel loop collapse(3) vector_length(acc_vector_size) present(embedded_proportions,dm_stripes_buf,dm_stripes_total_buf,sums) async
 #else
     // use dynamic scheduling due to non-homogeneity in the loop
@@ -694,7 +694,7 @@ void su::UnifracUnweightedTask<TFloat>::_run(unsigned int filled_embs, const TFl
 }
 
 template<class TFloat>
-void su::UnifracVawUnweightedTask<TFloat>::_run(unsigned int filled_embs, const TFloat * __restrict__ lengths) {
+void SUCMP_NM::UnifracVawUnweightedTask<TFloat>::_run(unsigned int filled_embs, const TFloat * __restrict__ lengths) {
     const unsigned int start_idx = this->task_p->start;
     const unsigned int stop_idx = this->task_p->stop;
     const unsigned int n_samples = this->task_p->n_samples;
@@ -707,14 +707,14 @@ void su::UnifracVawUnweightedTask<TFloat>::_run(unsigned int filled_embs, const 
     TFloat * const __restrict__ dm_stripes_buf = this->dm_stripes.buf;
     TFloat * const __restrict__ dm_stripes_total_buf = this->dm_stripes_total.buf;
 
-    const unsigned int step_size = su::UnifracVawUnweightedTask<TFloat>::step_size;
+    const unsigned int step_size = SUCMP_NM::UnifracVawUnweightedTask<TFloat>::step_size;
     const unsigned int sample_steps = (n_samples+(step_size-1))/step_size; // round up
 
     const unsigned int filled_embs_els = (filled_embs+31)/32; // round up
 
     // point of thread
 #ifdef _OPENACC
-    const unsigned int acc_vector_size = su::UnifracVawUnweightedTask<TFloat>::acc_vector_size;
+    const unsigned int acc_vector_size = SUCMP_NM::UnifracVawUnweightedTask<TFloat>::acc_vector_size;
 #pragma acc parallel loop collapse(3) vector_length(acc_vector_size) present(embedded_proportions,embedded_counts,sample_total_counts,dm_stripes_buf,dm_stripes_total_buf,lengths) async
 #else
 #pragma omp parallel for schedule(dynamic,1) default(shared)

--- a/sucpp/unifrac_task.hpp
+++ b/sucpp/unifrac_task.hpp
@@ -1,3 +1,12 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2016-2021, UniFrac development team.
+ * All rights reserved.
+ *
+ * See LICENSE file for more details
+ */
+
 #include "task_parameters.hpp"
 #include <math.h>
 #include <vector>

--- a/sucpp/unifrac_task.hpp
+++ b/sucpp/unifrac_task.hpp
@@ -10,10 +10,9 @@
 #ifndef __UNIFRAC_TASKS
 #define __UNIFRAC_TASKS 1
 
-namespace su {
-
-
 #ifdef _OPENACC
+
+#define SUCMP_NM su_acc
 
   #ifndef SMALLGPU
   // defaultt on larger alignment, which improves performance on GPUs like V100
@@ -25,9 +24,14 @@ namespace su {
 
 #else
 
+#define SUCMP_NM su_cpu
+
+
 // CPUs don't need such a big alignment
 #define UNIFRAC_BLOCK 16
 #endif
+
+namespace SUCMP_NM {
 
     // Note: This adds a copy, which is suboptimal
     //       But was the easiest way to get a contiguous buffer
@@ -261,7 +265,7 @@ namespace su {
     template<> inline  unsigned int UnifracTaskBase<double,uint64_t>::get_emb_els(unsigned int max_embs) {return (max_embs+63)/64;}
     template<> inline  unsigned int UnifracTaskBase<float,uint64_t>::get_emb_els(unsigned int max_embs) {return (max_embs+63)/64;}
 
-    /* void su::unifrac tasks
+    /* void unifrac tasks
      *
      * all methods utilize the same function signature. that signature is as follows:
      *
@@ -426,7 +430,7 @@ namespace su {
         void _run(unsigned int filled_embs, const TFloat * __restrict__ length);
     };
 
-    /* void su::unifrac_vaw tasks
+    /* void unifrac_vaw tasks
      *
      * all methods utilize the same function signature. that signature is as follows:
      *


### PR DESCRIPTION
Slight change in the compile procedure to allow for CPU and GPU code paths to co-exist in a single installation.
The GPU compilation is now triggered by the presence of a ACC_CXX environment variable; the documentation has been updated accordingly.

When both CPU and GPU code paths are available, the code will use GPUs whenever possible.
The CPU path can be forced at runtime with UNIFRAC_USE_GPU=N.
Informative messages about CPU/GPU  switch can be enabled with UNIFRAC_GPU_INFO=Y.

Note: No change for MacOS, as GPU code paths are not supported there.