### PR TITLE
Switch h5unifrac_all to lazy load semantics 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -121,6 +121,8 @@ jobs:
         python -c "import unifrac,skbio; dm = skbio.DistanceMatrix.read('ci/test.dm'); dm_u=unifrac.h5unifrac('ci/test2.dm.h5'); t=abs(dm_u.data-dm.data).max(); print(t); assert t < 0.1"
         python -c "import unifrac; st_l=unifrac.h5permanova_dict('ci/test2.dm.h5'); assert len(st_l) == 1"
         python -c "import unifrac; pc=unifrac.h5pcoa('ci/test3.dm.h5'); print(pc); assert len(pc.eigvals) == 2"
+        ssu -i unifrac/tests/data/crawford.biom -t unifrac/tests/data/crawford.tre --pcoa 3 --mode multi --subsample-depth 2 --n-subsamples 10 -r hdf5 -o ci/test4.dm.h5 -m unweighted
+        python -c "import unifrac; dm_u=unifrac.h5unifrac_all('ci/test4.dm.h5'); assert len(dm_u) == 10; print(dm_u[0]); print(dm_u[4]); print(dm_u[9]); dm_u.close(); assert len(dm_u) == 0"
         if [[ "$(uname -s)" == "Linux" ]]; 
         then
           MD5=md5sum

--- a/unifrac/_methods.py
+++ b/unifrac/_methods.py
@@ -2592,6 +2592,15 @@ class H5UnifracTuple(collections.abc.Sequence):
             self.nels = i
         return self.nels
 
+    def close(self):
+        """Explicitly close the underlying file descriptor"""
+        self.f_u.close()
+        # invalidate all other cache values
+        self.order = None
+        self.nels = 0
+        self.cached_idx = None
+        self.cached_el = None
+
 
 def h5unifrac_all(h5file: str) -> H5UnifracTuple:
     """Read all UniFrac distance matrices from a hdf5 file

--- a/unifrac/_methods.py
+++ b/unifrac/_methods.py
@@ -2575,14 +2575,14 @@ class H5UnifracTuple(collections.abc.Sequence):
             i = 0
             if 'matrix' in self.f_u.keys():
                 # single format
-                i= 1
+                i = 1
             else:
                 # multi format
                 while 'matrix:%i' % i in self.f_u.keys():
                     i = i + 1
             self.nels = i
         return self.nels
-    
+
 
 def h5unifrac_all(h5file: str) -> H5UnifracTuple:
     """Read all UniFrac distance matrices from a hdf5 file


### PR DESCRIPTION
Multi-unifrac HDF5 files can be huge.
The old eager semantics could make it impossible to load everything in memory.
The new semantics reads the data in memory only as-needed.

The major side effect is that the HDF5 is open (on read-only mode) for the lifetime of the returned object.