### PR TITLE
Update arguments name used in beta_diversity in tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ import sys
 PREFIX = os.environ.get('PREFIX', "")
 
 base = ["cython >= 0.26", "biom-format", "numpy", "h5py >= 3.3.0",
-        "scikit-bio >= 0.5.8", "iow"]
+        "scikit-bio >= 0.6.0", "iow"]
 
 test = ["nose", "flake8"]
 

--- a/unifrac/tests/test_api.py
+++ b/unifrac/tests/test_api.py
@@ -37,7 +37,7 @@ class UnifracAPITests(unittest.TestCase):
         otu_ids = table.ids(axis='observation')
         cnts = table.matrix_data.astype(int).toarray().T
         exp = skbio.diversity.beta_diversity('unweighted_unifrac', cnts,
-                                             ids=ids, otu_ids=otu_ids,
+                                             ids=ids, taxa=otu_ids,
                                              tree=tree)
         obs = ssu_inmem(table, tree, 'unweighted', False, 1.0,
                         False, 1)
@@ -57,7 +57,7 @@ class UnifracAPITests(unittest.TestCase):
         otu_ids = table.ids(axis='observation')
         cnts = table.matrix_data.astype(int).toarray().T
         exp = skbio.diversity.beta_diversity('unweighted_unifrac', cnts,
-                                             ids=ids, otu_ids=otu_ids,
+                                             ids=ids, taxa=otu_ids,
                                              tree=tree)
         obs = ssu_inmem(table, tree, 'unweighted_fp32', False, 1.0,
                         False, 1)
@@ -77,7 +77,7 @@ class UnifracAPITests(unittest.TestCase):
         otu_ids = table.ids(axis='observation')
         cnts = table.matrix_data.astype(int).toarray().T
         exp = skbio.diversity.beta_diversity('unweighted_unifrac', cnts,
-                                             ids=ids, otu_ids=otu_ids,
+                                             ids=ids, taxa=otu_ids,
                                              tree=tree)
         obs = ssu_inmem(table, tree, 'unweighted_fp64', False, 1.0,
                         False, 1)
@@ -102,7 +102,7 @@ class UnifracAPITests(unittest.TestCase):
         otu_ids = table_inmem.ids(axis='observation')
         cnts = table_inmem.matrix_data.astype(int).toarray().T
         exp = skbio.diversity.beta_diversity('unweighted_unifrac', cnts,
-                                             ids=ids, otu_ids=otu_ids,
+                                             ids=ids, taxa=otu_ids,
                                              tree=tree_inmem)
         obs = ssu(table, tree, 'unweighted', False, 1.0, False, 1)
         npt.assert_almost_equal(obs.data, exp.data, decimal=6)


### PR DESCRIPTION
In scikit-bio change the name OTU in favor of taxon. See https://github.com/scikit-bio/scikit-bio/commit/c59a7755f7f0271bc3df783518e202bf4b9dcf1c

This commit update the test_api.py according to this new change in scikit-bio.

The original bug was reported [here](https://bugs.debian.org/1074302)