### PR TITLE
Clarify installation and add reference to 0.20.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,12 @@ The easiest way to use this library is through [QIIME2](https://docs.qiime2.org/
 This library can also be installed via a combination of `conda-forge` and `bioconda`:
 
 ```
-conda install -c conda-forge -c bioconda unifrac
+conda create --name unifrac -c conda-forge -c bioconda unifrac
 ```
 
 Note: Only the CPU version of the binaries is currently available in conda. 
 The GPU version must either be [locally compiled using freely-available NVIDIA HPC SDK](docs/compile_gpu.README.md) 
-or obtained [from a github branch](https://github.com/sfiligoi/unifrac/blob/v0.20.1-docs/docs/install_gpu.README.txt).
+or obtained [from a github branch](https://github.com/sfiligoi/unifrac/blob/v0.20.2-docs/docs/install_gpu.README.md).
 
 Note: If you desire a fully optimized the binaries for your CPU, you can [compile them locally](docs/compile_cpu.README.md).
 

--- a/docs/compile_cpu.README.md
+++ b/docs/compile_cpu.README.md
@@ -88,5 +88,5 @@ mv $CONDA_PREFIX/lib/libssu.so $CONDA_PREFIX/bin/libssu.so.cpu
 And you are all done.
 The UniFrac binary and libraries in the Anaconda environment are now the locally compiled ones.
 
-Note: If you do not want the cutting edge UniFrac from git, you can get a tarball of the released versions. These instructions have been tested with version [0.20.1](https://codeload.github.com/biocore/unifrac/tar.gz/0.20.1).
+Note: If you do not want the cutting edge UniFrac from git, you can get a tarball of the released versions. These instructions have been tested with version [0.20.2](https://codeload.github.com/biocore/unifrac/tar.gz/0.20.2).
 

--- a/docs/compile_gpu.README.md
+++ b/docs/compile_gpu.README.md
@@ -148,5 +148,9 @@ mv $CONDA_PREFIX/lib/libssu.so $CONDA_PREFIX/bin/libssu.so.cpu
 And you are all done.
 The UniFrac binary and libraries in the Anaconda environment are now the GPU-enabled ones.
 
-Note: If you do not want the cutting edge UniFrac from git, you can get a tarball of the released versions. The first fully GPU-enabled version was [0.20.1](https://codeload.github.com/biocore/unifrac/tar.gz/0.20.1).
- 
+## Compiling an older version of Unifrac for GPUs
+
+If you do not want the cutting edge UniFrac from git, you will have to use version-specific instructions:
+* [0.20.1 GPU compile instructions](https://github.com/sfiligoi/unifrac/blob/v0.20.1-docs/docs/compile_gpu.README.txt)
+* [0.20.2 GPU compile instructions](https://github.com/sfiligoi/unifrac/blob/v0.20.2-docs/docs/compile_gpu.README.md)
+


### PR DESCRIPTION
Installing unifrac in the anaconda base seems to create conflicts; creating a new environment is safer.
Also update links to point to 0.20.2 (instead of 0.20.1).