### PR TITLE
Switch from condensed to matrix API calls

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,7 +61,7 @@ jobs:
         fi
         conda install --yes -c conda-forge -c bioconda unifrac-binaries
         # TEMP HACK: Use older version of scipy to work around scikit-bio problem
-        conda install --yes -c conda-forge -c bioconda cython "scipy<1.9" "hdf5<1.12.1" biom-format numpy "h5py<3.0.0 | >3.3.0" "scikit-bio>=0.5.1" nose
+        conda install --yes -c conda-forge -c bioconda cython "scipy<1.9" "hdf5<1.12.1" biom-format numpy "h5py<3.0.0 | >3.3.0" "scikit-bio>=0.5.7" nose
         echo "$(uname -s)"
         if [[ "$(uname -s)" == "Linux" ]];
         then

--- a/unifrac/__init__.py
+++ b/unifrac/__init__.py
@@ -27,7 +27,7 @@ from unifrac._methods import (unweighted,
                               meta,
                               h5unifrac,
                               h5pcoa)
-from unifrac._api import ssu, faith_pd, ssu_to_file, ssu_inmem
+from unifrac._api import ssu, ssu_fast, faith_pd, ssu_to_file, ssu_inmem
 
 
 __version__ = pkg_resources.get_distribution('unifrac').version
@@ -42,4 +42,4 @@ __all__ = ['unweighted', 'weighted_normalized', 'weighted_unnormalized',
            'weighted_unnormalized_fp32_to_file',
            'generalized_fp32_to_file',
            'h5unifrac', 'h5pcoa',
-           'ssu', 'faith_pd', 'ssu_to_file', 'ssu_inmem']
+           'ssu', 'ssu_fast', 'faith_pd', 'ssu_to_file', 'ssu_inmem']

--- a/unifrac/_api.pxd
+++ b/unifrac/_api.pxd
@@ -55,15 +55,25 @@ cdef extern from "api.hpp":
         char** names
         int n_parens
 
-    compute_status one_off(const char* biom_filename, const char* tree_filename, 
-                               const char* unifrac_method, bool variance_adjust, double alpha,
-                               bool bypass_tips, unsigned int n_substeps, mat** result)
+    compute_status one_off(const char* biom_filename, const char* tree_filename,
+                           const char* unifrac_method, bool variance_adjust, double alpha,
+                           bool bypass_tips, unsigned int n_substeps, mat** result)
     
-    compute_status one_off_inmem(const support_biom *table, const support_bptree *tree, 
+    compute_status one_off_matrix(const char* biom_filename, const char* tree_filename,
+                                  const char* unifrac_method, bool variance_adjust, double alpha,
+                                  bool bypass_tips, unsigned int n_substeps, const char *mmap_dir,
+                                  mat_full_fp64** result)
+
+    compute_status one_off_matrix_fp32(const char* biom_filename, const char* tree_filename,
+                                       const char* unifrac_method, bool variance_adjust, double alpha,
+                                       bool bypass_tips, unsigned int n_substeps, const char *mmap_dir,
+                                       mat_full_fp32** result)
+
+    compute_status one_off_inmem(const support_biom *table, const support_bptree *tree,
                                  const char* unifrac_method, bool variance_adjust, double alpha,
                                  bool bypass_tips, unsigned int n_substeps, mat_full_fp64** result)
 
-    compute_status one_off_inmem_fp32(const support_biom *table, const support_bptree *tree, 
+    compute_status one_off_inmem_fp32(const support_biom *table, const support_bptree *tree,
                                       const char* unifrac_method, bool variance_adjust, double alpha,
                                       bool bypass_tips, unsigned int n_substeps, mat_full_fp32** result)
 

--- a/unifrac/_api.pyx
+++ b/unifrac/_api.pyx
@@ -87,14 +87,14 @@ def ssu_inmem(object table, object tree,
         numpy_arr_fp32 = _ssu_inmem_fp32(inmem_biom, inmem_tree, met_c_string, 
                                          variance_adjust, alpha, bypass_tips, 
                                          n_substeps)
-        # validate=False would shave 5% but it's currently in skbio master
-        result_dm = skbio.DistanceMatrix(numpy_arr_fp32, table.ids())
+        result_dm = skbio.DistanceMatrix(numpy_arr_fp32, table.ids(),
+                                         validate=False)
     else:
         numpy_arr_fp64 = _ssu_inmem_fp64(inmem_biom, inmem_tree, met_c_string, 
                                          variance_adjust, alpha, bypass_tips, 
                                          n_substeps)
-        # validate=False would shave 5% but it's currently in skbio master
-        result_dm = skbio.DistanceMatrix(numpy_arr_fp64, table.ids())
+        result_dm = skbio.DistanceMatrix(numpy_arr_fp64, table.ids(),
+                                         validate=False)
    
     destroy_support_biom(inmem_biom)
     destroy_support_bptree(inmem_tree)

--- a/unifrac/_methods.py
+++ b/unifrac/_methods.py
@@ -38,7 +38,7 @@ def is_biom_v210(f, ids=None):
         if tuple(version) != (2, 1):
             return False
 
-        if ids!=None:
+        if ids is not None:
             for idel in fp['sample/ids']:
                 ids.append(idel.decode('ascii'))
 
@@ -61,7 +61,7 @@ def _call_ssu(table, phylogeny, *args):
     if isinstance(table, Table) and isinstance(phylogeny, (TreeNode, BP)):
         return qsu.ssu_inmem(table, phylogeny, *args)
     elif isinstance(table, str) and isinstance(phylogeny, str):
-        ids=[]
+        ids = []
         _validate(table, phylogeny, ids)
         return qsu.ssu_fast(table, phylogeny, ids, *args)
     else:

--- a/unifrac/_methods.py
+++ b/unifrac/_methods.py
@@ -40,7 +40,10 @@ def is_biom_v210(f, ids=None):
 
         if ids is not None:
             for idel in fp['sample/ids']:
-                ids.append(idel.decode('ascii'))
+                if isinstance(idel, bytes):
+                    ids.append(idel.decode('ascii'))
+                else:
+                    ids.append(idel)
 
     return True
 


### PR DESCRIPTION
Using condensed form requires several memory copies, which is both slower and uses more memory that using the matrix data layout.
The matrix varion of the API has been available in all the versions of unifrac-binaries.
We also disable the validation of the uffer in skbio, which requires at least 0.5.7.
