### PR TITLE
BUG FIX: Fix compute of large matrices

### DIFF
--- a/sucpp/api.cpp
+++ b/sucpp/api.cpp
@@ -621,6 +621,7 @@ IOStatus write_mat_from_matrix(const char* output_filename, mat_full_fp64_t* res
     output.open(output_filename);
 
     double v;
+    const uint64_t n_samples_64 = result->n_samples; // 64-bit to avoid overflow
 
     for(unsigned int i = 0; i < result->n_samples; i++)
         output << "\t" << result->sample_ids[i];
@@ -629,7 +630,7 @@ IOStatus write_mat_from_matrix(const char* output_filename, mat_full_fp64_t* res
     for(unsigned int i = 0; i < result->n_samples; i++) {
         output << result->sample_ids[i];
         for(unsigned int j = 0; j < result->n_samples; j++) {
-            v = buf2d[i*result->n_samples+j];
+            v = buf2d[i*n_samples_64+j];
             output << std::setprecision(16) << "\t" << v;
         }
         output << std::endl;

--- a/sucpp/unifrac_cmp.cpp
+++ b/sucpp/unifrac_cmp.cpp
@@ -181,15 +181,15 @@ inline void unifracTT(const su::biom_interface &table,
 #pragma acc wait
 
     if(want_total) {
-        const unsigned int start_idx = task_p->start;
-        const unsigned int stop_idx = task_p->stop;
+        const uint64_t start_idx = task_p->start;
+        const uint64_t stop_idx = task_p->stop;
 
         TFloat * const dm_stripes_buf = taskObj.dm_stripes.buf;
         const TFloat * const dm_stripes_total_buf = taskObj.dm_stripes_total.buf;
 
 #pragma acc parallel loop collapse(2) present(dm_stripes_buf,dm_stripes_total_buf)
-        for(unsigned int i = start_idx; i < stop_idx; i++)
-            for(unsigned int j = 0; j < n_samples; j++) {
+        for(uint64_t i = start_idx; i < stop_idx; i++)
+            for(uint64_t j = 0; j < n_samples; j++) {
                 uint64_t idx = (i-start_idx)*n_samples_r+j;
                 dm_stripes_buf[idx]=dm_stripes_buf[idx]/dm_stripes_total_buf[idx];
                 // taskObj.dm_stripes[i][j] = taskObj.dm_stripes[i][j] / taskObj.dm_stripes_total[i][j];
@@ -332,15 +332,15 @@ inline void unifrac_vawTT(const su::biom_interface &table,
 
 #pragma acc wait
     if(want_total) {
-        const unsigned int start_idx = task_p->start;
-        const unsigned int stop_idx = task_p->stop;
+        const uint64_t start_idx = task_p->start;
+        const uint64_t stop_idx = task_p->stop;
 
         TFloat * const dm_stripes_buf = taskObj.dm_stripes.buf;
         const TFloat * const dm_stripes_total_buf = taskObj.dm_stripes_total.buf;
 
 #pragma acc parallel loop collapse(2) present(dm_stripes_buf,dm_stripes_total_buf)
-        for(unsigned int i = start_idx; i < stop_idx; i++)
-            for(unsigned int j = 0; j < n_samples; j++) {
+        for(uint64_t i = start_idx; i < stop_idx; i++)
+            for(uint64_t j = 0; j < n_samples; j++) {
                 uint64_t idx = (i-start_idx)*n_samples_r+j;
                 dm_stripes_buf[idx]=dm_stripes_buf[idx]/dm_stripes_total_buf[idx];
                 // taskObj.dm_stripes[i][j] = taskObj.dm_stripes[i][j] / taskObj.dm_stripes_total[i][j];

--- a/sucpp/unifrac_cmp.cpp
+++ b/sucpp/unifrac_cmp.cpp
@@ -341,7 +341,7 @@ inline void unifrac_vawTT(const su::biom_interface &table,
 #pragma acc parallel loop collapse(2) present(dm_stripes_buf,dm_stripes_total_buf)
         for(unsigned int i = start_idx; i < stop_idx; i++)
             for(unsigned int j = 0; j < n_samples; j++) {
-                unit64_t idx = (i-start_idx)*n_samples_r+j;
+                uint64_t idx = (i-start_idx)*n_samples_r+j;
                 dm_stripes_buf[idx]=dm_stripes_buf[idx]/dm_stripes_total_buf[idx];
                 // taskObj.dm_stripes[i][j] = taskObj.dm_stripes[i][j] / taskObj.dm_stripes_total[i][j];
             }

--- a/sucpp/unifrac_cmp.cpp
+++ b/sucpp/unifrac_cmp.cpp
@@ -190,7 +190,7 @@ inline void unifracTT(const su::biom_interface &table,
 #pragma acc parallel loop collapse(2) present(dm_stripes_buf,dm_stripes_total_buf)
         for(unsigned int i = start_idx; i < stop_idx; i++)
             for(unsigned int j = 0; j < n_samples; j++) {
-                unsigned int idx = (i-start_idx)*n_samples_r+j;
+                uint64_t idx = (i-start_idx)*n_samples_r+j;
                 dm_stripes_buf[idx]=dm_stripes_buf[idx]/dm_stripes_total_buf[idx];
                 // taskObj.dm_stripes[i][j] = taskObj.dm_stripes[i][j] / taskObj.dm_stripes_total[i][j];
             }
@@ -341,7 +341,7 @@ inline void unifrac_vawTT(const su::biom_interface &table,
 #pragma acc parallel loop collapse(2) present(dm_stripes_buf,dm_stripes_total_buf)
         for(unsigned int i = start_idx; i < stop_idx; i++)
             for(unsigned int j = 0; j < n_samples; j++) {
-                unsigned int idx = (i-start_idx)*n_samples_r+j;
+                unit64_t idx = (i-start_idx)*n_samples_r+j;
                 dm_stripes_buf[idx]=dm_stripes_buf[idx]/dm_stripes_total_buf[idx];
                 // taskObj.dm_stripes[i][j] = taskObj.dm_stripes[i][j] / taskObj.dm_stripes_total[i][j];
             }

--- a/sucpp/unifrac_task.hpp
+++ b/sucpp/unifrac_task.hpp
@@ -405,7 +405,7 @@ namespace SUCMP_NM {
         UnifracUnweightedTask(std::vector<double*> &_dm_stripes, std::vector<double*> &_dm_stripes_total, unsigned int _max_embs, const su::task_parameters* _task_p)
         : UnifracTask<TFloat, uint64_t>(_dm_stripes,_dm_stripes_total,_max_embs,_task_p) 
         {
-          const unsigned int bsize = _max_embs*0x400/32;
+          const unsigned int bsize = _max_embs*(0x400/32);
           sums = NULL;
           posix_memalign((void **)&sums, 4096, sizeof(TFloat) * bsize);
 #pragma acc enter data create(sums[:bsize])
@@ -414,7 +414,7 @@ namespace SUCMP_NM {
         virtual ~UnifracUnweightedTask()
         {
 #ifdef _OPENACC
-           const unsigned int bsize = this->max_embs*0x400/32;
+           const unsigned int bsize = this->max_embs*(0x400/32);
 #pragma acc exit data delete(sums[:bsize])
 #endif
           free(sums);


### PR DESCRIPTION
Preciously, Unifrac could produce the wrong output when computing large matrices, due to 32-bit wraparound.
The limiting factor was: (n_samples x n_stripes) could not exceed 2^31 in GPU code, and 2^32 in CPU code.

Note: Was only a problem for large-memory GPUs, like the A100 and A40.
