### PR TITLE
Deprecate threads and add n_substeps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,8 @@ jobs:
           conda install --yes -c conda-forge -c bioconda clangxx_osx-64
         fi
         conda install --yes -c conda-forge -c bioconda unifrac-binaries
-        conda install --yes -c conda-forge -c bioconda cython "hdf5<1.12.1" biom-format numpy "h5py<3.0.0 | >3.3.0" "scikit-bio>=0.5.1" nose
+        # TEMP HACK: Use older version of scipy to work around scikit-bio problem
+        conda install --yes -c conda-forge -c bioconda cython "scipy<1.9" "hdf5<1.12.1" biom-format numpy "h5py<3.0.0 | >3.3.0" "scikit-bio>=0.5.1" nose
         echo "$(uname -s)"
         if [[ "$(uname -s)" == "Linux" ]];
         then

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     - name: flake8
       uses: actions/setup-python@v2
       with:
-        python-version: 3.6
+        python-version: 3.9
     - name: install dependencies
       run: python -m pip install --upgrade pip
     - name: lint
@@ -29,7 +29,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A detailed description of the Strided State UniFrac algorithm can be found in [M
 
     ssu
     For UniFrac, please see:
+        Sfiligoi et al. mSystems 2022; DOI: 10.1128/msystems.00028-22
         McDonald et al. Nature Methods 2018; DOI: 10.1038/s41592-018-0187-8
         Lozupone and Knight Appl Environ Microbiol 2005; DOI: 10.1128/AEM.71.12.8228-8235.2005
         Lozupone et al. Appl Environ Microbiol 2007; DOI: 10.1128/AEM.01996-06

--- a/README.md
+++ b/README.md
@@ -377,10 +377,6 @@ The methods can also be used directly through the command line after install:
 			Faith Biological Conservation 1992; DOI: 10.1016/0006-3207(92)91201-3
 
             
-## Shared library access
-
-In addition to the above methods to access UniFrac, it is also possible to link against the shared library. The C API is described in `sucpp/api.hpp`, and examples of linking against this API can be found in `examples/`. 
-
 ## Minor test dataset
 
 A small test `.biom` and `.tre` can be found in `sucpp/`. An example with expected output is below, and should execute in 10s of milliseconds:

--- a/README.md
+++ b/README.md
@@ -158,12 +158,14 @@ The library can be accessed directly from within Python. If operating in this mo
         phylogeny : str
             A filepath to a Newick formatted tree.
         threads : int, optional
-            The number of threads to split it into. Default of 1.
+            Deprecated, no-op.
         variance_adjusted : bool, optional
             Adjust for varianace or not. Default is False.
         bypass_tips : bool, optional
             Bypass the tips of the tree in the computation. This reduces compute
             by about 50%, but is an approximation.
+        n_substeps : int, optional
+            Internally split the problem in n substeps for reduced memory footprint.
 
         Returns
         -------
@@ -178,6 +180,15 @@ The library can be accessed directly from within Python. If operating in this mo
         ValueError
             If the table does not appear to be BIOM-Format v2.1.
             If the phylogeny does not appear to be in Newick format.
+
+        Environment variables
+        ---------------------
+        OMP_NUM_THREADS
+            Number of CPU cores to use. If not defined, use all detected cores.
+        UNIFRAC_USE_GPU
+            Enable or disable GPU offload. If not defined, if a NVIDIA GPU is detected, it will be used.
+        ACC_DEVICE_NUM
+            The GPU to use. If not defined, the first GPU will be used.
 
         Notes
         -----
@@ -211,7 +222,7 @@ The library can be accessed directly from within Python. If operating in this mo
             if set to 0, no PCoA is computed.
             Defaults of 10.
         threads : int, optional
-            The number of threads to split it into. Default of 1.
+            Deprecated, no-op.
         variance_adjusted : bool, optional
             Adjust for varianace or not. Default is False.
         bypass_tips : bool, optional
@@ -222,6 +233,8 @@ The library can be accessed directly from within Python. If operating in this mo
         buf_dirname : str, optional
             If set, the directory where the disk buffer is hosted,
             can be used to reduce the amount of memory needed.
+        n_substeps : int, optional
+            Internally split the problem in n substeps for reduced memory footprint.
 
         Returns
         -------
@@ -237,6 +250,15 @@ The library can be accessed directly from within Python. If operating in this mo
         ValueError
             If the table does not appear to be BIOM-Format v2.1.
             If the phylogeny does not appear to be in Newick format.
+
+        Environment variables
+        ---------------------
+        OMP_NUM_THREADS
+            Number of CPU cores to use. If not defined, use all detected cores.
+        UNIFRAC_USE_GPU
+            Enable or disable GPU offload. If not defined, if a NVIDIA GPU is detected, it will be used.
+        ACC_DEVICE_NUM
+            The GPU to use. If not defined, the first GPU will be used.
 
         Notes
         -----

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ The library can be accessed directly from within Python. If operating in this mo
             Bypass the tips of the tree in the computation. This reduces compute
             by about 50%, but is an approximation.
         n_substeps : int, optional
-            Internally split the problem in n substeps for reduced memory footprint.
+            Internally split the problem in substeps for reduced memory footprint.
 
         Returns
         -------
@@ -186,7 +186,7 @@ The library can be accessed directly from within Python. If operating in this mo
         OMP_NUM_THREADS
             Number of CPU cores to use. If not defined, use all detected cores.
         UNIFRAC_USE_GPU
-            Enable or disable GPU offload. If not defined, if a NVIDIA GPU is detected, it will be used.
+            Enable or disable GPU offload. If not defined, autodetect.
         ACC_DEVICE_NUM
             The GPU to use. If not defined, the first GPU will be used.
 
@@ -234,7 +234,7 @@ The library can be accessed directly from within Python. If operating in this mo
             If set, the directory where the disk buffer is hosted,
             can be used to reduce the amount of memory needed.
         n_substeps : int, optional
-            Internally split the problem in n substeps for reduced memory footprint.
+            Internally split the problem in substeps for reduced memory footprint.
 
         Returns
         -------
@@ -256,7 +256,7 @@ The library can be accessed directly from within Python. If operating in this mo
         OMP_NUM_THREADS
             Number of CPU cores to use. If not defined, use all detected cores.
         UNIFRAC_USE_GPU
-            Enable or disable GPU offload. If not defined, if a NVIDIA GPU is detected, it will be used.
+            Enable or disable GPU offload. If not defined, autodetect.
         ACC_DEVICE_NUM
             The GPU to use. If not defined, the first GPU will be used.
 

--- a/README.md
+++ b/README.md
@@ -312,16 +312,16 @@ The methods can also be used directly through the command line after install:
     $ which ssu
     /Users/<username>/miniconda3/envs/qiime2-20xx.x/bin/ssu
     $ ssu --help
-    usage: ssu -i <biom> -o <out.dm> -m [METHOD] -t <newick> [-n threads] [-a alpha] [-f]  [--vaw]
-        [--mode [MODE]] [--start starting-stripe] [--stop stopping-stripe] [--partial-pattern <glob>]
+    usage: ssu -i <biom> -o <out.dm> -m [METHOD] -t <newick> [-a alpha] [-f]  [--vaw]
+        [--mode MODE] [--start starting-stripe] [--stop stopping-stripe] [--partial-pattern <glob>]
         [--n-partials number_of_partitions] [--report-bare] [--format|-r out-mode]
+        [--n-substeps n] [--pcoa dims] [--diskbuf path]
 
         -i		The input BIOM table.
         -t		The input phylogeny in newick.
         -m		The method, [unweighted | weighted_normalized | weighted_unnormalized | generalized | 
                                  unweighted_fp32 | weighted_normalized_fp32 | weighted_unnormalized_fp32 | generalized_fp32].
         -o		The output distance matrix.
-        -n		[OPTIONAL] The number of threads, default is 1.
         -a		[OPTIONAL] Generalized UniFrac alpha, default is 1.
         -f		[OPTIONAL] Bypass tips, reduces compute by about 50%.
         --vaw	[OPTIONAL] Variance adjusted, default is to not adjust for variance.
@@ -333,8 +333,9 @@ The methods can also be used directly through the command line after install:
         --start	[OPTIONAL] If mode==partial, the starting stripe.
         --stop	[OPTIONAL] If mode==partial, the stopping stripe.
         --partial-pattern	[OPTIONAL] If mode==merge-partial, a glob pattern for partial outputs to merge.
-        --n-partials	[OPTIONAL] If mode==partial-report, the number of partitions to compute.
+        --n-partials 	[OPTIONAL] If mode==partial-report, the number of partitions to compute.
         --report-bare	[OPTIONAL] If mode==partial-report, produce barebones output.
+        --n-substeps 	[OPTIONAL] Internally split the problem in n substeps for reduced memory footprint, default is 1.
         --format|-r	[OPTIONAL]  Output format:
                                  ascii : [DEFAULT] Original ASCII format.
                                  hfd5 : HFD5 format.  May be fp32 or fp64, depending on method.
@@ -342,9 +343,16 @@ The methods can also be used directly through the command line after install:
                                  hdf5_fp64 : HFD5 format, using fp64 precision.
         --pcoa	[OPTIONAL] Number of PCoA dimensions to compute (default: 10, do not compute if 0)
         --diskbuf	[OPTIONAL] Use a disk buffer to reduce memory footprint. Provide path to a fast partition (ideally NVMe).
+        -n		[OPTIONAL] DEPRECATED, no-op.
+
+    Environment variables: 
+        CPU parallelism is controlled by OMP_NUM_THREADS. If not defined, all detected core will be used.
+        GPU offload can be disabled with UNIFRAC_USE_GPU=N. By default, if a NVIDIA GPU is detected, it will be used.
+        A specific GPU can be selected with ACC_DEVICE_NUM. If not defined, the first GPU will be used.
 
     Citations: 
         For UniFrac, please see:
+            Sfiligoi et al. mSystems 2022; DOI: 10.1128/msystems.00028-22
             McDonald et al. Nature Methods 2018; DOI: 10.1038/s41592-018-0187-8
             Lozupone and Knight Appl Environ Microbiol 2005; DOI: 10.1128/AEM.71.12.8228-8235.2005
             Lozupone et al. Appl Environ Microbiol 2007; DOI: 10.1128/AEM.01996-06

--- a/unifrac/_api.pxd
+++ b/unifrac/_api.pxd
@@ -57,15 +57,15 @@ cdef extern from "api.hpp":
 
     compute_status one_off(const char* biom_filename, const char* tree_filename, 
                                const char* unifrac_method, bool variance_adjust, double alpha,
-                               bool bypass_tips, unsigned int threads, mat** result)
+                               bool bypass_tips, unsigned int n_substeps, mat** result)
     
     compute_status one_off_inmem(const support_biom *table, const support_bptree *tree, 
                                  const char* unifrac_method, bool variance_adjust, double alpha,
-                                 bool bypass_tips, unsigned int threads, mat_full_fp64** result)
+                                 bool bypass_tips, unsigned int n_substeps, mat_full_fp64** result)
 
     compute_status one_off_inmem_fp32(const support_biom *table, const support_bptree *tree, 
                                       const char* unifrac_method, bool variance_adjust, double alpha,
-                                      bool bypass_tips, unsigned int threads, mat_full_fp32** result)
+                                      bool bypass_tips, unsigned int n_substeps, mat_full_fp32** result)
 
     compute_status faith_pd_one_off(const char* biom_filename, const char* tree_filename,
                                     results_vec** result)
@@ -77,6 +77,6 @@ cdef extern from "api.hpp":
 
     compute_status unifrac_to_file(const char* biom_filename, const char* tree_filename, const char* out_filename,
                                      const char* unifrac_method, bool variance_adjust, double alpha,
-                                     bool bypass_tips, unsigned int threads, const char* format,
+                                     bool bypass_tips, unsigned int n_substeps, const char* format,
                                      unsigned int pcoa_dims, const char *mmap_dir)
 

--- a/unifrac/_api.pyx
+++ b/unifrac/_api.pyx
@@ -29,7 +29,7 @@ def check_status(compute_status status):
 #
 def ssu_inmem(object table, object tree,
               str unifrac_method, bool variance_adjust, double alpha,
-              bool bypass_tips, unsigned int threads):
+              bool bypass_tips, unsigned int n_substeps):
     """Execute a call to Strided State UniFrac via the direct API
 
     Parameters
@@ -51,8 +51,8 @@ def ssu_inmem(object table, object tree,
     bypass_tips : bool
         Bypass the tips of the tree in the computation. This reduces compute
         by about 50%, but is an approximation.
-    threads : int
-        The number of threads to use.
+    n_substeps : int
+        The number of substeps to use.
 
     Returns
     -------
@@ -86,13 +86,13 @@ def ssu_inmem(object table, object tree,
     if '_fp32' in unifrac_method:
         numpy_arr_fp32 = _ssu_inmem_fp32(inmem_biom, inmem_tree, met_c_string, 
                                          variance_adjust, alpha, bypass_tips, 
-                                         threads)
+                                         n_substeps)
         # validate=False would shave 5% but it's currently in skbio master
         result_dm = skbio.DistanceMatrix(numpy_arr_fp32, table.ids())
     else:
         numpy_arr_fp64 = _ssu_inmem_fp64(inmem_biom, inmem_tree, met_c_string, 
                                          variance_adjust, alpha, bypass_tips, 
-                                         threads)
+                                         n_substeps)
         # validate=False would shave 5% but it's currently in skbio master
         result_dm = skbio.DistanceMatrix(numpy_arr_fp64, table.ids())
    
@@ -106,7 +106,7 @@ cdef np.ndarray _ssu_inmem_fp64(support_biom *inmem_biom,
                                 support_bptree *inmem_tree, 
                                 char* met_c_string, 
                                 bool variance_adjust, double alpha,
-                                bool bypass_tips, unsigned int threads):
+                                bool bypass_tips, unsigned int n_substeps):
     cdef: 
         compute_status status
         mat_full_fp64 *result
@@ -128,7 +128,7 @@ cdef np.ndarray _ssu_inmem_fp64(support_biom *inmem_biom,
                            variance_adjust,
                            alpha,
                            bypass_tips,
-                           threads,
+                           n_substeps,
                            &result)
     check_status(status)
 
@@ -145,7 +145,7 @@ cdef np.ndarray _ssu_inmem_fp32(support_biom *inmem_biom,
                                 support_bptree *inmem_tree, 
                                 char* met_c_string, 
                                 bool variance_adjust, double alpha,
-                                bool bypass_tips, unsigned int threads):
+                                bool bypass_tips, unsigned int n_substeps):
     cdef: 
         compute_status status
         mat_full_fp32 *result
@@ -167,7 +167,7 @@ cdef np.ndarray _ssu_inmem_fp32(support_biom *inmem_biom,
                                 variance_adjust,
                                 alpha,
                                 bypass_tips,
-                                threads,
+                                n_substeps,
                                 &result)
     check_status(status)
     
@@ -182,7 +182,7 @@ cdef np.ndarray _ssu_inmem_fp32(support_biom *inmem_biom,
 
 def ssu(str biom_filename, str tree_filename,
         str unifrac_method, bool variance_adjust, double alpha,
-        bool bypass_tips, unsigned int threads):
+        bool bypass_tips, unsigned int n_substeps):
     """Execute a call to Strided State UniFrac via the direct API
 
     Parameters
@@ -204,8 +204,8 @@ def ssu(str biom_filename, str tree_filename,
     bypass_tips : bool
         Bypass the tips of the tree in the computation. This reduces compute
         by about 50%, but is an approximation.
-    threads : int
-        The number of threads to use.
+    n_substeps : int
+        The number of substeps to use.
 
     Returns
     -------
@@ -247,7 +247,7 @@ def ssu(str biom_filename, str tree_filename,
                      variance_adjust,
                      alpha,
                      bypass_tips,
-                     threads,
+                     n_substeps,
                      &result)
     check_status(status)
     
@@ -337,7 +337,7 @@ def faith_pd(str biom_filename, str tree_filename):
 
 def ssu_to_file(str biom_filename, str tree_filename, str out_filename,
                 str unifrac_method, bool variance_adjust, double alpha,
-                bool bypass_tips, unsigned int threads, str format,
+                bool bypass_tips, unsigned int n_substeps, str format,
                 unsigned int pcoa_dims, str buf_dirname):
     """Execute a call to Strided State UniFrac to file via the direct API
 
@@ -362,8 +362,8 @@ def ssu_to_file(str biom_filename, str tree_filename, str out_filename,
     bypass_tips : bool
         Bypass the tips of the tree in the computation. This reduces compute
         by about 50%, but is an approximation.
-    threads : int
-        The number of threads to use.
+    n_substeps : int
+        The number of substeps to use.
     format : str
         Onput format to use; one of {hdf5, hdf5_fp32, hdf5_fp64}
     pcoa_dims : int
@@ -422,7 +422,7 @@ def ssu_to_file(str biom_filename, str tree_filename, str out_filename,
     status = unifrac_to_file(biom_c_string, tree_c_string, out_c_string,
                              met_c_string,
                              variance_adjust, alpha, bypass_tips,
-                             threads, format_c_string, 
+                             n_substeps, format_c_string, 
                              pcoa_dims, dirbuf_c_string)
     check_status(status)
 

--- a/unifrac/_methods.py
+++ b/unifrac/_methods.py
@@ -421,7 +421,7 @@ def weighted_unnormalized_fp32(table: Union[str, Table],
                                phylogeny: Union[str, TreeNode, BP],
                                threads: int = 1,
                                variance_adjusted: bool = False,
-                               bypass_tips: bool = False, 
+                               bypass_tips: bool = False,
                                n_substeps: int = 1
                                ) -> skbio.DistanceMatrix:
     # noqa
@@ -490,7 +490,7 @@ def generalized(table: Union[str, Table],
                 threads: int = 1,
                 alpha: float = 1.0,
                 variance_adjusted: bool = False,
-                bypass_tips: bool = False, 
+                bypass_tips: bool = False,
                 n_substeps: int = 1) -> skbio.DistanceMatrix:
     """Compute Generalized UniFrac
 
@@ -576,7 +576,7 @@ def generalized_fp32(table: Union[str, Table],
                      threads: int = 1,
                      alpha: float = 1.0,
                      variance_adjusted: bool = False,
-                     bypass_tips: bool = False, 
+                     bypass_tips: bool = False,
                      n_substeps: int = 1) -> skbio.DistanceMatrix:
     """Compute Generalized UniFrac using fp32 math
 
@@ -651,7 +651,8 @@ def generalized_fp32(table: Union[str, Table],
              "optimized.",
              Warning)
         return weighted_normalized_fp32(table, phylogeny, threads,
-                                        variance_adjusted, bypass_tips, n_substeps)
+                                        variance_adjusted, bypass_tips,
+                                        n_substeps)
     else:
         return _call_ssu(str(table), str(phylogeny), 'generalized_fp32',
                          variance_adjusted, alpha, bypass_tips, n_substeps)
@@ -670,7 +671,7 @@ METHODS = {'unweighted': unweighted,
 def meta(tables: tuple, phylogenies: tuple, weights: tuple = None,
          consolidation: str = None, method: str = None,
          threads: int = 1, variance_adjusted: bool = False,
-         alpha: float = None, bypass_tips: bool = False, 
+         alpha: float = None, bypass_tips: bool = False,
          n_substeps: int = 1) -> \
          skbio.DistanceMatrix:
     """Compute meta UniFrac
@@ -821,7 +822,7 @@ def unweighted_to_file(table: str,
                        variance_adjusted: bool = False,
                        bypass_tips: bool = False,
                        format: str = "hdf5",
-                       buf_dirname: str = "", 
+                       buf_dirname: str = "",
                        n_substeps: int = 1) -> str:
     """Compute Unweighted UniFrac and write to file
 
@@ -906,7 +907,7 @@ def unweighted_fp32_to_file(table: str,
                             variance_adjusted: bool = False,
                             bypass_tips: bool = False,
                             format: str = "hdf5",
-                            buf_dirname: str = "", 
+                            buf_dirname: str = "",
                             n_substeps: int = 1) -> str:
     """Compute Unweighted UniFrac using fp32 math and write to file
 
@@ -991,7 +992,7 @@ def weighted_normalized_to_file(table: str,
                                 variance_adjusted: bool = False,
                                 bypass_tips: bool = False,
                                 format: str = "hdf5",
-                                buf_dirname: str = "", 
+                                buf_dirname: str = "",
                                 n_substeps: int = 1) -> str:
     """Compute weighted normalized UniFrac and write to file
 
@@ -1075,7 +1076,7 @@ def weighted_normalized_fp32_to_file(table: str,
                                      variance_adjusted: bool = False,
                                      bypass_tips: bool = False,
                                      format: str = "hdf5",
-                                     buf_dirname: str = "", 
+                                     buf_dirname: str = "",
                                      n_substeps: int = 1) -> str:
     """Compute weighted normalized UniFrac using fp32 math and write to file
 
@@ -1159,7 +1160,7 @@ def weighted_unnormalized_to_file(table: str,
                                   variance_adjusted: bool = False,
                                   bypass_tips: bool = False,
                                   format: str = "hdf5",
-                                  buf_dirname: str = "", 
+                                  buf_dirname: str = "",
                                   n_substeps: int = 1) -> str:
     """Compute weighted unnormalized UniFrac and write it to file
 
@@ -1243,9 +1244,9 @@ def weighted_unnormalized_fp32_to_file(table: str,
                                        variance_adjusted: bool = False,
                                        bypass_tips: bool = False,
                                        format: str = "hdf5",
-                                       buf_dirname: str = "", 
+                                       buf_dirname: str = "",
                                        n_substeps: int = 1) -> str:
-    """Compute weighted unnormalized UniFrac using fp32 math and write it to file
+    """Compute weighted unnormalized UniFrac using fp32 math and write to file
 
     Parameters
     ----------
@@ -1328,7 +1329,7 @@ def generalized_to_file(table: str,
                         variance_adjusted: bool = False,
                         bypass_tips: bool = False,
                         format: str = "hdf5",
-                        buf_dirname: str = "", 
+                        buf_dirname: str = "",
                         n_substeps: int = 1) -> str:
     """Compute Generalized UniFrac and write to file
 
@@ -1436,7 +1437,7 @@ def generalized_fp32_to_file(table: str,
                              variance_adjusted: bool = False,
                              bypass_tips: bool = False,
                              format: str = "hdf5",
-                             buf_dirname: str = "", 
+                             buf_dirname: str = "",
                              n_substeps: int = 1) -> str:
     """Compute Generalized UniFrac using fp32 math and write to file
 

--- a/unifrac/_methods.py
+++ b/unifrac/_methods.py
@@ -121,6 +121,15 @@ def unweighted(table: Union[str, Table],
         If the table does not appear to be BIOM-Format v2.1.
         If the phylogeny does not appear to be in Newick format.
 
+    Environment variables
+    ---------------------
+    OMP_NUM_THREADS
+        Number of CPU cores to use. If not defined, use all detected cores.
+    UNIFRAC_USE_GPU
+        Enable or disable GPU offload. If not defined, if a NVIDIA GPU is detected, it will be used.
+    ACC_DEVICE_NUM
+        The GPU to use. If not defined, the first GPU will be used.
+
     Notes
     -----
     Unweighted UniFrac was originally described in [1]_. Variance Adjusted
@@ -178,6 +187,15 @@ def unweighted_fp32(table: Union[str, Table],
     ValueError
         If the table does not appear to be BIOM-Format v2.1.
         If the phylogeny does not appear to be in Newick format.
+
+    Environment variables
+    ---------------------
+    OMP_NUM_THREADS
+        Number of CPU cores to use. If not defined, use all detected cores.
+    UNIFRAC_USE_GPU
+        Enable or disable GPU offload. If not defined, if a NVIDIA GPU is detected, it will be used.
+    ACC_DEVICE_NUM
+        The GPU to use. If not defined, the first GPU will be used.
 
     Notes
     -----
@@ -237,6 +255,15 @@ def weighted_normalized(table: Union[str, Table],
         If the table does not appear to be BIOM-Format v2.1.
         If the phylogeny does not appear to be in Newick format.
 
+    Environment variables
+    ---------------------
+    OMP_NUM_THREADS
+        Number of CPU cores to use. If not defined, use all detected cores.
+    UNIFRAC_USE_GPU
+        Enable or disable GPU offload. If not defined, if a NVIDIA GPU is detected, it will be used.
+    ACC_DEVICE_NUM
+        The GPU to use. If not defined, the first GPU will be used.
+
     Notes
     -----
     Weighted UniFrac was originally described in [1]_. Variance Adjusted
@@ -294,6 +321,15 @@ def weighted_normalized_fp32(table: Union[str, Table],
     ValueError
         If the table does not appear to be BIOM-Format v2.1.
         If the phylogeny does not appear to be in Newick format.
+
+    Environment variables
+    ---------------------
+    OMP_NUM_THREADS
+        Number of CPU cores to use. If not defined, use all detected cores.
+    UNIFRAC_USE_GPU
+        Enable or disable GPU offload. If not defined, if a NVIDIA GPU is detected, it will be used.
+    ACC_DEVICE_NUM
+        The GPU to use. If not defined, the first GPU will be used.
 
     Notes
     -----
@@ -353,6 +389,15 @@ def weighted_unnormalized(table: Union[str, Table],
         If the table does not appear to be BIOM-Format v2.1.
         If the phylogeny does not appear to be in Newick format.
 
+    Environment variables
+    ---------------------
+    OMP_NUM_THREADS
+        Number of CPU cores to use. If not defined, use all detected cores.
+    UNIFRAC_USE_GPU
+        Enable or disable GPU offload. If not defined, if a NVIDIA GPU is detected, it will be used.
+    ACC_DEVICE_NUM
+        The GPU to use. If not defined, the first GPU will be used.
+
     Notes
     -----
     Weighted UniFrac was originally described in [1]_. Variance Adjusted
@@ -411,6 +456,15 @@ def weighted_unnormalized_fp32(table: Union[str, Table],
     ValueError
         If the table does not appear to be BIOM-Format v2.1.
         If the phylogeny does not appear to be in Newick format.
+
+    Environment variables
+    ---------------------
+    OMP_NUM_THREADS
+        Number of CPU cores to use. If not defined, use all detected cores.
+    UNIFRAC_USE_GPU
+        Enable or disable GPU offload. If not defined, if a NVIDIA GPU is detected, it will be used.
+    ACC_DEVICE_NUM
+        The GPU to use. If not defined, the first GPU will be used.
 
     Notes
     -----
@@ -474,6 +528,15 @@ def generalized(table: Union[str, Table],
     ValueError
         If the table does not appear to be BIOM-Format v2.1.
         If the phylogeny does not appear to be in Newick format.
+
+    Environment variables
+    ---------------------
+    OMP_NUM_THREADS
+        Number of CPU cores to use. If not defined, use all detected cores.
+    UNIFRAC_USE_GPU
+        Enable or disable GPU offload. If not defined, if a NVIDIA GPU is detected, it will be used.
+    ACC_DEVICE_NUM
+        The GPU to use. If not defined, the first GPU will be used.
 
     Notes
     -----
@@ -551,6 +614,15 @@ def generalized_fp32(table: Union[str, Table],
     ValueError
         If the table does not appear to be BIOM-Format v2.1.
         If the phylogeny does not appear to be in Newick format.
+
+    Environment variables
+    ---------------------
+    OMP_NUM_THREADS
+        Number of CPU cores to use. If not defined, use all detected cores.
+    UNIFRAC_USE_GPU
+        Enable or disable GPU offload. If not defined, if a NVIDIA GPU is detected, it will be used.
+    ACC_DEVICE_NUM
+        The GPU to use. If not defined, the first GPU will be used.
 
     Notes
     -----
@@ -652,6 +724,15 @@ def meta(tables: tuple, phylogenies: tuple, weights: tuple = None,
     ValueError
         If the table does not appear to be BIOM-Format v2.1.
         If the phylogeny does not appear to be in Newick format.
+
+    Environment variables
+    ---------------------
+    OMP_NUM_THREADS
+        Number of CPU cores to use. If not defined, use all detected cores.
+    UNIFRAC_USE_GPU
+        Enable or disable GPU offload. If not defined, if a NVIDIA GPU is detected, it will be used.
+    ACC_DEVICE_NUM
+        The GPU to use. If not defined, the first GPU will be used.
 
     Notes
     -----
@@ -786,6 +867,15 @@ def unweighted_to_file(table: str,
         If the table does not appear to be BIOM-Format v2.1.
         If the phylogeny does not appear to be in Newick format.
 
+    Environment variables
+    ---------------------
+    OMP_NUM_THREADS
+        Number of CPU cores to use. If not defined, use all detected cores.
+    UNIFRAC_USE_GPU
+        Enable or disable GPU offload. If not defined, if a NVIDIA GPU is detected, it will be used.
+    ACC_DEVICE_NUM
+        The GPU to use. If not defined, the first GPU will be used.
+
     Notes
     -----
     Unweighted UniFrac was originally described in [1]_. Variance Adjusted
@@ -861,6 +951,15 @@ def unweighted_fp32_to_file(table: str,
     ValueError
         If the table does not appear to be BIOM-Format v2.1.
         If the phylogeny does not appear to be in Newick format.
+
+    Environment variables
+    ---------------------
+    OMP_NUM_THREADS
+        Number of CPU cores to use. If not defined, use all detected cores.
+    UNIFRAC_USE_GPU
+        Enable or disable GPU offload. If not defined, if a NVIDIA GPU is detected, it will be used.
+    ACC_DEVICE_NUM
+        The GPU to use. If not defined, the first GPU will be used.
 
     Notes
     -----
@@ -938,6 +1037,15 @@ def weighted_normalized_to_file(table: str,
         If the table does not appear to be BIOM-Format v2.1.
         If the phylogeny does not appear to be in Newick format.
 
+    Environment variables
+    ---------------------
+    OMP_NUM_THREADS
+        Number of CPU cores to use. If not defined, use all detected cores.
+    UNIFRAC_USE_GPU
+        Enable or disable GPU offload. If not defined, if a NVIDIA GPU is detected, it will be used.
+    ACC_DEVICE_NUM
+        The GPU to use. If not defined, the first GPU will be used.
+
     Notes
     -----
     Weighted UniFrac was originally described in [1]_. Variance Adjusted
@@ -1012,6 +1120,15 @@ def weighted_normalized_fp32_to_file(table: str,
     ValueError
         If the table does not appear to be BIOM-Format v2.1.
         If the phylogeny does not appear to be in Newick format.
+
+    Environment variables
+    ---------------------
+    OMP_NUM_THREADS
+        Number of CPU cores to use. If not defined, use all detected cores.
+    UNIFRAC_USE_GPU
+        Enable or disable GPU offload. If not defined, if a NVIDIA GPU is detected, it will be used.
+    ACC_DEVICE_NUM
+        The GPU to use. If not defined, the first GPU will be used.
 
     Notes
     -----
@@ -1088,6 +1205,15 @@ def weighted_unnormalized_to_file(table: str,
         If the table does not appear to be BIOM-Format v2.1.
         If the phylogeny does not appear to be in Newick format.
 
+    Environment variables
+    ---------------------
+    OMP_NUM_THREADS
+        Number of CPU cores to use. If not defined, use all detected cores.
+    UNIFRAC_USE_GPU
+        Enable or disable GPU offload. If not defined, if a NVIDIA GPU is detected, it will be used.
+    ACC_DEVICE_NUM
+        The GPU to use. If not defined, the first GPU will be used.
+
     Notes
     -----
     Weighted UniFrac was originally described in [1]_. Variance Adjusted
@@ -1162,6 +1288,15 @@ def weighted_unnormalized_fp32_to_file(table: str,
     ValueError
         If the table does not appear to be BIOM-Format v2.1.
         If the phylogeny does not appear to be in Newick format.
+
+    Environment variables
+    ---------------------
+    OMP_NUM_THREADS
+        Number of CPU cores to use. If not defined, use all detected cores.
+    UNIFRAC_USE_GPU
+        Enable or disable GPU offload. If not defined, if a NVIDIA GPU is detected, it will be used.
+    ACC_DEVICE_NUM
+        The GPU to use. If not defined, the first GPU will be used.
 
     Notes
     -----
@@ -1243,6 +1378,15 @@ def generalized_to_file(table: str,
     ValueError
         If the table does not appear to be BIOM-Format v2.1.
         If the phylogeny does not appear to be in Newick format.
+
+    Environment variables
+    ---------------------
+    OMP_NUM_THREADS
+        Number of CPU cores to use. If not defined, use all detected cores.
+    UNIFRAC_USE_GPU
+        Enable or disable GPU offload. If not defined, if a NVIDIA GPU is detected, it will be used.
+    ACC_DEVICE_NUM
+        The GPU to use. If not defined, the first GPU will be used.
 
     Notes
     -----
@@ -1342,6 +1486,15 @@ def generalized_fp32_to_file(table: str,
     ValueError
         If the table does not appear to be BIOM-Format v2.1.
         If the phylogeny does not appear to be in Newick format.
+
+    Environment variables
+    ---------------------
+    OMP_NUM_THREADS
+        Number of CPU cores to use. If not defined, use all detected cores.
+    UNIFRAC_USE_GPU
+        Enable or disable GPU offload. If not defined, if a NVIDIA GPU is detected, it will be used.
+    ACC_DEVICE_NUM
+        The GPU to use. If not defined, the first GPU will be used.
 
     Notes
     -----

--- a/unifrac/_methods.py
+++ b/unifrac/_methods.py
@@ -87,7 +87,8 @@ def unweighted(table: Union[str, Table],
                phylogeny: Union[str, TreeNode, BP],
                threads: int = 1,
                variance_adjusted: bool = False,
-               bypass_tips: bool = False) -> skbio.DistanceMatrix:
+               bypass_tips: bool = False,
+               n_substeps: int = 1) -> skbio.DistanceMatrix:
     """Compute Unweighted UniFrac
 
     Parameters
@@ -97,12 +98,14 @@ def unweighted(table: Union[str, Table],
     phylogeny : str
         A filepath to a Newick formatted tree.
     threads : int, optional
-        The number of threads to split it into. Default of 1.
+        Deprecated, no-op.
     variance_adjusted : bool, optional
         Adjust for varianace or not. Default is False.
     bypass_tips : bool, optional
         Bypass the tips of the tree in the computation. This reduces compute
         by about 50%, but is an approximation.
+    n_substeps : int, optional
+        Internally split the problem in n substeps for reduced memory footprint.
 
     Returns
     -------
@@ -135,14 +138,15 @@ def unweighted(table: Union[str, Table],
        phylogeny. BMC Bioinformatics 12:118 (2011).
     """
     return _call_ssu(table, phylogeny, 'unweighted', variance_adjusted, 1.0,
-                     bypass_tips, threads)
+                     bypass_tips, n_substeps)
 
 
 def unweighted_fp32(table: Union[str, Table],
                     phylogeny: Union[str, TreeNode, BP],
                     threads: int = 1,
                     variance_adjusted: bool = False,
-                    bypass_tips: bool = False) -> skbio.DistanceMatrix:
+                    bypass_tips: bool = False,
+                    n_substeps: int = 1) -> skbio.DistanceMatrix:
     """Compute Unweighted UniFrac using fp32 math
 
     Parameters
@@ -152,12 +156,14 @@ def unweighted_fp32(table: Union[str, Table],
     phylogeny : str
         A filepath to a Newick formatted tree.
     threads : int, optional
-        The number of threads to split it into. Default of 1.
+        Deprecated, no-op.
     variance_adjusted : bool, optional
         Adjust for varianace or not. Default is False.
     bypass_tips : bool, optional
         Bypass the tips of the tree in the computation. This reduces compute
         by about 50%, but is an approximation.
+    n_substeps : int, optional
+        Internally split the problem in n substeps for reduced memory footprint.
 
     Returns
     -------
@@ -190,14 +196,15 @@ def unweighted_fp32(table: Union[str, Table],
        phylogeny. BMC Bioinformatics 12:118 (2011).
     """
     return _call_ssu(table, phylogeny, 'unweighted_fp32', variance_adjusted,
-                     1.0, bypass_tips, threads)
+                     1.0, bypass_tips, n_substeps)
 
 
 def weighted_normalized(table: Union[str, Table],
                         phylogeny: Union[str, TreeNode, BP],
                         threads: int = 1,
                         variance_adjusted: bool = False,
-                        bypass_tips: bool = False) -> skbio.DistanceMatrix:
+                        bypass_tips: bool = False,
+                        n_substeps: int = 1) -> skbio.DistanceMatrix:
     """Compute weighted normalized UniFrac
 
     Parameters
@@ -207,12 +214,14 @@ def weighted_normalized(table: Union[str, Table],
     phylogeny : str
         A filepath to a Newick formatted tree.
     threads : int, optional
-        The number of threads to split it into. Default of 1.
+        Deprecated, no-op.
     variance_adjusted : bool, optional
         Adjust for varianace or not. Default is False.
     bypass_tips : bool, optional
         Bypass the tips of the tree in the computation. This reduces compute
         by about 50%, but is an approximation.
+    n_substeps : int, optional
+        Internally split the problem in n substeps for reduced memory footprint.
 
     Returns
     -------
@@ -244,14 +253,15 @@ def weighted_normalized(table: Union[str, Table],
        phylogeny. BMC Bioinformatics 12:118 (2011).
     """
     return _call_ssu(str(table), str(phylogeny), 'weighted_normalized',
-                     variance_adjusted, 1.0, bypass_tips, threads)
+                     variance_adjusted, 1.0, bypass_tips, n_substeps)
 
 
 def weighted_normalized_fp32(table: Union[str, Table],
                              phylogeny: Union[str, TreeNode, BP],
                              threads: int = 1,
                              variance_adjusted: bool = False,
-                             bypass_tips: bool = False
+                             bypass_tips: bool = False,
+                             n_substeps: int = 1
                              ) -> skbio.DistanceMatrix:
     """Compute weighted normalized UniFrac using fp32 math
 
@@ -262,12 +272,14 @@ def weighted_normalized_fp32(table: Union[str, Table],
     phylogeny : str
         A filepath to a Newick formatted tree.
     threads : int, optional
-        The number of threads to split it into. Default of 1.
+        Deprecated, no-op.
     variance_adjusted : bool, optional
         Adjust for varianace or not. Default is False.
     bypass_tips : bool, optional
         Bypass the tips of the tree in the computation. This reduces compute
         by about 50%, but is an approximation.
+    n_substeps : int, optional
+        Internally split the problem in n substeps for reduced memory footprint.
 
     Returns
     -------
@@ -299,14 +311,15 @@ def weighted_normalized_fp32(table: Union[str, Table],
        phylogeny. BMC Bioinformatics 12:118 (2011).
     """
     return _call_ssu(str(table), str(phylogeny), 'weighted_normalized_fp32',
-                     variance_adjusted, 1.0, bypass_tips, threads)
+                     variance_adjusted, 1.0, bypass_tips, n_substeps)
 
 
 def weighted_unnormalized(table: Union[str, Table],
                           phylogeny: Union[str, TreeNode, BP],
                           threads: int = 1,
                           variance_adjusted: bool = False,
-                          bypass_tips: bool = False) -> skbio.DistanceMatrix:
+                          bypass_tips: bool = False,
+                          n_substeps: int = 1) -> skbio.DistanceMatrix:
     # noqa
     """Compute weighted unnormalized UniFrac
 
@@ -317,12 +330,14 @@ def weighted_unnormalized(table: Union[str, Table],
     phylogeny : str
         A filepath to a Newick formatted tree.
     threads : int, optional
-        The number of threads to split it into. Default is 1.
+        Deprecated, no-op..
     variance_adjusted : bool, optional
         Adjust for varianace or not. Default is False.
     bypass_tips : bool, optional
         Bypass the tips of the tree in the computation. This reduces compute
         by about 50%, but is an approximation.
+    n_substeps : int, optional
+        Internally split the problem in n substeps for reduced memory footprint.
 
     Returns
     -------
@@ -354,14 +369,15 @@ def weighted_unnormalized(table: Union[str, Table],
        phylogeny. BMC Bioinformatics 12:118 (2011).
     """
     return _call_ssu(str(table), str(phylogeny), 'weighted_unnormalized',
-                     variance_adjusted, 1.0, bypass_tips, threads)
+                     variance_adjusted, 1.0, bypass_tips, n_substeps)
 
 
 def weighted_unnormalized_fp32(table: Union[str, Table],
                                phylogeny: Union[str, TreeNode, BP],
                                threads: int = 1,
                                variance_adjusted: bool = False,
-                               bypass_tips: bool = False
+                               bypass_tips: bool = False, 
+                               n_substeps: int = 1
                                ) -> skbio.DistanceMatrix:
     # noqa
     """Compute weighted unnormalized UniFrac using fp32 math
@@ -373,12 +389,14 @@ def weighted_unnormalized_fp32(table: Union[str, Table],
     phylogeny : str
         A filepath to a Newick formatted tree.
     threads : int, optional
-        The number of threads to split it into. Default is 1.
+        TDeprecated, no-op..
     variance_adjusted : bool, optional
         Adjust for varianace or not. Default is False.
     bypass_tips : bool, optional
         Bypass the tips of the tree in the computation. This reduces compute
         by about 50%, but is an approximation.
+    n_substeps : int, optional
+        Internally split the problem in n substeps for reduced memory footprint.
 
     Returns
     -------
@@ -410,7 +428,7 @@ def weighted_unnormalized_fp32(table: Union[str, Table],
        phylogeny. BMC Bioinformatics 12:118 (2011).
     """
     return _call_ssu(str(table), str(phylogeny), 'weighted_unnormalized_fp32',
-                     variance_adjusted, 1.0, bypass_tips, threads)
+                     variance_adjusted, 1.0, bypass_tips, n_substeps)
 
 
 def generalized(table: Union[str, Table],
@@ -418,7 +436,8 @@ def generalized(table: Union[str, Table],
                 threads: int = 1,
                 alpha: float = 1.0,
                 variance_adjusted: bool = False,
-                bypass_tips: bool = False) -> skbio.DistanceMatrix:
+                bypass_tips: bool = False, 
+                n_substeps: int = 1) -> skbio.DistanceMatrix:
     """Compute Generalized UniFrac
 
     Parameters
@@ -428,7 +447,7 @@ def generalized(table: Union[str, Table],
     phylogeny : str
         A filepath to a Newick formatted tree.
     threads : int, optional
-        The number of threads to split it into. Default is 1
+        Deprecated, no-op.
     alpha : float, optional
         The level of contribution of high abundance branches. Higher alpha
         increases the contribution of from high abundance branches while lower
@@ -439,6 +458,8 @@ def generalized(table: Union[str, Table],
     bypass_tips : bool, optional
         Bypass the tips of the tree in the computation. This reduces compute
         by about 50%, but is an approximation.
+    n_substeps : int, optional
+        Internally split the problem in n substeps for reduced memory footprint.
 
     Returns
     -------
@@ -481,10 +502,10 @@ def generalized(table: Union[str, Table],
              "optimized.",
              Warning)
         return weighted_normalized(table, phylogeny, threads,
-                                   variance_adjusted)
+                                   variance_adjusted, bypass_tips, n_substeps)
     else:
         return _call_ssu(str(table), str(phylogeny), 'generalized',
-                         variance_adjusted, alpha, bypass_tips, threads)
+                         variance_adjusted, alpha, bypass_tips, n_substeps)
 
 
 def generalized_fp32(table: Union[str, Table],
@@ -492,7 +513,8 @@ def generalized_fp32(table: Union[str, Table],
                      threads: int = 1,
                      alpha: float = 1.0,
                      variance_adjusted: bool = False,
-                     bypass_tips: bool = False) -> skbio.DistanceMatrix:
+                     bypass_tips: bool = False, 
+                     n_substeps: int = 1) -> skbio.DistanceMatrix:
     """Compute Generalized UniFrac using fp32 math
 
     Parameters
@@ -502,7 +524,7 @@ def generalized_fp32(table: Union[str, Table],
     phylogeny : str
         A filepath to a Newick formatted tree.
     threads : int, optional
-        The number of threads to split it into. Default is 1
+        Deprecated, no-op.
     alpha : float, optional
         The level of contribution of high abundance branches. Higher alpha
         increases the contribution of from high abundance branches while lower
@@ -513,6 +535,8 @@ def generalized_fp32(table: Union[str, Table],
     bypass_tips : bool, optional
         Bypass the tips of the tree in the computation. This reduces compute
         by about 50%, but is an approximation.
+    n_substeps : int, optional
+        Internally split the problem in n substeps for reduced memory footprint.
 
     Returns
     -------
@@ -555,10 +579,10 @@ def generalized_fp32(table: Union[str, Table],
              "optimized.",
              Warning)
         return weighted_normalized_fp32(table, phylogeny, threads,
-                                        variance_adjusted)
+                                        variance_adjusted, bypass_tips, n_substeps)
     else:
         return _call_ssu(str(table), str(phylogeny), 'generalized_fp32',
-                         variance_adjusted, alpha, bypass_tips, threads)
+                         variance_adjusted, alpha, bypass_tips, n_substeps)
 
 
 METHODS = {'unweighted': unweighted,
@@ -574,7 +598,8 @@ METHODS = {'unweighted': unweighted,
 def meta(tables: tuple, phylogenies: tuple, weights: tuple = None,
          consolidation: str = None, method: str = None,
          threads: int = 1, variance_adjusted: bool = False,
-         alpha: float = None, bypass_tips: bool = False) -> \
+         alpha: float = None, bypass_tips: bool = False, 
+         n_substeps: int = 1) -> \
          skbio.DistanceMatrix:
     """Compute meta UniFrac
 
@@ -600,7 +625,7 @@ def meta(tables: tuple, phylogenies: tuple, weights: tuple = None,
         'weighted_unnormalized_fp32', 'weighted_normalized',
         'weighted_normalized_fp32', 'generalized' and 'generalized_fp32'.
     threads : int, optional
-        The number of threads to split it into. Default is 1
+        TDeprecated, no-op.
     bypass_tips : bool, optional
         Bypass the tips of the tree in the computation. This reduces compute
         by about 50%, but is an approximation.
@@ -611,6 +636,8 @@ def meta(tables: tuple, phylogenies: tuple, weights: tuple = None,
         range [0, 1]. Default is 1.0
     variance_adjusted : bool, optional
         Adjust for varianace or not. Default is False.
+    n_substeps : int, optional
+        Internally split the problem in n substeps for reduced memory footprint.
 
     Returns
     -------
@@ -686,7 +713,7 @@ def meta(tables: tuple, phylogenies: tuple, weights: tuple = None,
                          "is set as 'generalized', the selected method is "
                          "'%s'." % method)
 
-    kwargs = {'threads': threads,
+    kwargs = {'n_substeps': n_substeps,
               'bypass_tips': bypass_tips,
               'variance_adjusted': variance_adjusted}
     if alpha is not None:
@@ -713,7 +740,8 @@ def unweighted_to_file(table: str,
                        variance_adjusted: bool = False,
                        bypass_tips: bool = False,
                        format: str = "hdf5",
-                       buf_dirname: str = "") -> str:
+                       buf_dirname: str = "", 
+                       n_substeps: int = 1) -> str:
     """Compute Unweighted UniFrac and write to file
 
     Parameters
@@ -729,7 +757,7 @@ def unweighted_to_file(table: str,
         if set to 0, no PCoA is computed.
         Defaults of 10.
     threads : int, optional
-        The number of threads to split it into. Default of 1.
+        Deprecated, no-op.
     variance_adjusted : bool, optional
         Adjust for varianace or not. Default is False.
     bypass_tips : bool, optional
@@ -740,6 +768,8 @@ def unweighted_to_file(table: str,
     buf_dirname : str, optional
         If set, the directory where the disk buffer is hosted,
         can be used to reduce the amount of memory needed.
+    n_substeps : int, optional
+        Internally split the problem in n substeps for reduced memory footprint.
 
     Returns
     -------
@@ -774,7 +804,7 @@ def unweighted_to_file(table: str,
     """
     return _call_ssu_to_file(table, phylogeny, out_filename,
                              'unweighted',
-                             variance_adjusted, 1.0, bypass_tips, threads,
+                             variance_adjusted, 1.0, bypass_tips, n_substeps,
                              format, pcoa_dims, buf_dirname)
 
 
@@ -786,7 +816,8 @@ def unweighted_fp32_to_file(table: str,
                             variance_adjusted: bool = False,
                             bypass_tips: bool = False,
                             format: str = "hdf5",
-                            buf_dirname: str = "") -> str:
+                            buf_dirname: str = "", 
+                            n_substeps: int = 1) -> str:
     """Compute Unweighted UniFrac using fp32 math and write to file
 
     Parameters
@@ -802,7 +833,7 @@ def unweighted_fp32_to_file(table: str,
         if set to 0, no PCoA is computed.
         Defaults of 10.
     threads : int, optional
-        The number of threads to split it into. Default of 1.
+        Deprecated, no-op.
     variance_adjusted : bool, optional
         Adjust for varianace or not. Default is False.
     bypass_tips : bool, optional
@@ -813,6 +844,8 @@ def unweighted_fp32_to_file(table: str,
     buf_dirname : str, optional
         If set, the directory where the disk buffer is hosted,
         can be used to reduce the amount of memory needed.
+    n_substeps : int, optional
+        Internally split the problem in n substeps for reduced memory footprint.
 
     Returns
     -------
@@ -847,7 +880,7 @@ def unweighted_fp32_to_file(table: str,
     """
     return _call_ssu_to_file(table, phylogeny, out_filename,
                              'unweighted_fp32',
-                             variance_adjusted, 1.0, bypass_tips, threads,
+                             variance_adjusted, 1.0, bypass_tips, n_substeps,
                              format, pcoa_dims, buf_dirname)
 
 
@@ -859,7 +892,8 @@ def weighted_normalized_to_file(table: str,
                                 variance_adjusted: bool = False,
                                 bypass_tips: bool = False,
                                 format: str = "hdf5",
-                                buf_dirname: str = "") -> str:
+                                buf_dirname: str = "", 
+                                n_substeps: int = 1) -> str:
     """Compute weighted normalized UniFrac and write to file
 
     Parameters
@@ -875,7 +909,7 @@ def weighted_normalized_to_file(table: str,
         if set to 0, no PCoA is computed.
         Defaults of 10.
     threads : int, optional
-        The number of threads to split it into. Default of 1.
+        Deprecated, no-op.
     variance_adjusted : bool, optional
         Adjust for varianace or not. Default is False.
     bypass_tips : bool, optional
@@ -886,6 +920,8 @@ def weighted_normalized_to_file(table: str,
     buf_dirname : str, optional
         If set, the directory where the disk buffer is hosted,
         can be used to reduce the amount of memory needed.
+    n_substeps : int, optional
+        Internally split the problem in n substeps for reduced memory footprint.
 
     Returns
     -------
@@ -919,7 +955,7 @@ def weighted_normalized_to_file(table: str,
     """
     return _call_ssu_to_file(table, phylogeny, out_filename,
                              'weighted_normalized',
-                             variance_adjusted, 1.0, bypass_tips, threads,
+                             variance_adjusted, 1.0, bypass_tips, n_substeps,
                              format, pcoa_dims, buf_dirname)
 
 
@@ -931,7 +967,8 @@ def weighted_normalized_fp32_to_file(table: str,
                                      variance_adjusted: bool = False,
                                      bypass_tips: bool = False,
                                      format: str = "hdf5",
-                                     buf_dirname: str = "") -> str:
+                                     buf_dirname: str = "", 
+                                     n_substeps: int = 1) -> str:
     """Compute weighted normalized UniFrac using fp32 math and write to file
 
     Parameters
@@ -947,7 +984,7 @@ def weighted_normalized_fp32_to_file(table: str,
         if set to 0, no PCoA is computed.
         Defaults of 10.
     threads : int, optional
-        The number of threads to split it into. Default of 1.
+        Deprecated, no-op.
     variance_adjusted : bool, optional
         Adjust for varianace or not. Default is False.
     bypass_tips : bool, optional
@@ -958,6 +995,8 @@ def weighted_normalized_fp32_to_file(table: str,
     buf_dirname : str, optional
         If set, the directory where the disk buffer is hosted,
         can be used to reduce the amount of memory needed.
+    n_substeps : int, optional
+        Internally split the problem in n substeps for reduced memory footprint.
 
     Returns
     -------
@@ -991,7 +1030,7 @@ def weighted_normalized_fp32_to_file(table: str,
     """
     return _call_ssu_to_file(table, phylogeny, out_filename,
                              'weighted_normalized_fp32',
-                             variance_adjusted, 1.0, bypass_tips, threads,
+                             variance_adjusted, 1.0, bypass_tips, n_substeps,
                              format, pcoa_dims, buf_dirname)
 
 
@@ -1003,7 +1042,8 @@ def weighted_unnormalized_to_file(table: str,
                                   variance_adjusted: bool = False,
                                   bypass_tips: bool = False,
                                   format: str = "hdf5",
-                                  buf_dirname: str = "") -> str:
+                                  buf_dirname: str = "", 
+                                  n_substeps: int = 1) -> str:
     """Compute weighted unnormalized UniFrac and write it to file
 
     Parameters
@@ -1019,7 +1059,7 @@ def weighted_unnormalized_to_file(table: str,
         if set to 0, no PCoA is computed.
         Defaults of 10.
     threads : int, optional
-        The number of threads to split it into. Default is 1.
+        TDeprecated, no-op..
     variance_adjusted : bool, optional
         Adjust for varianace or not. Default is False.
     bypass_tips : bool, optional
@@ -1030,6 +1070,8 @@ def weighted_unnormalized_to_file(table: str,
     buf_dirname : str, optional
         If set, the directory where the disk buffer is hosted,
         can be used to reduce the amount of memory needed.
+    n_substeps : int, optional
+        Internally split the problem in n substeps for reduced memory footprint.
 
     Returns
     -------
@@ -1063,7 +1105,7 @@ def weighted_unnormalized_to_file(table: str,
     """
     return _call_ssu_to_file(table, phylogeny, out_filename,
                              'weighted_unnormalized',
-                             variance_adjusted, 1.0, bypass_tips, threads,
+                             variance_adjusted, 1.0, bypass_tips, n_substeps,
                              format, pcoa_dims, buf_dirname)
 
 
@@ -1075,7 +1117,8 @@ def weighted_unnormalized_fp32_to_file(table: str,
                                        variance_adjusted: bool = False,
                                        bypass_tips: bool = False,
                                        format: str = "hdf5",
-                                       buf_dirname: str = "") -> str:
+                                       buf_dirname: str = "", 
+                                       n_substeps: int = 1) -> str:
     """Compute weighted unnormalized UniFrac using fp32 math and write it to file
 
     Parameters
@@ -1091,7 +1134,7 @@ def weighted_unnormalized_fp32_to_file(table: str,
         if set to 0, no PCoA is computed.
         Defaults of 10.
     threads : int, optional
-        The number of threads to split it into. Default is 1.
+        TDeprecated, no-op..
     variance_adjusted : bool, optional
         Adjust for varianace or not. Default is False.
     bypass_tips : bool, optional
@@ -1102,6 +1145,8 @@ def weighted_unnormalized_fp32_to_file(table: str,
     buf_dirname : str, optional
         If set, the directory where the disk buffer is hosted,
         can be used to reduce the amount of memory needed.
+    n_substeps : int, optional
+        Internally split the problem in n substeps for reduced memory footprint.
 
     Returns
     -------
@@ -1135,7 +1180,7 @@ def weighted_unnormalized_fp32_to_file(table: str,
     """
     return _call_ssu_to_file(table, phylogeny, out_filename,
                              'weighted_unnormalized_fp32',
-                             variance_adjusted, 1.0, bypass_tips, threads,
+                             variance_adjusted, 1.0, bypass_tips, n_substeps,
                              format, pcoa_dims, buf_dirname)
 
 
@@ -1148,7 +1193,8 @@ def generalized_to_file(table: str,
                         variance_adjusted: bool = False,
                         bypass_tips: bool = False,
                         format: str = "hdf5",
-                        buf_dirname: str = "") -> str:
+                        buf_dirname: str = "", 
+                        n_substeps: int = 1) -> str:
     """Compute Generalized UniFrac and write to file
 
     Parameters
@@ -1164,7 +1210,7 @@ def generalized_to_file(table: str,
         if set to 0, no PCoA is computed.
         Defaults of 10.
     threads : int, optional
-        The number of threads to split it into. Default is 1
+        TDeprecated, no-op.
     alpha : float, optional
         The level of contribution of high abundance branches. Higher alpha
         increases the contribution of from high abundance branches while lower
@@ -1180,6 +1226,8 @@ def generalized_to_file(table: str,
     buf_dirname : str, optional
         If set, the directory where the disk buffer is hosted,
         can be used to reduce the amount of memory needed.
+    n_substeps : int, optional
+        Internally split the problem in n substeps for reduced memory footprint.
 
     Returns
     -------
@@ -1225,13 +1273,13 @@ def generalized_to_file(table: str,
         return _call_ssu_to_file(table, phylogeny, out_filename,
                                  'weighted_normalized',
                                  variance_adjusted, alpha,
-                                 bypass_tips, threads,
+                                 bypass_tips, n_substeps,
                                  format, pcoa_dims, buf_dirname)
     else:
         return _call_ssu_to_file(table, phylogeny, out_filename,
                                  'generalized',
                                  variance_adjusted, alpha,
-                                 bypass_tips, threads,
+                                 bypass_tips, n_substeps,
                                  format, pcoa_dims, buf_dirname)
 
 
@@ -1244,7 +1292,8 @@ def generalized_fp32_to_file(table: str,
                              variance_adjusted: bool = False,
                              bypass_tips: bool = False,
                              format: str = "hdf5",
-                             buf_dirname: str = "") -> str:
+                             buf_dirname: str = "", 
+                             n_substeps: int = 1) -> str:
     """Compute Generalized UniFrac using fp32 math and write to file
 
     Parameters
@@ -1260,7 +1309,7 @@ def generalized_fp32_to_file(table: str,
         if set to 0, no PCoA is computed.
         Defaults of 10.
     threads : int, optional
-        The number of threads to split it into. Default is 1
+        TDeprecated, no-op.
     alpha : float, optional
         The level of contribution of high abundance branches. Higher alpha
         increases the contribution of from high abundance branches while lower
@@ -1276,6 +1325,8 @@ def generalized_fp32_to_file(table: str,
     buf_dirname : str, optional
         If set, the directory where the disk buffer is hosted,
         can be used to reduce the amount of memory needed.
+    n_substeps : int, optional
+        Internally split the problem in n substeps for reduced memory footprint.
 
     Returns
     -------
@@ -1321,13 +1372,13 @@ def generalized_fp32_to_file(table: str,
         return _call_ssu_to_file(table, phylogeny, out_filename,
                                  'weighted_normalized_fp32',
                                  variance_adjusted, alpha,
-                                 bypass_tips, threads,
+                                 bypass_tips, n_substeps,
                                  format, pcoa_dims, buf_dirname)
     else:
         return _call_ssu_to_file(table, phylogeny, out_filename,
                                  'generalized_fp32',
                                  variance_adjusted, alpha,
-                                 bypass_tips, threads,
+                                 bypass_tips, n_substeps,
                                  format, pcoa_dims, buf_dirname)
 
 #

--- a/unifrac/_methods.py
+++ b/unifrac/_methods.py
@@ -126,7 +126,7 @@ def unweighted(table: Union[str, Table],
     OMP_NUM_THREADS
         Number of CPU cores to use. If not defined, use all detected cores.
     UNIFRAC_USE_GPU
-        Enable or disable GPU offload. If not defined, if a NVIDIA GPU is detected, it will be used.
+        Enable or disable GPU offload. If not defined, autodetect.
     ACC_DEVICE_NUM
         The GPU to use. If not defined, the first GPU will be used.
 
@@ -193,7 +193,7 @@ def unweighted_fp32(table: Union[str, Table],
     OMP_NUM_THREADS
         Number of CPU cores to use. If not defined, use all detected cores.
     UNIFRAC_USE_GPU
-        Enable or disable GPU offload. If not defined, if a NVIDIA GPU is detected, it will be used.
+        Enable or disable GPU offload. If not defined, autodetect.
     ACC_DEVICE_NUM
         The GPU to use. If not defined, the first GPU will be used.
 
@@ -260,7 +260,7 @@ def weighted_normalized(table: Union[str, Table],
     OMP_NUM_THREADS
         Number of CPU cores to use. If not defined, use all detected cores.
     UNIFRAC_USE_GPU
-        Enable or disable GPU offload. If not defined, if a NVIDIA GPU is detected, it will be used.
+        Enable or disable GPU offload. If not defined, autodetect.
     ACC_DEVICE_NUM
         The GPU to use. If not defined, the first GPU will be used.
 
@@ -327,7 +327,7 @@ def weighted_normalized_fp32(table: Union[str, Table],
     OMP_NUM_THREADS
         Number of CPU cores to use. If not defined, use all detected cores.
     UNIFRAC_USE_GPU
-        Enable or disable GPU offload. If not defined, if a NVIDIA GPU is detected, it will be used.
+        Enable or disable GPU offload. If not defined, autodetect.
     ACC_DEVICE_NUM
         The GPU to use. If not defined, the first GPU will be used.
 
@@ -394,7 +394,7 @@ def weighted_unnormalized(table: Union[str, Table],
     OMP_NUM_THREADS
         Number of CPU cores to use. If not defined, use all detected cores.
     UNIFRAC_USE_GPU
-        Enable or disable GPU offload. If not defined, if a NVIDIA GPU is detected, it will be used.
+        Enable or disable GPU offload. If not defined, autodetect.
     ACC_DEVICE_NUM
         The GPU to use. If not defined, the first GPU will be used.
 
@@ -462,7 +462,7 @@ def weighted_unnormalized_fp32(table: Union[str, Table],
     OMP_NUM_THREADS
         Number of CPU cores to use. If not defined, use all detected cores.
     UNIFRAC_USE_GPU
-        Enable or disable GPU offload. If not defined, if a NVIDIA GPU is detected, it will be used.
+        Enable or disable GPU offload. If not defined, autodetect.
     ACC_DEVICE_NUM
         The GPU to use. If not defined, the first GPU will be used.
 
@@ -534,7 +534,7 @@ def generalized(table: Union[str, Table],
     OMP_NUM_THREADS
         Number of CPU cores to use. If not defined, use all detected cores.
     UNIFRAC_USE_GPU
-        Enable or disable GPU offload. If not defined, if a NVIDIA GPU is detected, it will be used.
+        Enable or disable GPU offload. If not defined, autodetect.
     ACC_DEVICE_NUM
         The GPU to use. If not defined, the first GPU will be used.
 
@@ -620,7 +620,7 @@ def generalized_fp32(table: Union[str, Table],
     OMP_NUM_THREADS
         Number of CPU cores to use. If not defined, use all detected cores.
     UNIFRAC_USE_GPU
-        Enable or disable GPU offload. If not defined, if a NVIDIA GPU is detected, it will be used.
+        Enable or disable GPU offload. If not defined, autodetect.
     ACC_DEVICE_NUM
         The GPU to use. If not defined, the first GPU will be used.
 
@@ -730,7 +730,7 @@ def meta(tables: tuple, phylogenies: tuple, weights: tuple = None,
     OMP_NUM_THREADS
         Number of CPU cores to use. If not defined, use all detected cores.
     UNIFRAC_USE_GPU
-        Enable or disable GPU offload. If not defined, if a NVIDIA GPU is detected, it will be used.
+        Enable or disable GPU offload. If not defined, autodetect.
     ACC_DEVICE_NUM
         The GPU to use. If not defined, the first GPU will be used.
 
@@ -872,7 +872,7 @@ def unweighted_to_file(table: str,
     OMP_NUM_THREADS
         Number of CPU cores to use. If not defined, use all detected cores.
     UNIFRAC_USE_GPU
-        Enable or disable GPU offload. If not defined, if a NVIDIA GPU is detected, it will be used.
+        Enable or disable GPU offload. If not defined, autodetect.
     ACC_DEVICE_NUM
         The GPU to use. If not defined, the first GPU will be used.
 
@@ -957,7 +957,7 @@ def unweighted_fp32_to_file(table: str,
     OMP_NUM_THREADS
         Number of CPU cores to use. If not defined, use all detected cores.
     UNIFRAC_USE_GPU
-        Enable or disable GPU offload. If not defined, if a NVIDIA GPU is detected, it will be used.
+        Enable or disable GPU offload. If not defined, autodetect.
     ACC_DEVICE_NUM
         The GPU to use. If not defined, the first GPU will be used.
 
@@ -1042,7 +1042,7 @@ def weighted_normalized_to_file(table: str,
     OMP_NUM_THREADS
         Number of CPU cores to use. If not defined, use all detected cores.
     UNIFRAC_USE_GPU
-        Enable or disable GPU offload. If not defined, if a NVIDIA GPU is detected, it will be used.
+        Enable or disable GPU offload. If not defined, autodetect.
     ACC_DEVICE_NUM
         The GPU to use. If not defined, the first GPU will be used.
 
@@ -1126,7 +1126,7 @@ def weighted_normalized_fp32_to_file(table: str,
     OMP_NUM_THREADS
         Number of CPU cores to use. If not defined, use all detected cores.
     UNIFRAC_USE_GPU
-        Enable or disable GPU offload. If not defined, if a NVIDIA GPU is detected, it will be used.
+        Enable or disable GPU offload. If not defined, autodetect.
     ACC_DEVICE_NUM
         The GPU to use. If not defined, the first GPU will be used.
 
@@ -1210,7 +1210,7 @@ def weighted_unnormalized_to_file(table: str,
     OMP_NUM_THREADS
         Number of CPU cores to use. If not defined, use all detected cores.
     UNIFRAC_USE_GPU
-        Enable or disable GPU offload. If not defined, if a NVIDIA GPU is detected, it will be used.
+        Enable or disable GPU offload. If not defined, autodetect.
     ACC_DEVICE_NUM
         The GPU to use. If not defined, the first GPU will be used.
 
@@ -1294,7 +1294,7 @@ def weighted_unnormalized_fp32_to_file(table: str,
     OMP_NUM_THREADS
         Number of CPU cores to use. If not defined, use all detected cores.
     UNIFRAC_USE_GPU
-        Enable or disable GPU offload. If not defined, if a NVIDIA GPU is detected, it will be used.
+        Enable or disable GPU offload. If not defined, autodetect.
     ACC_DEVICE_NUM
         The GPU to use. If not defined, the first GPU will be used.
 
@@ -1384,7 +1384,7 @@ def generalized_to_file(table: str,
     OMP_NUM_THREADS
         Number of CPU cores to use. If not defined, use all detected cores.
     UNIFRAC_USE_GPU
-        Enable or disable GPU offload. If not defined, if a NVIDIA GPU is detected, it will be used.
+        Enable or disable GPU offload. If not defined, autodetect.
     ACC_DEVICE_NUM
         The GPU to use. If not defined, the first GPU will be used.
 
@@ -1492,7 +1492,7 @@ def generalized_fp32_to_file(table: str,
     OMP_NUM_THREADS
         Number of CPU cores to use. If not defined, use all detected cores.
     UNIFRAC_USE_GPU
-        Enable or disable GPU offload. If not defined, if a NVIDIA GPU is detected, it will be used.
+        Enable or disable GPU offload. If not defined, autodetect.
     ACC_DEVICE_NUM
         The GPU to use. If not defined, the first GPU will be used.
 

--- a/unifrac/_methods.py
+++ b/unifrac/_methods.py
@@ -105,7 +105,7 @@ def unweighted(table: Union[str, Table],
         Bypass the tips of the tree in the computation. This reduces compute
         by about 50%, but is an approximation.
     n_substeps : int, optional
-        Internally split the problem in n substeps for reduced memory footprint.
+        Internally split the problem in substeps for reduced memory footprint.
 
     Returns
     -------
@@ -172,7 +172,7 @@ def unweighted_fp32(table: Union[str, Table],
         Bypass the tips of the tree in the computation. This reduces compute
         by about 50%, but is an approximation.
     n_substeps : int, optional
-        Internally split the problem in n substeps for reduced memory footprint.
+        Internally split the problem in substeps for reduced memory footprint.
 
     Returns
     -------
@@ -239,7 +239,7 @@ def weighted_normalized(table: Union[str, Table],
         Bypass the tips of the tree in the computation. This reduces compute
         by about 50%, but is an approximation.
     n_substeps : int, optional
-        Internally split the problem in n substeps for reduced memory footprint.
+        Internally split the problem in substeps for reduced memory footprint.
 
     Returns
     -------
@@ -306,7 +306,7 @@ def weighted_normalized_fp32(table: Union[str, Table],
         Bypass the tips of the tree in the computation. This reduces compute
         by about 50%, but is an approximation.
     n_substeps : int, optional
-        Internally split the problem in n substeps for reduced memory footprint.
+        Internally split the problem in substeps for reduced memory footprint.
 
     Returns
     -------
@@ -373,7 +373,7 @@ def weighted_unnormalized(table: Union[str, Table],
         Bypass the tips of the tree in the computation. This reduces compute
         by about 50%, but is an approximation.
     n_substeps : int, optional
-        Internally split the problem in n substeps for reduced memory footprint.
+        Internally split the problem in substeps for reduced memory footprint.
 
     Returns
     -------
@@ -441,7 +441,7 @@ def weighted_unnormalized_fp32(table: Union[str, Table],
         Bypass the tips of the tree in the computation. This reduces compute
         by about 50%, but is an approximation.
     n_substeps : int, optional
-        Internally split the problem in n substeps for reduced memory footprint.
+        Internally split the problem in substeps for reduced memory footprint.
 
     Returns
     -------
@@ -513,7 +513,7 @@ def generalized(table: Union[str, Table],
         Bypass the tips of the tree in the computation. This reduces compute
         by about 50%, but is an approximation.
     n_substeps : int, optional
-        Internally split the problem in n substeps for reduced memory footprint.
+        Internally split the problem in substeps for reduced memory footprint.
 
     Returns
     -------
@@ -599,7 +599,7 @@ def generalized_fp32(table: Union[str, Table],
         Bypass the tips of the tree in the computation. This reduces compute
         by about 50%, but is an approximation.
     n_substeps : int, optional
-        Internally split the problem in n substeps for reduced memory footprint.
+        Internally split the problem in substeps for reduced memory footprint.
 
     Returns
     -------
@@ -709,7 +709,7 @@ def meta(tables: tuple, phylogenies: tuple, weights: tuple = None,
     variance_adjusted : bool, optional
         Adjust for varianace or not. Default is False.
     n_substeps : int, optional
-        Internally split the problem in n substeps for reduced memory footprint.
+        Internally split the problem in substeps for reduced memory footprint.
 
     Returns
     -------
@@ -850,7 +850,7 @@ def unweighted_to_file(table: str,
         If set, the directory where the disk buffer is hosted,
         can be used to reduce the amount of memory needed.
     n_substeps : int, optional
-        Internally split the problem in n substeps for reduced memory footprint.
+        Internally split the problem in substeps for reduced memory footprint.
 
     Returns
     -------
@@ -935,7 +935,7 @@ def unweighted_fp32_to_file(table: str,
         If set, the directory where the disk buffer is hosted,
         can be used to reduce the amount of memory needed.
     n_substeps : int, optional
-        Internally split the problem in n substeps for reduced memory footprint.
+        Internally split the problem in substeps for reduced memory footprint.
 
     Returns
     -------
@@ -1020,7 +1020,7 @@ def weighted_normalized_to_file(table: str,
         If set, the directory where the disk buffer is hosted,
         can be used to reduce the amount of memory needed.
     n_substeps : int, optional
-        Internally split the problem in n substeps for reduced memory footprint.
+        Internally split the problem in substeps for reduced memory footprint.
 
     Returns
     -------
@@ -1104,7 +1104,7 @@ def weighted_normalized_fp32_to_file(table: str,
         If set, the directory where the disk buffer is hosted,
         can be used to reduce the amount of memory needed.
     n_substeps : int, optional
-        Internally split the problem in n substeps for reduced memory footprint.
+        Internally split the problem in substeps for reduced memory footprint.
 
     Returns
     -------
@@ -1188,7 +1188,7 @@ def weighted_unnormalized_to_file(table: str,
         If set, the directory where the disk buffer is hosted,
         can be used to reduce the amount of memory needed.
     n_substeps : int, optional
-        Internally split the problem in n substeps for reduced memory footprint.
+        Internally split the problem in substeps for reduced memory footprint.
 
     Returns
     -------
@@ -1272,7 +1272,7 @@ def weighted_unnormalized_fp32_to_file(table: str,
         If set, the directory where the disk buffer is hosted,
         can be used to reduce the amount of memory needed.
     n_substeps : int, optional
-        Internally split the problem in n substeps for reduced memory footprint.
+        Internally split the problem in substeps for reduced memory footprint.
 
     Returns
     -------
@@ -1362,7 +1362,7 @@ def generalized_to_file(table: str,
         If set, the directory where the disk buffer is hosted,
         can be used to reduce the amount of memory needed.
     n_substeps : int, optional
-        Internally split the problem in n substeps for reduced memory footprint.
+        Internally split the problem in substeps for reduced memory footprint.
 
     Returns
     -------
@@ -1470,7 +1470,7 @@ def generalized_fp32_to_file(table: str,
         If set, the directory where the disk buffer is hosted,
         can be used to reduce the amount of memory needed.
     n_substeps : int, optional
-        Internally split the problem in n substeps for reduced memory footprint.
+        Internally split the problem in substeps for reduced memory footprint.
 
     Returns
     -------


### PR DESCRIPTION
Document that the treads parameter has been deprecated and that users should rely on env variables.
Also add the n_substeps to preserve the past behavior.